### PR TITLE
Add _setup method

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -34,6 +34,10 @@ module.exports = {
       fn.call(self, protoService);
     });
 
+    if(typeof protoService._setup === 'function') {
+      protoService._setup(this, location);
+    }
+
     // Run the provider functions to register the service
     _.each(this.providers, function (provider) {
       provider(location, protoService, options);

--- a/readme.md
+++ b/readme.md
@@ -368,6 +368,48 @@ feathers()
 
 You can see the combination when going to `http://localhost:8000/my/test`.
 
+`setup` will be called after all REST routes have been set up. This means that you
+can't register custom middleware with potentially conflicting paths.
+In this case, implement `_setup(app, path)` instead which will run before the REST
+middleware is registered. An example would be implementing a `todos/count` route
+which returns the number of todos (instead of the todo with the id count):
+
+```js
+var todoService = {
+  todos: [
+    {
+      id: 0,
+      description: 'Learn Feathers'
+    },
+    {
+      id: 1,
+      description: 'Do dishes'
+    }
+  ],
+
+  find: function (params, callback) {
+    callback(null, this.todos);
+  },
+
+  _setup: function (app, path) {
+    var self = this;
+
+    app.get('/' + path + '/count', function (req, res) {
+      self.find({}, function (error, todos) {
+        res.json({
+          count: todos.length
+        });
+      });
+    });
+  }
+};
+
+feathers()
+  .use('todos', todoService)
+  .listen(8000);
+```
+
+
 __Pro tip:__
 
 Bind the apps `lookup` method to your service to always look your services up dynamically:

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -17,11 +17,6 @@ describe('SocketIO provider', function () {
     };
 
   before(function () {
-    // This seems to be the only way to not get the
-    // socket.io started log messing up the test output
-    var oldlog = console.log;
-    console.log = function () {};
-
     app = feathers()
       .configure(feathers.socketio(function(io) {
         io.use(function (socket, next) {
@@ -32,8 +27,6 @@ describe('SocketIO provider', function () {
       .use('todo', todoService);
 
     server = app.listen(7886);
-
-    console.log = oldlog;
 
     socket = io.connect('http://localhost:7886');
   });


### PR DESCRIPTION
This pull request adds a `service._setup(app, path)` method that allows registering conflicting routes as reported in and closes #86. Works as described in the documentation added:

`setup` will be called after all REST routes have been set up. This means that you
can't register custom middleware with potentially conflicting paths.
In this case, implement `_setup(app, path)` instead which will run before the REST
middleware is registered. An example would be implementing a `todos/count` route
which returns the number of todos (instead of the todo with the id count):

``` js
var todoService = {
  todos: [
    {
      id: 0,
      description: 'Learn Feathers'
    },
    {
      id: 1,
      description: 'Do dishes'
    }
  ],

  find: function (params, callback) {
    callback(null, this.todos);
  },

  _setup: function (app, path) {
    var self = this;

    app.get('/' + path + '/count', function (req, res) {
      self.find({}, function (error, todos) {
        res.json({
          count: todos.length
        });
      });
    });
  }
};

feathers()
  .use('todos', todoService)
  .listen(8000);
```
