### PR TITLE
Use URI parameters as service params and remove bodyParser dependendency

### DIFF
--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var bodyParser = require('body-parser');
 var wrappers = require('./wrappers');
 
 module.exports = function (config) {
@@ -23,7 +22,7 @@ module.exports = function (config) {
 
     app.enable('feathers rest');
 
-    app.use(bodyParser()).use(function (req, res, next) {
+    app.use(function (req, res, next) {
       req.feathers = {};
       next();
     });

--- a/lib/providers/rest/wrappers.js
+++ b/lib/providers/rest/wrappers.js
@@ -21,7 +21,7 @@ function getHandler (method, getArgs, service) {
     // Run the getArgs callback, if available, for additional parameters
     var args = getArgs(req, res, next);
     // Grab the service parameters. Use req.feathers and set the query to req.query
-    var params = _.extend({ query: req.query || {} }, req.feathers);
+    var params = _.extend({ query: req.query || {} }, _.omit(req.params || {}, 'id'), req.feathers);
     // The service success callback which sets res.data or calls next() with the error
     var callback = function (error, data) {
       if (error) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "npm": ">= 1.3.0"
   },
   "dependencies": {
-    "body-parser": "^1.0.2",
     "express": "^4.0.0",
     "lodash": "^2.4.1",
     "primus": "^2.2.1",
@@ -44,6 +43,7 @@
     "uberproto": "^1.1.0"
   },
   "devDependencies": {
+    "body-parser": "^1.0.2",
     "grunt": "^0.4.0",
     "grunt-cli": "^0.1.0",
     "grunt-contrib-jshint": "^0.x",

--- a/readme.md
+++ b/readme.md
@@ -8,18 +8,23 @@ If you are not familiar with Express head over to the [Express Guides](http://ex
 
 ### REST
 
-In almost every case you want to exposes your services through a RESTful JSON interface. This can be achieved by calling `app.configure(feathers.rest())`.
+In almost every case you want to exposes your services through a RESTful JSON interface. This can be achieved by calling `app.configure(feathers.rest())`. Note that you will have to provide your own body parser middleware like the standard [Express 4 body-parser](https://github.com/expressjs/body-parser) to make REST `.create`, `.update` and `.patch` calls pass the parsed data.
 
-To set service parameters in a middleware, just attach it to the `req.feathers` object which will become the params for any resulting service call:
+To set service parameters in a middleware, just attach it to the `req.feathers` object which will become the params for any resulting service call. It is also possible to use URL parameters for REST API calls which will also be added to the params object:
 
 ```js
-app.configure(feathers.rest()).use(function(req, res) {
-  req.feathers.data = 'Hello world';
-});
+var bodyParser = require('body-parser');
 
-app.use('/todos', {
+app.configure(feathers.rest())
+  .use(bodyParser())
+  .use(function(req, res) {
+    req.feathers.data = 'Hello world';
+  });
+
+app.use('/:app/todos', {
   get: function(name, params, callback) {
     console.log(params.data); // -> 'Hello world'
+    console.log(params.app); // will be `my` for GET /my/todos/dishes
     callback(null, {
       id: name,
       params: params,

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -210,4 +210,34 @@ describe('Feathers application', function () {
       });
     });
   });
+
+  it('extend params with route params (#76)', function (done) {
+    var todoService = {
+      get: function (id, params, callback) {
+        var result = {
+          id: id,
+          appId: params.appId
+        };
+        callback(null, result);
+      }
+    };
+
+    var app = feathers()
+      .configure(feathers.rest())
+      .use('/:appId/todo', todoService);
+
+    var expected = {
+      id: "dishes",
+      appId: "theApp"
+    };
+
+    var server = app.listen(6880).on('listening', function () {
+      request('http://localhost:6880/theApp/todo/' + expected.id, function (error, response, body) {
+        assert.ok(response.statusCode === 200, 'Got OK status code');
+        assert.deepEqual(expected, JSON.parse(body));
+        server.close(done);
+      });
+    });
+  });
+
 });

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -3,6 +3,7 @@
 var request = require('request');
 var assert = require('assert');
 var feathers = require('../../lib/feathers');
+var bodyParser = require('body-parser');
 
 var fixture = require('./service-fixture');
 var todoService = fixture.Service;
@@ -14,6 +15,7 @@ describe('REST provider', function () {
 
     before(function () {
       app = feathers().configure(feathers.rest())
+        .use(bodyParser())
         .use('codes', {
           get: function(id, params, callback) {
             callback();
@@ -237,6 +239,7 @@ describe('REST provider', function () {
       next();
     })
     .configure(feathers.rest())
+    .use(bodyParser())
     .use('/todo', {
       create: function (data, params, callback) {
         callback(null, data);


### PR DESCRIPTION
This pull request adds `req.params` as service parameters so that routes like `app.use('/:app/todos', todoService)` will pass the app name as `params.app`. Also removes the `body-parser` hard dependency and makes you use your own. Closes #76 and closes #73.
