### PR TITLE
Remove app.lookup and make the functionality available as app.service

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -20,6 +20,10 @@ module.exports = {
   },
 
   service: function(location, service, options) {
+    if(!service) {
+      return this.services[stripSlashes(location)];
+    }
+
     var protoService = Proto.extend(service);
     var self = this;
 
@@ -40,7 +44,7 @@ module.exports = {
 
     // Run the provider functions to register the service
     _.each(this.providers, function (provider) {
-      provider(location, protoService, options);
+      provider(location, protoService, options || {});
     });
 
     this.services[location] = protoService;
@@ -66,10 +70,6 @@ module.exports = {
       // Any arguments left over are other middleware that we want to pass to the providers
       middleware: args
     });
-  },
-
-  lookup: function (location) {
-    return this.services[stripSlashes(location)];
   },
 
   setup: function() {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "body-parser": "^1.0.2",
     "feathers-errors": ">=0.2.0",
     "lodash": "^2.4.1",
-    "primus": "^2.2.1",
+    "primus": "^2.4.0",
     "primus-emitter": "^3.0.2",
     "rubberduck": "^1.0.0",
-    "socket.io": "^1.0.0",
+    "socket.io": "^1.1.0",
     "uberproto": "^1.1.0"
   },
   "devDependencies": {

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -28,9 +28,9 @@ describe('Feathers application', function () {
 
     var app = feathers().use('/dummy/service/', dummyService);
 
-    assert.ok(typeof app.lookup('dummy/service').find === 'function', 'Could look up without slashes');
-    assert.ok(typeof app.lookup('/dummy/service').find === 'function', 'Could look up with leading slash');
-    assert.ok(typeof app.lookup('dummy/service/').find === 'function', 'Could look up with trailing slash');
+    assert.ok(typeof app.service('dummy/service').find === 'function', 'Could look up without slashes');
+    assert.ok(typeof app.service('/dummy/service').find === 'function', 'Could look up with leading slash');
+    assert.ok(typeof app.service('dummy/service/').find === 'function', 'Could look up with trailing slash');
   });
 
   it('registers a service, wraps it and adds the event mixin', function (done) {
@@ -42,7 +42,7 @@ describe('Feathers application', function () {
 
     var app = feathers().use('/dummy', dummyService);
     var server = app.listen(7887);
-    var wrappedService = app.lookup('dummy');
+    var wrappedService = app.service('dummy');
 
     assert.ok(Proto.isPrototypeOf(wrappedService), 'Service got wrapped as Uberproto object');
     assert.ok(typeof wrappedService.on === 'function', 'Wrapped service is an event emitter');

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -38,7 +38,7 @@ describe('Primus provider', function () {
   });
 
   it('passes handshake as service parameters', function(done) {
-    var service = app.lookup('todo');
+    var service = app.service('todo');
     var old = {
       find: service.find,
       create: service.create,
@@ -74,7 +74,7 @@ describe('Primus provider', function () {
   });
 
   it('missing parameters in socket call works (#88)', function(done) {
-    var service = app.lookup('todo');
+    var service = app.service('todo');
     var old = {
       find: service.find
     };
@@ -204,7 +204,7 @@ describe('Primus provider', function () {
 
   describe('Event filtering', function() {
     it('.created', function (done) {
-      var service = app.lookup('todo');
+      var service = app.service('todo');
       var original = { description: 'created event test' };
       var oldCreated = service.created;
 
@@ -239,7 +239,7 @@ describe('Primus provider', function () {
     });
 
     it('.removed', function (done) {
-      var service = app.lookup('todo');
+      var service = app.service('todo');
       var oldRemoved = service.removed;
 
       service.removed = function(data, params, callback) {

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -15,7 +15,7 @@ describe('REST provider', function () {
 
     before(function () {
       app = feathers().configure(feathers.rest())
-        .use(bodyParser())
+        .use(bodyParser.json())
         .use('codes', {
           get: function(id, params, callback) {
             callback();
@@ -239,7 +239,7 @@ describe('REST provider', function () {
       next();
     })
     .configure(feathers.rest())
-    .use(bodyParser())
+    .use(bodyParser.json())
     .use('/todo', {
       create: function (data, params, callback) {
         callback(null, data);

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -37,7 +37,7 @@ describe('SocketIO provider', function () {
   });
 
   it('passes handshake as service parameters', function(done) {
-    var service = app.lookup('todo');
+    var service = app.service('todo');
     var old = {
       find: service.find,
       create: service.create,
@@ -73,7 +73,7 @@ describe('SocketIO provider', function () {
   });
 
   it('missing parameters in socket call works (#88)', function(done) {
-    var service = app.lookup('todo');
+    var service = app.service('todo');
     var old = {
       find: service.find
     };
@@ -203,7 +203,7 @@ describe('SocketIO provider', function () {
 
   describe('Event filtering', function() {
     it('.created', function (done) {
-      var service = app.lookup('todo');
+      var service = app.service('todo');
       var original = { description: 'created event test' };
       var oldCreated = service.created;
 
@@ -238,7 +238,7 @@ describe('SocketIO provider', function () {
     });
 
     it('.removed', function (done) {
-      var service = app.lookup('todo');
+      var service = app.service('todo');
       var oldRemoved = service.removed;
 
       service.removed = function(data, params, callback) {


### PR DESCRIPTION
It turned out that `app.lookup` is somewhat redundant and not very descriptive. Instead I think it is a lot more explicit to make service lookup available as `app.service(path)`:

``` js
app.service('todos').create({ text: 'Do something!' }, {}, function(error, data) {
  console.log('Created Todo', data);
});
```

To maintain backwards compatibility simply assign `app.service` as `app.lookup` like so:

``` js
app.configure(function() {
  this.lookup = this.service;
});
```
