### PR TITLE
Allow not passing parameters in socket calls

### DIFF
--- a/lib/providers/socket/commons.js
+++ b/lib/providers/socket/commons.js
@@ -18,6 +18,11 @@ exports.setupMethodHandler = function setupMethodHandler (emitter, params, servi
   if (typeof service[method] === 'function') {
     emitter.on(name, function () {
       var args = _.toArray(arguments);
+      // If the service is called with no parameter object
+      // insert an empty object
+      if(typeof args[position] === 'function') {
+        args.splice(position, 0, {});
+      }
       args[position] = _.extend({ query: args[position] }, params);
       service[method].apply(service, args);
     });

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -73,6 +73,23 @@ describe('Primus provider', function () {
     });
   });
 
+  it('missing parameters in socket call works (#88)', function(done) {
+    var service = app.lookup('todo');
+    var old = {
+      find: service.find
+    };
+
+    service.find = function(params) {
+      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Handshake parameters passed on proper position');
+      old.find.apply(this, arguments);
+    };
+
+    socket.send('todo::find', function () {
+      _.extend(service, old);
+      done();
+    });
+  });
+
   describe('CRUD', function () {
     it('::find', function (done) {
       socket.send('todo::find', {}, function (error, data) {

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -79,6 +79,23 @@ describe('SocketIO provider', function () {
     });
   });
 
+  it('missing parameters in socket call works (#88)', function(done) {
+    var service = app.lookup('todo');
+    var old = {
+      find: service.find
+    };
+
+    service.find = function(params) {
+      assert.deepEqual(_.omit(params, 'query'), socketParams, 'Handshake parameters passed on proper position');
+      old.find.apply(this, arguments);
+    };
+
+    socket.emit('todo::find', function () {
+      _.extend(service, old);
+      done();
+    });
+  });
+
   describe('CRUD', function () {
     it('::find', function (done) {
       socket.emit('todo::find', {}, function (error, data) {


### PR DESCRIPTION
This pull request allows to not having to pass an empty parameter object for socket calls and closes #88.
