### PR TITLE
Rename Uberproto .create to avoid conflicts with service method

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -8,6 +8,11 @@ var stripSlashes = function (name) {
   return name.replace(/^\/|\/$/g, '');
 };
 
+// We do not want to support Uberproto's create functionality
+// Since our service methods have a method with the same name
+Proto._create = Proto.create;
+delete Proto.create;
+
 module.exports = {
   init: function () {
     _.extend(this, {

--- a/test/mixins/event.test.js
+++ b/test/mixins/event.test.js
@@ -5,6 +5,7 @@ var _ = require('lodash');
 var Proto = require('uberproto');
 var mixinEvent = require('../../lib/mixins/event');
 var EventMixin = mixinEvent.Mixin;
+var create = Proto._create;
 
 describe('Event mixin', function () {
   it('initializes', function () {
@@ -20,7 +21,7 @@ describe('Event mixin', function () {
     assert.equal(typeof FixtureService.on, 'function');
     assert.equal(typeof FixtureService.emit, 'function');
 
-    var instance = FixtureService.create();
+    var instance = create.call(FixtureService);
     assert.equal('Original setup: Test', instance.setup('Test'));
     assert.ok(instance._rubberDuck instanceof require('events').EventEmitter);
 
@@ -47,7 +48,7 @@ describe('Event mixin', function () {
 
     mixinEvent(FixtureService);
 
-    var instance = Proto.create.call(FixtureService);
+    var instance = create.call(FixtureService);
     instance.setup();
 
     instance.on('serviceError', function (error) {
@@ -77,7 +78,7 @@ describe('Event mixin', function () {
 
     mixinEvent(FixtureService);
 
-    var instance = Proto.create.call(FixtureService);
+    var instance = create.call(FixtureService);
     instance.setup();
 
     instance.on('created', function (data) {
@@ -107,7 +108,7 @@ describe('Event mixin', function () {
 
     mixinEvent(FixtureService);
 
-    var instance = Proto.create.call(FixtureService);
+    var instance = create.call(FixtureService);
     instance.setup();
 
     instance.on('updated', function (data) {
@@ -136,7 +137,7 @@ describe('Event mixin', function () {
 
     mixinEvent(FixtureService);
 
-    var instance = Proto.create.call(FixtureService);
+    var instance = create.call(FixtureService);
     instance.setup();
 
     instance.on('removed', function (data) {

--- a/test/mixins/promise.test.js
+++ b/test/mixins/promise.test.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert');
 var Proto = require('uberproto');
+var create = Proto._create;
 var q = require('q');
 var _ = require('lodash');
 
@@ -24,7 +25,7 @@ describe('Promises/A+ mixin', function () {
 
     mixin.call(context, FixtureService);
 
-    var instance = Proto.create.call(FixtureService);
+    var instance = create.call(FixtureService);
     instance.get('dishes', {}, function (error, data) {
       assert.deepEqual(data, {
         id: 'dishes',
@@ -53,7 +54,7 @@ describe('Promises/A+ mixin', function () {
 
     mixin.call(context, FixtureService);
 
-    var instance = Proto.create.call(FixtureService);
+    var instance = create.call(FixtureService);
     instance.get('dishes', {}, function (error) {
       assert.ok(error);
       assert.equal(error.message, 'Something went wrong');
@@ -84,7 +85,7 @@ describe('Promises/A+ mixin', function () {
 
     mixin.call(context, FixtureService);
 
-    var instance = Proto.create.call(FixtureService);
+    var instance = create.call(FixtureService);
     instance.create(original, {}).then(function(data) {
       assert.deepEqual(data, original);
       done();

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -140,7 +140,7 @@ describe('REST provider', function () {
       /* jshint ignore:start */
       // Error handler
       app.use(function (error, req, res, next) {
-        assert.equal(error.message, 'Method `remove` is not supported by this endpoint.');
+        assert.equal(error.message, 'Method `create` is not supported by this endpoint.');
         res.json({ message: error.message });
       });
       /* jshint ignore:end */
@@ -152,16 +152,16 @@ describe('REST provider', function () {
       server.close(done);
     });
 
-    it('throws a 405 for undefined service methods', function (done) {
+    it('throws a 405 for undefined service methods (#99)', function (done) {
       request('http://localhost:4780/todo/dishes', function (error, response, body) {
         assert.ok(response.statusCode === 200, 'Got OK status code for .get');
         assert.deepEqual(JSON.parse(body), { description: 'You have to do dishes' }, 'Got expected object');
         request({
-          method: 'delete',
-          url: 'http://localhost:4780/todo/2'
+          method: 'post',
+          url: 'http://localhost:4780/todo'
         }, function (error, response, body) {
-          assert.ok(response.statusCode === 405, 'Got 405 for .remove');
-          assert.deepEqual(JSON.parse(body), { message: 'Method `remove` is not supported by this endpoint.' }, 'Error serialized as expected');
+          assert.ok(response.statusCode === 405, 'Got 405 for .create');
+          assert.deepEqual(JSON.parse(body), { message: 'Method `create` is not supported by this endpoint.' }, 'Error serialized as expected');
           done();
         });
       });


### PR DESCRIPTION
This pull request removes the original [Uberproto](https://github.com/daffl/uberproto) `.create` which was conflicting with service methods with the same name causing unexpected issues. Closes #99.
