### PR TITLE
Send socket parameters as params.query

### DIFF
--- a/lib/providers/socket/commons.js
+++ b/lib/providers/socket/commons.js
@@ -18,7 +18,7 @@ exports.setupMethodHandler = function setupMethodHandler (emitter, params, servi
   if (typeof service[method] === 'function') {
     emitter.on(name, function () {
       var args = _.toArray(arguments);
-      args[position] = _.extend({}, args[position], params);
+      args[position] = _.extend({ query: args[position] }, params);
       service[method].apply(service, args);
     });
   }

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ var myService = {
 
 And can be used like any other Express middleware `app.use('/my-service', myService)`.
 
-All service callbacks follow the `function(error, data)` NodeJS convention. `params` can contain any additional parameters, for example the currently authenticated user. REST service calls set `params.query` with the query parameters (e.g. a query string like `?status=active&type=user` becomes `{ query: { status: "active", type: "user" } }`).
+All service callbacks follow the `function(error, data)` NodeJS convention. `params` can contain any additional parameters, for example the currently authenticated user. REST service calls set `params.query` with the query parameters (e.g. a query string like `?status=active&type=user` becomes `{ query: { status: "active", type: "user" } }`), socket call parameters will also be passed as `params.query`.
 
 It is also possible to return a [Promise](http://promises-aplus.github.io/promises-spec/) object from a service instead of using the callback, for example using [Q](https://github.com/kriskowal/q):
 
@@ -216,7 +216,7 @@ var todos = {
 
 ### find
 
-`find(params, callback)` retrieves a list of all resources from the service. Ideally use `params.query` for things like filtering and paging so that REST calls like `todo?status=completed&user=10` work right out of the box.
+`find(params, callback)` retrieves a list of all resources from the service. SocketIO parameters will be passed as `params.query` to the service.
 
 __REST__
 
@@ -226,13 +226,13 @@ __SocketIO__
 
 ```js
 socket.emit('todo::find', {
-  query: {
-    status: 'completed'
-    user: 10
-  }
+  status: 'completed'
+  user: 10
 }, function(error, data) {
 });
 ```
+
+> Will call .create with `params` { query: { status: 'completed', user: 10 } }
 
 ### get
 

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -47,33 +47,28 @@ describe('Primus provider', function () {
     };
 
     service.find = function(params) {
-      assert.deepEqual(params, socketParams, 'Handshake parameters passed on proper position');
+      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Handshake parameters passed on proper position');
       old.find.apply(this, arguments);
     };
 
     service.create = function(data, params) {
-      assert.deepEqual(params, socketParams, 'Passed handshake parameters');
+      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Passed handshake parameters');
       old.create.apply(this, arguments);
     };
 
     service.update = function(id, data, params) {
-      assert.deepEqual(params, _.extend(socketParams, {
-        test: 'param'
-      }), 'Extended handshake paramters with original');
+      assert.deepEqual(params, _.extend({
+        query: {
+          test: 'param'
+        }
+      }, socketParams), 'Passed handshake parameters as query');
       old.update.apply(this, arguments);
-    };
-
-    service.remove = function(id, params) {
-      assert.equal(params.provider, 'sockjs', 'Handshake parameters have priority');
-      old.remove.apply(this, arguments);
     };
 
     socket.send('todo::create', {}, {}, function () {
       socket.send('todo::update', 1, {}, { test: 'param' }, function() {
-        socket.send('todo::remove', 1, { provider: 'something' }, function() {
-          _.extend(service, old);
-          done();
-        });
+        _.extend(service, old);
+        done();
       });
     });
   });

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -53,33 +53,28 @@ describe('SocketIO provider', function () {
     };
 
     service.find = function(params) {
-      assert.deepEqual(params, socketParams, 'Handshake parameters passed on proper position');
+      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Handshake parameters passed on proper position');
       old.find.apply(this, arguments);
     };
 
     service.create = function(data, params) {
-      assert.deepEqual(params, socketParams, 'Passed handshake parameters');
+      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Passed handshake parameters');
       old.create.apply(this, arguments);
     };
 
     service.update = function(id, data, params) {
-      assert.deepEqual(params, _.extend(socketParams, {
-        test: 'param'
-      }), 'Extended handshake paramters with original');
+      assert.deepEqual(params, _.extend({
+        query: {
+          test: 'param'
+        }
+      }, socketParams), 'Passed handshake parameters as query');
       old.update.apply(this, arguments);
-    };
-
-    service.remove = function(id, params) {
-      assert.equal(params.provider, 'socketio', 'Handshake parameters have priority');
-      old.remove.apply(this, arguments);
     };
 
     socket.emit('todo::create', {}, {}, function () {
       socket.emit('todo::update', 1, {}, { test: 'param' }, function() {
-        socket.emit('todo::remove', 1, { provider: 'something' }, function() {
-          _.extend(service, old);
-          done();
-        });
+        _.extend(service, old);
+        done();
       });
     });
   });


### PR DESCRIPTION
This pull request send socket library service call parameters as `params.query` to the actual service. Closes #60 and closes #69.
