### PR TITLE
Remove middleware: connect.bodyParser()

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -18,7 +18,8 @@ function createApplication() {
   Proto.mixin(Application, app);
   app.init();
   // Add REST provider by default, can always be disabled using app.disable('feathers rest')
-  app.use(express.bodyParser()).configure(providers.rest());
+  app.use(express.urlencoded());
+  app.use(express.json()).configure(providers.rest());
   return app;
 }
 


### PR DESCRIPTION
Because `connect.bodyParser()` is deprecated
and will be removed in Connect 3, this
commit removes it from the stack and
uses `express.urlencoded()` and
`express.json()` instead.

Visit the [Connect Wiki](https://github.com/senchalabs/connect/wiki/Connect-3.0) for more information.
