### PR TITLE
Adding SocketIO handshake data to service call parameters

### DIFF
--- a/lib/providers/socketio.js
+++ b/lib/providers/socketio.js
@@ -4,6 +4,14 @@ var _ = require('lodash');
 var socketio = require('socket.io');
 var Proto = require('uberproto');
 
+// The position of the params parameters for a service method so that we can extend them
+// default is 1
+var paramsPositions = {
+  find: 0,
+  update: 2,
+  patch: 2
+};
+
 module.exports = function(config) {
   return function() {
     var app = this;
@@ -38,8 +46,14 @@ module.exports = function(config) {
           _.each(services, function(service, path) {
             _.each(self.methods, function(method) {
               var name = path + '::' + method;
-              if (service[method]) {
-                socket.on(name, service[method].bind(service));
+              var position = typeof paramsPositions[method] !== 'undefined' ? paramsPositions[method] : 1;
+
+              if (typeof service[method] === 'function') {
+                socket.on(name, function() {
+                  var args = _.toArray(arguments);
+                  args[position] = _.extend({}, args[position], socket.handshake.feathers);
+                  service[method].apply(service, args);
+                });
               }
             });
           });

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,24 @@ app.configure(feathers.socketio(function(io) {
 }));
 ```
 
+Similar than the REST middleware, the SocketIO handshakes `feathers` property will be extended
+for service parameters:
+
+```js
+app.configure(feathers.socketio(function(io) {
+  io.set('authorization', function (handshake, callback) {
+    handshake.feathers.user = { name: 'David' };
+  });
+}));
+
+app.use('todos', {
+  create: function(data, params, callback) {
+    // When called via SocketIO:
+    params.user // -> { name: 'David' }
+  }
+});
+```
+
 Once the server has been started with `app.listen()` the SocketIO object is available as `app.io`.
 
 ### Primus


### PR DESCRIPTION
This is related to #44, #48 and #32 adding SocketIO handshake data as the service parameters like:

``` js
app.configure(feathers.socketio(function(io) {
  io.set('authorization', function (handshake, callback) {
    handshake.feathers.user = { name: 'David' };
  });
}));
```

With something like:

``` js
app.use('todos', {
  create: function(data, params, callback) {
    // When called via SocketIO:
    params.user // -> { name: 'David' }
  }
});
```
