### PR TITLE
Callbacks not required.  Log any errors for the developer.

### DIFF
--- a/lib/providers/socket/commons.js
+++ b/lib/providers/socket/commons.js
@@ -35,6 +35,18 @@ exports.setupMethodHandler = function setupMethodHandler(emitter, params, servic
       if(typeof args[position] === 'function') {
         args.splice(position, 0, {});
       }
+
+      // If no callback was provided...
+      if (typeof args[args.length - 1] !== 'function') {
+        // ... create one that logs errors for the developer.
+        var callback = function(err){
+          if (err) {
+            console.log('Error on ' + path + '::' + method, args, err);
+          }
+        };
+        args.push(callback);
+      }
+
       args[position] = _.extend({ query: args[position] }, params);
       service[method].apply(service, args);
     });


### PR DESCRIPTION
Addressing #96 .  This makes callbacks optional for all service methods.  If no callback is provided, one is added in commons.js.  If there is an error, it will be logged to the server console in this format:

```
Error on <location>::<method>  [<args array>]  <the service's error message>
```

For example:
```
Error on todos::find [ { query: { test: 'this is a test' } }, [Function] ] Error: There was a problem blah blah blah
```