### PR TITLE
Allows registering services with slashes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,9 @@ module.exports = function (grunt) {
       files: ['lib/**/*.js', 'test/**/*.js', 'Gruntfile.js', 'package.json']
     },
     simplemocha: {
+      application: {
+        src: ['test/application.test.js']
+      },
       mixins: {
         src: ['test/mixins/**/*.test.js']
       },

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,10 @@
+__0.1.0__
+
+- First beta release
+- Directly extends Express
+- Removed built in services and moved to [Legs](https://github.com/feathersjs/legs)
+- Created [example repository](https://github.com/feathersjs/examples)
+
+__0.0.x__
+
+- Initial test alpha releases

--- a/lib/application.js
+++ b/lib/application.js
@@ -4,6 +4,9 @@ var Proto = require('uberproto');
 var _ = require('underscore');
 
 var mixins = require('./mixins');
+var stripSlashes = function (name) {
+  return name.replace(/^\/|\/$/g, '');
+};
 
 module.exports = {
   init: function () {
@@ -25,6 +28,8 @@ module.exports = {
       var protoService = Proto.extend(service);
       var self = this;
 
+      location = stripSlashes(location);
+
       // Add all the mixins
       _.each(this.mixins, function (fn) {
         fn.call(self, protoService);
@@ -44,7 +49,7 @@ module.exports = {
   },
 
   lookup: function (location) {
-    return this.services[location];
+    return this.services[stripSlashes(location)];
   },
 
   listen: function () {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feathers",
   "description": "An ultra scalable, feather weight, data oriented framework",
   "version": "0.1.0",
-  "homepage": "https://feathersjs.com",
+  "homepage": "http://feathersjs.com",
   "repository": {
     "type": "git",
     "url": "git://github.com/feathersjs/feathers.git"

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var assert = require('assert');
+var Proto = require('uberproto');
+var io = require('socket.io-client');
+var request = require('request');
+
+var feathers = require('../lib/feathers');
+var express = require('express');
+
+describe('Feathers application', function () {
+  it('registers service and looks it up with and without leading and trailing slashes', function () {
+    var dummyService = {
+      find: function (params, callback) {
+        // No need to implement this
+      }
+    };
+
+    var app = feathers().use('/dummy/service/', dummyService);
+
+    assert.ok(typeof app.lookup('dummy/service').find === 'function', 'Could look up without slashes');
+    assert.ok(typeof app.lookup('/dummy/service').find === 'function', 'Could look up with leading slash');
+    assert.ok(typeof app.lookup('dummy/service/').find === 'function', 'Could look up with trailing slash');
+  });
+
+  it('registers a service, wraps it and adds the event mixin', function (done) {
+    var dummyService = {
+      create: function (data, params, callback) {
+        callback(null, data);
+      }
+    };
+
+    var app = feathers().use('/dummy', dummyService);
+    var server = app.listen(7887);
+    var wrappedService = app.lookup('dummy');
+
+    assert.ok(Proto.isPrototypeOf(wrappedService), 'Service got wrapped as Uberproto object');
+    assert.ok(typeof wrappedService.on === 'function', 'Wrapped service is an event emitter');
+
+    wrappedService.on('created', function (data) {
+      assert.equal(data.message, 'Test message', 'Got created event with test message');
+      server.close(done);
+    });
+
+    wrappedService.create({
+      message: 'Test message'
+    }, {}, function (error, data) {
+      assert.ok(!error, 'No error');
+      assert.equal(data.message, 'Test message', 'Got created event with test message');
+    });
+  });
+
+  it('adds REST by default and registers SocketIO provider', function (done) {
+    var todoService = {
+      get: function (name, params, callback) {
+        callback(null, {
+          id: name,
+          description: "You have to do " + name + "!"
+        });
+      }
+    };
+
+    var oldlog = console.log;
+    console.log = function () {};
+
+    var app = feathers().configure(feathers.socketio()).use('/todo', todoService);
+    var server = app.listen(6999).on('listening', function () {
+      console.log = oldlog;
+
+      var socket = io.connect('http://localhost:6999');
+
+      request('http://localhost:6999/todo/dishes', function (error, response, body) {
+        assert.ok(response.statusCode === 200, 'Got OK status code');
+        var data = JSON.parse(body);
+        assert.equal(data.description, 'You have to do dishes!');
+
+        socket.emit('todo::get', 'laundry', {}, function (error, data) {
+          assert.equal(data.description, 'You have to do laundry!');
+
+          socket.disconnect();
+          server.close(done);
+        });
+      });
+    });
+  });
+});

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var feathers = require('../../lib/feathers');
 var io = require('socket.io-client');
+var request = require('request');
 
 var fixture = require('./service-fixture');
 var todoService = fixture.Service;
@@ -20,11 +21,11 @@ describe('SocketIO provider', function () {
     server = feathers()
       .configure(feathers.socketio())
       .use('todo', todoService)
-      .listen(3000);
+      .listen(7886);
 
     console.log = oldlog;
 
-    socket = io.connect('http://localhost:3000');
+    socket = io.connect('http://localhost:7886');
   });
 
   after(function (done) {


### PR DESCRIPTION
Now services can be registered and looked up with trailing and leading slashes so that it fits in better with the express conventions. Also added application tests and a changelog.
