### PR TITLE
Make sure that mixins are specific to each new app

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -14,7 +14,7 @@ module.exports = {
   init: function () {
     _.extend(this, {
       methods: ['find', 'get', 'create', 'update', 'patch', 'remove'],
-      mixins: mixins,
+      mixins: mixins(),
       services: {},
       providers: [],
       _setup: false

--- a/lib/mixins/index.js
+++ b/lib/mixins/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = [
-  require('./promise'),
-  require('./event')
-];
+module.exports = function() {
+  return [
+    require('./promise'),
+    require('./event')
+  ];
+};

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -293,4 +293,14 @@ describe('Feathers application', function () {
       });
     });
   });
+
+  it('mixins are unique to one application', function() {
+    var app = feathers();
+    app.mixins.push(function() {});
+    assert.equal(app.mixins.length, 3);
+
+    var otherApp = feathers();
+    otherApp.mixins.push(function() {});
+    assert.equal(otherApp.mixins.length, 3);
+  });
 });


### PR DESCRIPTION
This pull request fixes a bug that cause weird issues. The reason was that an applications `mixins` array was shared through *every* Feathers application.