### PR TITLE
Dynamic services 2

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -29,10 +29,6 @@ module.exports = {
     var protoService = Proto.extend(service);
     var self = this;
 
-    if(this._setup) {
-      throw new Error('You can not register a service after app.setup() has been called.');
-    }
-
     location = stripSlashes(location);
 
     // Add all the mixins
@@ -50,7 +46,7 @@ module.exports = {
     });
 
     this.services[location] = protoService;
-    return this;
+    return protoService;
   },
 
   use: function () {
@@ -68,10 +64,17 @@ module.exports = {
       return this._super.apply(this, arguments);
     }
 
-    return this.service(location, service, {
+    var svc = this.service(location, service, {
       // Any arguments left over are other middleware that we want to pass to the providers
       middleware: args
     });
+
+    // If already _setup, just add this single service.
+    if (this._setup && this.addService) {
+      this.addService(svc, stripSlashes(location));
+    }
+
+    return this;
   },
 
   setup: function() {

--- a/lib/application.js
+++ b/lib/application.js
@@ -45,6 +45,11 @@ module.exports = {
       provider(location, protoService, options || {});
     });
 
+    // If already _setup, just add this single service.
+    if (this._setup && this.addService) {
+      this.addService(protoService, stripSlashes(location));
+    }
+
     this.services[location] = protoService;
     return protoService;
   },
@@ -64,15 +69,10 @@ module.exports = {
       return this._super.apply(this, arguments);
     }
 
-    var svc = this.service(location, service, {
+    this.service(location, service, {
       // Any arguments left over are other middleware that we want to pass to the providers
       middleware: args
     });
-
-    // If already _setup, just add this single service.
-    if (this._setup && this.addService) {
-      this.addService(svc, stripSlashes(location));
-    }
 
     return this;
   },

--- a/lib/mixins/event.js
+++ b/lib/mixins/event.js
@@ -17,12 +17,16 @@ var eventMappings = {
  */
 var EventMixin = {
   setup: function () {
+    this.applyEvents();
+    return this._super ? this._super.apply(this, arguments) : this;
+  },
+  applyEvents:function(){
     var emitter = this._rubberDuck = rubberduck.emitter(this);
     var self = this;
 
     self._serviceEvents = [];
-    // Pass the Rubberduck error event through
 
+    // Pass the Rubberduck error event through
     // TODO deal with error events properly
     emitter.on('error', function (errors) {
       self.emit('serviceError', errors[0]);
@@ -45,9 +49,6 @@ var EventMixin = {
         });
       }
     });
-
-
-    return this._super ? this._super.apply(this, arguments) : this;
   }
 };
 

--- a/lib/providers/socket/commons.js
+++ b/lib/providers/socket/commons.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var eventsMixin = require('../../mixins/event').Mixin;
 
 // The position of the params parameters for a service method so that we can extend them
 // default is 1
@@ -10,8 +11,19 @@ var paramsPositions = {
   patch: 2
 };
 
-// Set up the service method handlers for a service and socket.
-exports.setupMethodHandler = function setupMethodHandler (emitter, params, service, path, method) {
+exports.addService = function addService(service, path){
+  // Add handlers for the service to connected sockets.
+  _.each(this.info.connections, function (spark) {
+    this.setupMethodHandlers(service, path, spark);
+  }, this);
+
+  // Setup events for the service.
+  eventsMixin.applyEvents.call(service);
+  exports.setupEventHandlers.call(this, service, path);
+};
+
+// Set up the service method handler for a service and socket.
+exports.setupMethodHandler = function setupMethodHandler(emitter, params, service, path, method) {
   var name = path + '::' + method;
   var position = typeof paramsPositions[method] !== 'undefined' ? paramsPositions[method] : 1;
 
@@ -26,6 +38,15 @@ exports.setupMethodHandler = function setupMethodHandler (emitter, params, servi
       args[position] = _.extend({ query: args[position] }, params);
       service[method].apply(service, args);
     });
+  }
+};
+
+exports.setupEventHandlers = function setupEventHandlers(service, path){
+  // If the service emits events that we want to listen to (Event mixin)
+  if (typeof service.on === 'function' && service._serviceEvents) {
+    _.each(service._serviceEvents, function (ev) {
+      exports.setupEventHandler(this.info, service, path, ev);
+    }, this);
   }
 };
 
@@ -54,4 +75,3 @@ exports.setupEventHandler = function setupEventHandler (info, service, path, ev)
     });
   });
 };
-

--- a/lib/providers/socket/primus.js
+++ b/lib/providers/socket/primus.js
@@ -5,7 +5,6 @@ var Proto = require('uberproto');
 var Primus = require('primus');
 var Emitter = require('primus-emitter');
 var commons = require('./commons');
-var eventsMixin = require('../../mixins/event').Mixin;
 
 module.exports = function(config, configurer) {
   return function() {
@@ -31,7 +30,8 @@ module.exports = function(config, configurer) {
           params: function(spark) {
             return spark.request.feathers;
           },
-          method: 'send'
+          method: 'send',
+          connections: this.primus.connections
         };
 
         primus.use('emitter', Emitter);
@@ -40,14 +40,14 @@ module.exports = function(config, configurer) {
         primus.on('connection', function (spark) {
           // Process services that were registered at startup.
           _.each(self.services, function (service, path) {
-            self.setupHandlers(service, path, spark);
+            self.setupMethodHandlers.call(self, service, path, spark);
           });
         });
 
         // Set up events and event dispatching
-        _.each(self.services, function (service, path) {
-          self.setupEvents(service, path);
-        });
+        _.each(this.services, function (service, path) {
+          commons.setupEventHandlers.call(this, service, path);
+        }, this);
 
         if (typeof configurer === 'function') {
           configurer.call(this, primus);
@@ -56,32 +56,12 @@ module.exports = function(config, configurer) {
         return result;
       },
 
-      addService: function(service, path){
-        var self = this;
-        // Add handlers for the service to connected sockets.
-        _.each(self.primus.connections, function (spark) {
-          self.setupHandlers(service, path, spark);
-        });
-        // Setup events for the service.
-        eventsMixin.applyEvents.call(service);
-        this.setupEvents(service, path);
-      },
+      addService: commons.addService,
 
-      setupHandlers: function(service, path, spark){
-        var self = this;
-        _.each(self.methods, function (method) {
+      setupMethodHandlers: function(service, path, spark){
+        _.each(this.methods, function (method) {
           commons.setupMethodHandler(spark, spark.request.feathers, service, path, method);
-        });
-      },
-
-      setupEvents: function(service, path){
-        var self = this;
-        // If the service emits events that we want to listen to (Event mixin)
-        if (typeof service.on === 'function' && service._serviceEvents) {
-          _.each(service._serviceEvents, function (ev) {
-            commons.setupEventHandler(self.info, service, path, ev);
-          });
-        }
+        }, this);
       }
     }, app);
   };

--- a/lib/providers/socket/primus.js
+++ b/lib/providers/socket/primus.js
@@ -5,6 +5,7 @@ var Proto = require('uberproto');
 var Primus = require('primus');
 var Emitter = require('primus-emitter');
 var commons = require('./commons');
+var eventsMixin = require('../../mixins/event').Mixin;
 
 module.exports = function(config, configurer) {
   return function() {
@@ -23,7 +24,7 @@ module.exports = function(config, configurer) {
         }
 
         var primus = this.primus = new Primus(server, config);
-        var info = {
+        this.info = {
           emitters: function() {
             return primus;
           },
@@ -37,21 +38,15 @@ module.exports = function(config, configurer) {
 
         // For a new connection, set up the service method handlers
         primus.on('connection', function (spark) {
+          // Process services that were registered at startup.
           _.each(self.services, function (service, path) {
-            _.each(self.methods, function (method) {
-              commons.setupMethodHandler(spark, spark.request.feathers, service, path, method);
-            });
+            self.setupHandlers(service, path, spark);
           });
         });
 
         // Set up events and event dispatching
         _.each(self.services, function (service, path) {
-          // If the service emits events that we want to listen to (Event mixin)
-          if (typeof service.on === 'function' && service._serviceEvents) {
-            _.each(service._serviceEvents, function (ev) {
-              commons.setupEventHandler(info, service, path, ev);
-            });
-          }
+          self.setupEvents(service, path);
         });
 
         if (typeof configurer === 'function') {
@@ -59,6 +54,34 @@ module.exports = function(config, configurer) {
         }
 
         return result;
+      },
+
+      addService: function(service, path){
+        var self = this;
+        // Add handlers for the service to connected sockets.
+        _.each(self.primus.connections, function (spark) {
+          self.setupHandlers(service, path, spark);
+        });
+        // Setup events for the service.
+        eventsMixin.applyEvents.call(service);
+        this.setupEvents(service, path);
+      },
+
+      setupHandlers: function(service, path, spark){
+        var self = this;
+        _.each(self.methods, function (method) {
+          commons.setupMethodHandler(spark, spark.request.feathers, service, path, method);
+        });
+      },
+
+      setupEvents: function(service, path){
+        var self = this;
+        // If the service emits events that we want to listen to (Event mixin)
+        if (typeof service.on === 'function' && service._serviceEvents) {
+          _.each(service._serviceEvents, function (ev) {
+            commons.setupEventHandler(self.info, service, path, ev);
+          });
+        }
       }
     }, app);
   };

--- a/lib/providers/socket/socketio.js
+++ b/lib/providers/socket/socketio.js
@@ -4,7 +4,6 @@ var _ = require('lodash');
 var socketio = require('socket.io');
 var Proto = require('uberproto');
 var commons = require('./commons');
-var eventsMixin = require('../../mixins/event').Mixin;
 
 module.exports = function (config) {
   return function () {
@@ -31,21 +30,22 @@ module.exports = function (config) {
           params: function(socket) {
             return socket.feathers;
           },
-          method: 'emit'
+          method: 'emit',
+          connections: this.connections = this.io.sockets.connected
         };
 
         // For a new connection, set up the service method handlers
         io.sockets.on('connection', function (socket) {
           // Process services that were registered at startup.
           _.each(self.services, function (service, path) {
-            self.setupHandlers(service, path, socket);
+            self.setupMethodHandlers.call(self, service, path, socket);
           });
         });
 
         // Set up events and event dispatching
         _.each(self.services, function (service, path) {
-          self.setupEvents(service, path);
-        });
+          commons.setupEventHandlers.call(this, service, path);
+        }, this);
 
         if (typeof config === 'function') {
           config.call(this, io);
@@ -54,33 +54,12 @@ module.exports = function (config) {
         return result;
       },
 
-      addService: function(service, path){
-        var self = this;
-        // Add handlers for the service to connected sockets.
-        _.each(self.io.sockets.connected, function (socket) {
-          self.setupHandlers(service, path, socket);
-        });
+      addService: commons.addService,
 
-        // Setup events for the service.
-        eventsMixin.applyEvents.call(service);
-        this.setupEvents(service, path);
-      },
-
-      setupHandlers: function(service, path, socket){
-        var self = this;
-        _.each(self.methods, function (method) {
+      setupMethodHandlers: function(service, path, socket){
+        _.each(this.methods, function (method) {
           commons.setupMethodHandler(socket, socket.feathers || {}, service, path, method);
-        });
-      },
-
-      setupEvents: function(service, path){
-        var self = this;
-        // If the service emits events that we want to listen to (Event mixin)
-        if (typeof service.on === 'function' && service._serviceEvents) {
-          _.each(service._serviceEvents, function (ev) {
-            commons.setupEventHandler(self.info, service, path, ev);
-          });
-        }
+        }, this);
       }
     }, app);
   };

--- a/lib/providers/socket/socketio.js
+++ b/lib/providers/socket/socketio.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var socketio = require('socket.io');
 var Proto = require('uberproto');
 var commons = require('./commons');
+var eventsMixin = require('../../mixins/event').Mixin;
 
 module.exports = function (config) {
   return function () {
@@ -23,7 +24,7 @@ module.exports = function (config) {
 
         var io = this.io = socketio.listen(server);
         // The info object we can pass to commons.setupEventHandler
-        var info = {
+        this.info = {
           emitters: function() {
             return io.sockets.sockets;
           },
@@ -35,21 +36,15 @@ module.exports = function (config) {
 
         // For a new connection, set up the service method handlers
         io.sockets.on('connection', function (socket) {
+          // Process services that were registered at startup.
           _.each(self.services, function (service, path) {
-            _.each(self.methods, function (method) {
-              commons.setupMethodHandler(socket, socket.feathers || {}, service, path, method);
-            });
+            self.setupHandlers(service, path, socket);
           });
         });
 
         // Set up events and event dispatching
         _.each(self.services, function (service, path) {
-          // If the service emits events that we want to listen to (Event mixin)
-          if (typeof service.on === 'function' && service._serviceEvents) {
-            _.each(service._serviceEvents, function (ev) {
-              commons.setupEventHandler(info, service, path, ev);
-            });
-          }
+          self.setupEvents(service, path);
         });
 
         if (typeof config === 'function') {
@@ -57,6 +52,35 @@ module.exports = function (config) {
         }
 
         return result;
+      },
+
+      addService: function(service, path){
+        var self = this;
+        // Add handlers for the service to connected sockets.
+        _.each(self.io.sockets.connected, function (socket) {
+          self.setupHandlers(service, path, socket);
+        });
+
+        // Setup events for the service.
+        eventsMixin.applyEvents.call(service);
+        this.setupEvents(service, path);
+      },
+
+      setupHandlers: function(service, path, socket){
+        var self = this;
+        _.each(self.methods, function (method) {
+          commons.setupMethodHandler(socket, socket.feathers || {}, service, path, method);
+        });
+      },
+
+      setupEvents: function(service, path){
+        var self = this;
+        // If the service emits events that we want to listen to (Event mixin)
+        if (typeof service.on === 'function' && service._serviceEvents) {
+          _.each(service._serviceEvents, function (ev) {
+            commons.setupEventHandler(self.info, service, path, ev);
+          });
+        }
       }
     }, app);
   };

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -11,7 +11,7 @@ var q = require('q');
 var feathers = require('../lib/feathers');
 
 describe('Feathers application', function () {
-  it("Express application should use express apps", function () {
+  it("Express application should use express apps.", function () {
     var app = feathers();
     var child = feathers();
 
@@ -19,7 +19,7 @@ describe('Feathers application', function () {
     assert.equal(child.parent, app);
   });
 
-  it('registers service and looks it up with and without leading and trailing slashes', function () {
+  it('Register services and look them up with and without leading and trailing slashes.', function () {
     var dummyService = {
       find: function () {
         // No need to implement this
@@ -28,12 +28,22 @@ describe('Feathers application', function () {
 
     var app = feathers().use('/dummy/service/', dummyService);
 
+    app.listen(8012, function(){
+      app.use('/another/dummy/service/', dummyService);
+    });
+
     assert.ok(typeof app.service('dummy/service').find === 'function', 'Could look up without slashes');
     assert.ok(typeof app.service('/dummy/service').find === 'function', 'Could look up with leading slash');
     assert.ok(typeof app.service('dummy/service/').find === 'function', 'Could look up with trailing slash');
+
+    app.on('listening', function () {
+      assert.ok(typeof app.service('another/dummy/service').find === 'function', 'Could look up without slashes');
+      assert.ok(typeof app.service('/another/dummy/service').find === 'function', 'Could look up with leading slash');
+      assert.ok(typeof app.service('another/dummy/service/').find === 'function', 'Could look up with trailing slash');
+    });
   });
 
-  it('registers a service, wraps it and adds the event mixin', function (done) {
+  it('Registers a service, wraps it, and adds the event mixin.', function (done) {
     var dummyService = {
       create: function (data, params, callback) {
         callback(null, data);
@@ -60,7 +70,7 @@ describe('Feathers application', function () {
     });
   });
 
-  it('adds REST and SocketIO provider', function (done) {
+  it('Adds REST and SocketIO providers.', function (done) {
     var todoService = {
       get: function (name, params, callback) {
         callback(null, {
@@ -91,7 +101,7 @@ describe('Feathers application', function () {
     });
   });
 
-  it('uses custom middleware (#21)', function (done) {
+  it('Uses custom middleware. (#21)', function (done) {
     var todoService = {
       get: function (name, params, callback) {
         callback(null, {
@@ -176,7 +186,7 @@ describe('Feathers application', function () {
     });
   });
 
-  it('returns the value of a promise (#41)', function (done) {
+  it('Returns the value of a promise. (#41)', function (done) {
     var original = {};
     var todoService = {
       get: function (name) {
@@ -202,7 +212,7 @@ describe('Feathers application', function () {
     });
   });
 
-  it('extend params with route params (#76)', function (done) {
+  it('Extend params with route params. (#76)', function (done) {
     var todoService = {
       get: function (id, params, callback) {
         var result = {
@@ -231,36 +241,12 @@ describe('Feathers application', function () {
     });
   });
 
-  it('throws a warning when trying to register a service after application setup (#67)', function (done) {
+  it('Calls _setup in order to set up custom routes with higher priority. (#86)', function (done) {
     var todoService = {
       get: function (name, params, callback) {
         callback(null, {
           id: name,
           q: true,
-          description: "You have to do " + name + "!"
-        });
-      }
-    };
-    var app = feathers()
-      .configure(feathers.rest())
-      .use('/todo', todoService);
-
-    var server = app.listen();
-    server.on('listening', function () {
-      try {
-        app.use('/dummy', todoService);
-        done(new Error('Should throw an error'));
-      } catch (e) {
-        server.close(done);
-      }
-    });
-  });
-
-  it('calls _setup in order to set up custom routes with higher priority (#86)', function (done) {
-    var todoService = {
-      get: function (name, params, callback) {
-        callback(null, {
-          id: name,
           description: "You have to do " + name + "!"
         });
       },

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -11,7 +11,7 @@ var q = require('q');
 var feathers = require('../lib/feathers');
 
 describe('Feathers application', function () {
-  it("Express application should use express apps.", function () {
+  it('Express application should use express apps.', function () {
     var app = feathers();
     var child = feathers();
 
@@ -75,14 +75,15 @@ describe('Feathers application', function () {
       get: function (name, params, callback) {
         callback(null, {
           id: name,
-          description: "You have to do " + name + "!"
+          description: 'You have to do ' + name + '!'
         });
       }
     };
 
     var app = feathers()
       .configure(feathers.rest())
-      .configure(feathers.socketio()).use('/todo', todoService);
+      .configure(feathers.socketio())
+      .use('/todo', todoService);
     var server = app.listen(6999).on('listening', function () {
       var socket = io.connect('http://localhost:6999');
 
@@ -106,7 +107,7 @@ describe('Feathers application', function () {
       get: function (name, params, callback) {
         callback(null, {
           id: name,
-          description: "You have to do " + name + "!",
+          description: 'You have to do ' + name + '!',
           stuff: params.stuff
         });
       }
@@ -139,13 +140,13 @@ describe('Feathers application', function () {
   it('REST and SocketIO with SSL server (#25)', function (done) {
     // For more info on Reqest HTTPS settings see https://github.com/mikeal/request/issues/418
     // This needs to be set so that the SocektIO client can connect
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
     var todoService = {
       get: function (name, params, callback) {
         callback(null, {
           id: name,
-          description: "You have to do " + name + "!"
+          description: 'You have to do ' + name + '!'
         });
       }
     };
@@ -193,7 +194,7 @@ describe('Feathers application', function () {
         original = {
           id: name,
           q: true,
-          description: "You have to do " + name + "!"
+          description: 'You have to do ' + name + '!'
         };
         return q(original);
       }
@@ -228,8 +229,8 @@ describe('Feathers application', function () {
       .use('/:appId/todo', todoService);
 
     var expected = {
-      id: "dishes",
-      appId: "theApp"
+      id: 'dishes',
+      appId: 'theApp'
     };
 
     var server = app.listen(6880).on('listening', function () {
@@ -247,7 +248,7 @@ describe('Feathers application', function () {
         callback(null, {
           id: name,
           q: true,
-          description: "You have to do " + name + "!"
+          description: 'You have to do ' + name + '!'
         });
       },
 

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -29,7 +29,9 @@ describe('Primus provider', function () {
       }))
       .use('todo', todoService);
 
-    server = app.listen(7888);
+    server = app.listen(7888, function(){
+      app.use('tasks', todoService);
+    });
   });
 
   after(function (done) {
@@ -37,7 +39,7 @@ describe('Primus provider', function () {
     server.close(done);
   });
 
-  it('passes handshake as service parameters', function(done) {
+  it('Passes handshake as service parameters.', function(done) {
     var service = app.service('todo');
     var old = {
       find: service.find,
@@ -73,7 +75,7 @@ describe('Primus provider', function () {
     });
   });
 
-  it('missing parameters in socket call works (#88)', function(done) {
+  it('Missing parameters in socket call works. (#88)', function(done) {
     var service = app.service('todo');
     var old = {
       find: service.find
@@ -89,6 +91,9 @@ describe('Primus provider', function () {
       done();
     });
   });
+
+
+  /* * * * * * * * * Services * * * * * * * * */
 
   describe('CRUD', function () {
     it('::find', function (done) {
@@ -257,6 +262,183 @@ describe('Primus provider', function () {
       socket.send('todo::remove', 23, {}, function() {});
 
       socket.on('todo removed', function (data) {
+        service.removed = oldRemoved;
+        assert.equal(data.id, 23);
+        done();
+      });
+    });
+  });
+
+
+  /* * * * * * * * * Dynamically-Added Services * * * * * * * * */
+
+  describe('Dynamic Service CRUD', function () {
+    it('::find', function (done) {
+      socket.send('tasks::find', {}, function (error, data) {
+        verify.find(data);
+
+        done(error);
+      });
+    });
+
+    it('::get', function (done) {
+      socket.send('tasks::get', 'laundry', {}, function (error, data) {
+        verify.get('laundry', data);
+
+        done(error);
+      });
+    });
+
+    it('::create', function (done) {
+      var original = {
+        name: 'creating'
+      };
+
+      socket.send('tasks::create', original, {}, function (error, data) {
+        verify.create(original, data);
+
+        done(error);
+      });
+    });
+
+    it('::update', function (done) {
+      var original = {
+        name: 'updating'
+      };
+
+      socket.send('tasks::update', 23, original, {}, function (error, data) {
+        verify.update(23, original, data);
+
+        done(error);
+      });
+    });
+
+    it('::patch', function (done) {
+      var original = {
+        name: 'patching'
+      };
+
+      socket.send('tasks::patch', 25, original, {}, function (error, data) {
+        verify.patch(25, original, data);
+
+        done(error);
+      });
+    });
+
+    it('::remove', function (done) {
+      socket.send('tasks::remove', 11, {}, function (error, data) {
+        verify.remove(11, data);
+
+        done(error);
+      });
+    });
+  });
+
+  describe('Dynamic Service Events', function () {
+    it('created', function (done) {
+      var original = {
+        name: 'created event'
+      };
+
+      socket.once('tasks created', function (data) {
+        verify.create(original, data);
+        done();
+      });
+
+      socket.send('tasks::create', original, {}, function () {});
+    });
+
+    it('updated', function (done) {
+      var original = {
+        name: 'updated event'
+      };
+
+      socket.once('tasks updated', function (data) {
+        verify.update(10, original, data);
+        done();
+      });
+
+      socket.send('tasks::update', 10, original, {}, function () {});
+    });
+
+    it('patched', function(done) {
+      var original = {
+        name: 'patched event'
+      };
+
+      socket.once('tasks patched', function (data) {
+        verify.patch(12, original, data);
+        done();
+      });
+
+      socket.send('tasks::patch', 12, original, {}, function () {});
+    });
+
+    it('removed', function (done) {
+      socket.once('tasks removed', function (data) {
+        verify.remove(333, data);
+        done();
+      });
+
+      socket.send('tasks::remove', 333, {}, function () {});
+    });
+  });
+
+  describe('Dynamic Service Event filtering', function() {
+    it('.created', function (done) {
+      var service = app.service('tasks');
+      var original = { description: 'created event test' };
+      var oldCreated = service.created;
+
+      service.created = function(data, params, callback) {
+        assert.deepEqual(params, socketParams);
+        verify.create(original, data);
+
+        callback(null, _.extend({ processed: true }, data));
+      };
+
+      socket.send('tasks::create', original, {}, function() {});
+
+      socket.once('tasks created', function (data) {
+        service.created = oldCreated;
+        // Make sure Todo got processed
+        verify.create(_.extend({ processed: true }, original), data);
+        done();
+      });
+    });
+
+    it('.updated', function (done) {
+      var original = {
+        name: 'updated event'
+      };
+
+      socket.once('tasks updated', function (data) {
+        verify.update(10, original, data);
+        done();
+      });
+
+      socket.send('tasks::update', 10, original, {}, function () {});
+    });
+
+    it('.removed', function (done) {
+      var service = app.service('tasks');
+      var oldRemoved = service.removed;
+
+      service.removed = function(data, params, callback) {
+        assert.deepEqual(params, socketParams);
+
+        if(data.id === 23) {
+          // Only dispatch with given id
+          return callback(null, data);
+        }
+
+        callback();
+      };
+
+      socket.send('tasks::remove', 1, {}, function() {});
+      socket.send('tasks::remove', 23, {}, function() {});
+
+      socket.on('tasks removed', function (data) {
         service.removed = oldRemoved;
         assert.equal(data.id, 23);
         done();

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -26,12 +26,18 @@ describe('REST provider', function () {
           }
         })
         .use('todo', todoService);
-      server = app.listen(4777);
+
+      server = app.listen(4777, function(){
+        app.use('tasks', todoService);
+      });
     });
 
     after(function (done) {
       server.close(done);
     });
+
+
+    /* * * * * * * * * Services * * * * * * * * */
 
     it('GET .find', function (done) {
       request('http://localhost:4777/todo', function (error, response, body) {
@@ -109,6 +115,9 @@ describe('REST provider', function () {
       });
     });
 
+
+    /* * * * * * * * * Dynamically-Added Services * * * * * * * * */
+
     it('DELETE .remove', function (done) {
       request({
         url: 'http://localhost:4777/todo/233',
@@ -120,6 +129,95 @@ describe('REST provider', function () {
         done(error);
       });
     });
+
+    it('Dynamic GET .find', function (done) {
+      request('http://localhost:4777/tasks', function (error, response, body) {
+        assert.ok(response.statusCode === 200, 'Got OK status code');
+        verify.find(JSON.parse(body));
+        done(error);
+      });
+    });
+
+    it('Dynamic GET .get', function (done) {
+      request('http://localhost:4777/tasks/dishes', function (error, response, body) {
+        assert.ok(response.statusCode === 200, 'Got OK status code');
+        verify.get('dishes', JSON.parse(body));
+        done(error);
+      });
+    });
+
+    it('Dynamic POST .create', function (done) {
+      var original = {
+        description: 'Dynamic POST .create'
+      };
+
+      request({
+        url: 'http://localhost:4777/tasks',
+        method: 'post',
+        body: JSON.stringify(original),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, function (error, response, body) {
+        assert.ok(response.statusCode === 201, 'Got CREATED status code');
+        verify.create(original, JSON.parse(body));
+
+        done(error);
+      });
+    });
+
+    it('Dynamic PUT .update', function (done) {
+      var original = {
+        description: 'Dynamic PUT .update'
+      };
+
+      request({
+        url: 'http://localhost:4777/tasks/544',
+        method: 'put',
+        body: JSON.stringify(original),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, function (error, response, body) {
+        assert.ok(response.statusCode === 200, 'Got OK status code');
+        verify.update(544, original, JSON.parse(body));
+
+        done(error);
+      });
+    });
+
+    it('Dynamic PATCH .patch', function (done) {
+      var original = {
+        description: 'Dynamic PATCH .patch'
+      };
+
+      request({
+        url: 'http://localhost:4777/tasks/544',
+        method: 'patch',
+        body: JSON.stringify(original),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, function (error, response, body) {
+        assert.ok(response.statusCode === 200, 'Got OK status code');
+        verify.patch(544, original, JSON.parse(body));
+
+        done(error);
+      });
+    });
+
+    it('Dynamic DELETE .remove', function (done) {
+      request({
+        url: 'http://localhost:4777/tasks/233',
+        method: 'delete'
+      }, function (error, response, body) {
+        assert.ok(response.statusCode === 200, 'Got OK status code');
+        verify.remove(233, JSON.parse(body));
+
+        done(error);
+      });
+    });
+    /* * * End of Dynamically-Added Tests * * */
   });
 
   describe('HTTP status codes', function() {

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -26,7 +26,9 @@ describe('SocketIO provider', function () {
       }))
       .use('todo', todoService);
 
-    server = app.listen(7886);
+    server = app.listen(7886, function(){
+      app.use('tasks', todoService);
+    });
 
     socket = io.connect('http://localhost:7886');
   });
@@ -88,6 +90,9 @@ describe('SocketIO provider', function () {
       done();
     });
   });
+
+
+/* * * * * * * * * Services * * * * * * * * */
 
   describe('CRUD', function () {
     it('::find', function (done) {
@@ -256,6 +261,183 @@ describe('SocketIO provider', function () {
       socket.emit('todo::remove', 23, {}, function() {});
 
       socket.on('todo removed', function (data) {
+        service.removed = oldRemoved;
+        assert.equal(data.id, 23);
+        done();
+      });
+    });
+  });
+
+
+/* * * * * * * * * Dynamically-Added Services * * * * * * * * */
+
+  describe('Dynamic Service CRUD', function () {
+    it('::find', function (done) {
+      socket.emit('tasks::find', {}, function (error, data) {
+        verify.find(data);
+
+        done(error);
+      });
+    });
+
+    it('::get', function (done) {
+      socket.emit('tasks::get', 'laundry', {}, function (error, data) {
+        verify.get('laundry', data);
+
+        done(error);
+      });
+    });
+
+    it('::create', function (done) {
+      var original = {
+        name: 'creating'
+      };
+
+      socket.emit('tasks::create', original, {}, function (error, data) {
+        verify.create(original, data);
+
+        done(error);
+      });
+    });
+
+    it('::update', function (done) {
+      var original = {
+        name: 'updating'
+      };
+
+      socket.emit('tasks::update', 23, original, {}, function (error, data) {
+        verify.update(23, original, data);
+
+        done(error);
+      });
+    });
+
+    it('::patch', function (done) {
+      var original = {
+        name: 'patching'
+      };
+
+      socket.emit('tasks::patch', 25, original, {}, function (error, data) {
+        verify.patch(25, original, data);
+
+        done(error);
+      });
+    });
+
+    it('::remove', function (done) {
+      socket.emit('tasks::remove', 11, {}, function (error, data) {
+        verify.remove(11, data);
+
+        done(error);
+      });
+    });
+  });
+
+  describe('Dynamic Service Events', function () {
+    it('created', function (done) {
+      var original = {
+        name: 'created event'
+      };
+
+      socket.once('tasks created', function (data) {
+        verify.create(original, data);
+        done();
+      });
+
+      socket.emit('tasks::create', original, {}, function () {});
+    });
+
+    it('updated', function (done) {
+      var original = {
+        name: 'updated event'
+      };
+
+      socket.once('tasks updated', function (data) {
+        verify.update(10, original, data);
+        done();
+      });
+
+      socket.emit('tasks::update', 10, original, {}, function () {});
+    });
+
+    it('patched', function(done) {
+      var original = {
+        name: 'patched event'
+      };
+
+      socket.once('tasks patched', function (data) {
+        verify.patch(12, original, data);
+        done();
+      });
+
+      socket.emit('tasks::patch', 12, original, {}, function () {});
+    });
+
+    it('removed', function (done) {
+      socket.once('tasks removed', function (data) {
+        verify.remove(333, data);
+        done();
+      });
+
+      socket.emit('tasks::remove', 333, {}, function () {});
+    });
+  });
+
+  describe('Dynamic Service Event Filtering', function() {
+    it('.created', function (done) {
+      var service = app.service('tasks');
+      var original = { description: 'created event test' };
+      var oldCreated = service.created;
+
+      service.created = function(data, params, callback) {
+        assert.deepEqual(params, socketParams);
+        verify.create(original, data);
+
+        callback(null, _.extend({ processed: true }, data));
+      };
+
+      socket.emit('tasks::create', original, {}, function() {});
+
+      socket.once('tasks created', function (data) {
+        service.created = oldCreated;
+        // Make sure Todo got processed
+        verify.create(_.extend({ processed: true }, original), data);
+        done();
+      });
+    });
+
+    it('.updated', function (done) {
+      var original = {
+        name: 'updated event'
+      };
+
+      socket.once('tasks updated', function (data) {
+        verify.update(10, original, data);
+        done();
+      });
+
+      socket.emit('tasks::update', 10, original, {}, function () {});
+    });
+
+    it('.removed', function (done) {
+      var service = app.service('tasks');
+      var oldRemoved = service.removed;
+
+      service.removed = function(data, params, callback) {
+        assert.deepEqual(params, socketParams);
+
+        if(data.id === 23) {
+          // Only dispatch with given id
+          return callback(null, data);
+        }
+
+        callback();
+      };
+
+      socket.emit('tasks::remove', 1, {}, function() {});
+      socket.emit('tasks::remove', 23, {}, function() {});
+
+      socket.on('tasks removed', function (data) {
         service.removed = oldRemoved;
         assert.equal(data.id, 23);
         done();


### PR DESCRIPTION
This is Dynamic Services on top of the recent 1.0.2 patch.  I've also made it no longer a requirement to pass a callback (#96).  If the request fails, it logs a message to the console for a developer to track down.

As for consolidating the code a bit more.  This is basically creating a second path in the code to setup a service.  The first way is through the setup methods, and now this for sure works after the server has started.  I'm not sure if it would be possible to just use this new way BEFORE the server starts.  I would have to check to see if there is anything that the setup methods put in place that the services require as prerequisites.

**Update:** We for sure have to wait until the providers are set in place, which isn't really guaranteed until after the server starts (since providers are setup with configure).  There may be other optimizations that can be made?

Closes #67 and closes #82