### PR TITLE
Fix duplicate events in dynamic services.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -45,13 +45,9 @@ module.exports = {
       provider(location, protoService, options || {});
     });
 
-    // If already _setup, just add this single service.
-    if (this._setup) {
+    // If we ran setup already, set this service up explicitly
+    if (this._isSetup) {
       protoService.setup(this, location);
-      // If we're using a socket provider, register the service on it.
-      if (this.addService) {
-        this.addService(protoService, location);
-      }
     }
 
     this.services[location] = protoService;
@@ -89,7 +85,7 @@ module.exports = {
       }
     }.bind(this));
 
-    this._setup = true;
+    this._isSetup = true;
 
     return this;
   },

--- a/lib/application.js
+++ b/lib/application.js
@@ -47,11 +47,11 @@ module.exports = {
 
     // If already _setup, just add this single service.
     if (this._setup) {
+      protoService.setup(this, location);
       // If we're using a socket provider, register the service on it.
       if (this.addService) {
         this.addService(protoService, location);
       }
-      protoService.setup(this, location);
     }
 
     this.services[location] = protoService;

--- a/lib/application.js
+++ b/lib/application.js
@@ -62,14 +62,14 @@ module.exports = {
     var args = _.toArray(arguments);
     var location = args.shift();
     var service = args.pop();
-    var hasMethod = function() {
-      return _.some(arguments, function(name) {
+    var hasMethod = function(methods) {
+      return _.some(methods, function(name) {
         return (service && typeof service[name] === 'function');
       });
     };
 
     // Check for service (any object with at least one service method)
-    if(hasMethod('handle', 'set') || !hasMethod.apply(null, this.methods)) {
+    if(hasMethod(['handle', 'set']) || !hasMethod(this.methods)) {
       return this._super.apply(this, arguments);
     }
 

--- a/lib/mixins/event.js
+++ b/lib/mixins/event.js
@@ -17,10 +17,6 @@ var eventMappings = {
  */
 var EventMixin = {
   setup: function () {
-    this.applyEvents();
-    return this._super ? this._super.apply(this, arguments) : this;
-  },
-  applyEvents:function(){
     var emitter = this._rubberDuck = rubberduck.emitter(this);
     var self = this;
 
@@ -49,6 +45,8 @@ var EventMixin = {
         });
       }
     });
+
+    return this._super ? this._super.apply(this, arguments) : this;
   }
 };
 

--- a/lib/providers/socket/commons.js
+++ b/lib/providers/socket/commons.js
@@ -1,75 +1,105 @@
-'use strict';
-
 var _ = require('lodash');
 
 // The position of the params parameters for a service method so that we can extend them
 // default is 1
-var paramsPositions = {
+exports.paramsPositions = {
   find: 0,
   update: 2,
   patch: 2
 };
 
-exports.addService = function addService(service, path){
-  // Add handlers for the service to connected sockets.
-  _.each(this.info.connections, function (spark) {
-    this.setupMethodHandlers(service, path, spark);
-  }, this);
-
-  // Setup events for the service.
-  exports.setupEventHandlers.call(this, service, path);
+// The default event dispatcher
+exports.defaultDispatcher = function (data, params, callback) {
+  callback(null, data);
 };
 
-// Set up the service method handler for a service and socket.
-exports.setupMethodHandler = function setupMethodHandler(emitter, params, service, path, method) {
-  var name = path + '::' + method;
-  var position = typeof paramsPositions[method] !== 'undefined' ? paramsPositions[method] : 1;
+// Set up event handlers for a given service using the event dispatching mechanism
+exports.setupEventHandlers = function (info, service, path) {
+  // If the service emits events that we want to listen to (Event mixin)
+  if (typeof service.on === 'function' && service._serviceEvents) {
+    var addEvent = function (ev) {
+      service.on(ev, function (data) {
+        // Check if there is a method on the service with the same name as the event
+        var dispatcher = typeof service[ev] === 'function' ?
+          service[ev] : exports.defaultDispatcher;
+        var eventName = path + ' ' + ev;
 
-  if (typeof service[method] === 'function') {
-    emitter.on(name, function () {
+        info.clients().forEach(function (socket) {
+          dispatcher(data, info.params(socket), function (error, dispatchData) {
+            if (error) {
+              socket[info.method]('error', error);
+            } else if (dispatchData) { // Only dispatch if we have data
+              socket[info.method](eventName, dispatchData);
+            }
+          });
+        });
+      });
+    };
+
+    _.each(service._serviceEvents, addEvent);
+  }
+};
+
+// Set up all method handlers for a service and socket.
+exports.setupMethodHandlers = function (info, socket, service, path) {
+  this.methods.forEach(function (method) {
+    if (typeof service[method] !== 'function') {
+      return;
+    }
+
+    var name = path + '::' + method;
+    var params = info.params(socket);
+    var position = typeof exports.paramsPositions[method] !== 'undefined' ?
+      exports.paramsPositions[method] : 1;
+
+    socket.on(name, function () {
       var args = _.toArray(arguments);
       // If the service is called with no parameter object
       // insert an empty object
-      if(typeof args[position] === 'function') {
+      if (typeof args[position] === 'function') {
         args.splice(position, 0, {});
       }
-      args[position] = _.extend({ query: args[position] }, params);
+      args[position] = _.extend({query: args[position]}, params);
       service[method].apply(service, args);
     });
-  }
-};
-
-exports.setupEventHandlers = function setupEventHandlers(service, path){
-  // If the service emits events that we want to listen to (Event mixin)
-  if (typeof service.on === 'function' && service._serviceEvents) {
-    _.each(service._serviceEvents, function (ev) {
-      exports.setupEventHandler(this.info, service, path, ev);
-    }, this);
-  }
-};
-
-// Set up event handlers for a given service and connected sockets.
-// Send it through the service dispatching mechanism (`removed(data, params, callback)`,
-// `updated(data, params, callback)` and `created(data, params, callback)`) if it
-// exists.
-exports.setupEventHandler = function setupEventHandler (info, service, path, ev) {
-  var defaultDispatcher = function (data, params, callback) {
-    callback(null, data);
-  };
-
-  service.on(ev, function (data) {
-    // Check if there is a method on the service with the same name as the event
-    var dispatcher = typeof service[ev] === 'function' ? service[ev] : defaultDispatcher;
-    var eventName = path + ' ' + ev;
-
-    info.emitters().forEach(function (emitter) {
-      dispatcher(data, info.params(emitter), function (error, dispatchData) {
-        if (error) {
-          emitter[info.method]('error', error);
-        } else if (dispatchData) {
-          emitter[info.method](eventName, dispatchData);
-        }
-      });
-    });
   });
+};
+
+// Common setup functionality taking the info object which abstracts websocket access
+exports.setup = function (info) {
+  var app = this;
+  var setupEventHandlers = exports.setupEventHandlers.bind(this, info);
+
+  app._commons = info;
+
+  // For a new connection, set up the service method handlers
+  info.connection().on('connection', function (socket) {
+    var setupMethodHandlers = exports.setupMethodHandlers.bind(app, info, socket);
+    // Process all registered services
+    _.each(app.services, setupMethodHandlers);
+  });
+
+  // Set up events and event dispatching
+  _.each(app.services, setupEventHandlers);
+};
+
+// Socket mixin when a new service is registered
+exports.service = function (path, service) {
+  var protoService = this._super.apply(this, arguments);
+  var info = this._commons;
+
+  // app._socketInfo will only be available once we are set up
+  if (service && info) {
+    var setupEventHandlers = exports.setupEventHandlers.bind(this, info);
+    var setupMethodHandlers = exports.setupMethodHandlers.bind(this, info);
+
+    // Set up event handlers for this new service
+    setupEventHandlers(protoService, path);
+    // For any existing connection add method handlers
+    info.clients().forEach(function (socket) {
+      setupMethodHandlers(socket, path, protoService);
+    });
+  }
+
+  return protoService;
 };

--- a/lib/providers/socket/commons.js
+++ b/lib/providers/socket/commons.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash');
-var eventsMixin = require('../../mixins/event').Mixin;
 
 // The position of the params parameters for a service method so that we can extend them
 // default is 1
@@ -18,7 +17,6 @@ exports.addService = function addService(service, path){
   }, this);
 
   // Setup events for the service.
-  eventsMixin.applyEvents.call(service);
   exports.setupEventHandlers.call(this, service, path);
 };
 

--- a/lib/providers/socket/primus.js
+++ b/lib/providers/socket/primus.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var Proto = require('uberproto');
 var Primus = require('primus');
 var Emitter = require('primus-emitter');
@@ -14,8 +13,9 @@ module.exports = function(config, configurer) {
 
     // Monkey patch app.setup(server)
     Proto.mixin({
+      service: commons.service,
+
       setup: function(server) {
-        var self = this;
         var result = this._super.apply(this, arguments);
 
         if (this.disabled('feathers primus')) {
@@ -23,45 +23,27 @@ module.exports = function(config, configurer) {
         }
 
         var primus = this.primus = new Primus(server, config);
-        this.info = {
-          emitters: function() {
+
+        commons.setup.call(this, {
+          method: 'send',
+          connection: function() {
+            return primus;
+          },
+          clients: function() {
             return primus;
           },
           params: function(spark) {
             return spark.request.feathers;
-          },
-          method: 'send',
-          connections: this.primus.connections
-        };
-
-        primus.use('emitter', Emitter);
-
-        // For a new connection, set up the service method handlers
-        primus.on('connection', function (spark) {
-          // Process services that were registered at startup.
-          _.each(self.services, function (service, path) {
-            self.setupMethodHandlers.call(self, service, path, spark);
-          });
+          }
         });
 
-        // Set up events and event dispatching
-        _.each(this.services, function (service, path) {
-          commons.setupEventHandlers.call(this, service, path);
-        }, this);
+        primus.use('emitter', Emitter);
 
         if (typeof configurer === 'function') {
           configurer.call(this, primus);
         }
 
         return result;
-      },
-
-      addService: commons.addService,
-
-      setupMethodHandlers: function(service, path, spark){
-        _.each(this.methods, function (method) {
-          commons.setupMethodHandler(spark, spark.request.feathers, service, path, method);
-        }, this);
       }
     }, app);
   };

--- a/lib/providers/socket/socketio.js
+++ b/lib/providers/socket/socketio.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var socketio = require('socket.io');
 var Proto = require('uberproto');
 var commons = require('./commons');
@@ -13,8 +12,9 @@ module.exports = function (config) {
 
     // Monkey patch app.setup(server)
     Proto.mixin({
+      service: commons.service,
+
       setup: function (server) {
-        var self = this;
         var result = this._super.apply(this, arguments);
 
         if (this.disabled('feathers socketio')) {
@@ -22,44 +22,25 @@ module.exports = function (config) {
         }
 
         var io = this.io = socketio.listen(server);
-        // The info object we can pass to commons.setupEventHandler
-        this.info = {
-          emitters: function() {
+
+        commons.setup.call(this, {
+          method: 'emit',
+          connection: function() {
+            return io.sockets;
+          },
+          clients: function() {
             return io.sockets.sockets;
           },
           params: function(socket) {
             return socket.feathers;
-          },
-          method: 'emit',
-          connections: this.connections = this.io.sockets.connected
-        };
-
-        // For a new connection, set up the service method handlers
-        io.sockets.on('connection', function (socket) {
-          // Process services that were registered at startup.
-          _.each(self.services, function (service, path) {
-            self.setupMethodHandlers.call(self, service, path, socket);
-          });
+          }
         });
-
-        // Set up events and event dispatching
-        _.each(self.services, function (service, path) {
-          commons.setupEventHandlers.call(this, service, path);
-        }, this);
 
         if (typeof config === 'function') {
           config.call(this, io);
         }
 
         return result;
-      },
-
-      addService: commons.addService,
-
-      setupMethodHandlers: function(service, path, socket){
-        _.each(this.methods, function (method) {
-          commons.setupMethodHandler(socket, socket.feathers || {}, service, path, method);
-        }, this);
       }
     }, app);
   };

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -255,7 +255,7 @@ describe('Primus provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.send('todo::remove', 1, {}, function() {});
@@ -432,21 +432,16 @@ describe('Primus provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.send('tasks::remove', 1, {}, function() {});
       socket.send('tasks::remove', 23, {}, function() {});
 
-      var ready = false;
-
       socket.on('tasks removed', function (data) {
         service.removed = oldRemoved;
         assert.equal(data.id, 23);
-        if (ready) {
-          done();
-        }
-        ready = true;
+        done();
       });
     });
   });

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -36,188 +36,186 @@ describe('REST provider', function () {
       server.close(done);
     });
 
+    describe('Services', function() {
 
-    /* * * * * * * * * Services * * * * * * * * */
+      it('GET .find', function (done) {
+        request('http://localhost:4777/todo', function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.find(JSON.parse(body));
+          done(error);
+        });
+      });
 
-    it('GET .find', function (done) {
-      request('http://localhost:4777/todo', function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.find(JSON.parse(body));
-        done(error);
+      it('GET .get', function (done) {
+        request('http://localhost:4777/todo/dishes', function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.get('dishes', JSON.parse(body));
+          done(error);
+        });
+      });
+
+      it('POST .create', function (done) {
+        var original = {
+          description: 'POST .create'
+        };
+
+        request({
+          url: 'http://localhost:4777/todo',
+          method: 'post',
+          body: JSON.stringify(original),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 201, 'Got CREATED status code');
+          verify.create(original, JSON.parse(body));
+
+          done(error);
+        });
+      });
+
+      it('PUT .update', function (done) {
+        var original = {
+          description: 'PUT .update'
+        };
+
+        request({
+          url: 'http://localhost:4777/todo/544',
+          method: 'put',
+          body: JSON.stringify(original),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.update(544, original, JSON.parse(body));
+
+          done(error);
+        });
+      });
+
+      it('PATCH .patch', function (done) {
+        var original = {
+          description: 'PATCH .patch'
+        };
+
+        request({
+          url: 'http://localhost:4777/todo/544',
+          method: 'patch',
+          body: JSON.stringify(original),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.patch(544, original, JSON.parse(body));
+
+          done(error);
+        });
       });
     });
 
-    it('GET .get', function (done) {
-      request('http://localhost:4777/todo/dishes', function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.get('dishes', JSON.parse(body));
-        done(error);
+    describe('Dynamic Services', function() {
+      it('.remove', function (done) {
+        request({
+          url: 'http://localhost:4777/todo/233',
+          method: 'delete'
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.remove(233, JSON.parse(body));
+
+          done(error);
+        });
+      });
+
+      it('GET .find', function (done) {
+        request('http://localhost:4777/tasks', function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.find(JSON.parse(body));
+          done(error);
+        });
+      });
+
+      it('GET .get', function (done) {
+        request('http://localhost:4777/tasks/dishes', function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.get('dishes', JSON.parse(body));
+          done(error);
+        });
+      });
+
+      it('POST .create', function (done) {
+        var original = {
+          description: 'Dynamic POST .create'
+        };
+
+        request({
+          url: 'http://localhost:4777/tasks',
+          method: 'post',
+          body: JSON.stringify(original),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 201, 'Got CREATED status code');
+          verify.create(original, JSON.parse(body));
+
+          done(error);
+        });
+      });
+
+      it('PUT .update', function (done) {
+        var original = {
+          description: 'Dynamic PUT .update'
+        };
+
+        request({
+          url: 'http://localhost:4777/tasks/544',
+          method: 'put',
+          body: JSON.stringify(original),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.update(544, original, JSON.parse(body));
+
+          done(error);
+        });
+      });
+
+      it('PATCH .patch', function (done) {
+        var original = {
+          description: 'Dynamic PATCH .patch'
+        };
+
+        request({
+          url: 'http://localhost:4777/tasks/544',
+          method: 'patch',
+          body: JSON.stringify(original),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.patch(544, original, JSON.parse(body));
+
+          done(error);
+        });
+      });
+
+      it('DELETE .remove', function (done) {
+        request({
+          url: 'http://localhost:4777/tasks/233',
+          method: 'delete'
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.remove(233, JSON.parse(body));
+
+          done(error);
+        });
       });
     });
-
-    it('POST .create', function (done) {
-      var original = {
-        description: 'POST .create'
-      };
-
-      request({
-        url: 'http://localhost:4777/todo',
-        method: 'post',
-        body: JSON.stringify(original),
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 201, 'Got CREATED status code');
-        verify.create(original, JSON.parse(body));
-
-        done(error);
-      });
-    });
-
-    it('PUT .update', function (done) {
-      var original = {
-        description: 'PUT .update'
-      };
-
-      request({
-        url: 'http://localhost:4777/todo/544',
-        method: 'put',
-        body: JSON.stringify(original),
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.update(544, original, JSON.parse(body));
-
-        done(error);
-      });
-    });
-
-    it('PATCH .patch', function (done) {
-      var original = {
-        description: 'PATCH .patch'
-      };
-
-      request({
-        url: 'http://localhost:4777/todo/544',
-        method: 'patch',
-        body: JSON.stringify(original),
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.patch(544, original, JSON.parse(body));
-
-        done(error);
-      });
-    });
-
-
-    /* * * * * * * * * Dynamically-Added Services * * * * * * * * */
-
-    it('DELETE .remove', function (done) {
-      request({
-        url: 'http://localhost:4777/todo/233',
-        method: 'delete'
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.remove(233, JSON.parse(body));
-
-        done(error);
-      });
-    });
-
-    it('Dynamic GET .find', function (done) {
-      request('http://localhost:4777/tasks', function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.find(JSON.parse(body));
-        done(error);
-      });
-    });
-
-    it('Dynamic GET .get', function (done) {
-      request('http://localhost:4777/tasks/dishes', function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.get('dishes', JSON.parse(body));
-        done(error);
-      });
-    });
-
-    it('Dynamic POST .create', function (done) {
-      var original = {
-        description: 'Dynamic POST .create'
-      };
-
-      request({
-        url: 'http://localhost:4777/tasks',
-        method: 'post',
-        body: JSON.stringify(original),
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 201, 'Got CREATED status code');
-        verify.create(original, JSON.parse(body));
-
-        done(error);
-      });
-    });
-
-    it('Dynamic PUT .update', function (done) {
-      var original = {
-        description: 'Dynamic PUT .update'
-      };
-
-      request({
-        url: 'http://localhost:4777/tasks/544',
-        method: 'put',
-        body: JSON.stringify(original),
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.update(544, original, JSON.parse(body));
-
-        done(error);
-      });
-    });
-
-    it('Dynamic PATCH .patch', function (done) {
-      var original = {
-        description: 'Dynamic PATCH .patch'
-      };
-
-      request({
-        url: 'http://localhost:4777/tasks/544',
-        method: 'patch',
-        body: JSON.stringify(original),
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.patch(544, original, JSON.parse(body));
-
-        done(error);
-      });
-    });
-
-    it('Dynamic DELETE .remove', function (done) {
-      request({
-        url: 'http://localhost:4777/tasks/233',
-        method: 'delete'
-      }, function (error, response, body) {
-        assert.ok(response.statusCode === 200, 'Got OK status code');
-        verify.remove(233, JSON.parse(body));
-
-        done(error);
-      });
-    });
-    /* * * End of Dynamically-Added Tests * * */
   });
 
   describe('HTTP status codes', function() {

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -91,356 +91,354 @@ describe('SocketIO provider', function () {
     });
   });
 
+  describe('Services', function() {
+    describe('CRUD', function () {
+      it('::find', function (done) {
+        socket.emit('todo::find', {}, function (error, data) {
+          verify.find(data);
 
-/* * * * * * * * * Services * * * * * * * * */
+          done(error);
+        });
+      });
 
-  describe('CRUD', function () {
-    it('::find', function (done) {
-      socket.emit('todo::find', {}, function (error, data) {
-        verify.find(data);
+      it('::get', function (done) {
+        socket.emit('todo::get', 'laundry', {}, function (error, data) {
+          verify.get('laundry', data);
 
-        done(error);
+          done(error);
+        });
+      });
+
+      it('::create', function (done) {
+        var original = {
+          name: 'creating'
+        };
+
+        socket.emit('todo::create', original, {}, function (error, data) {
+          verify.create(original, data);
+
+          done(error);
+        });
+      });
+
+      it('::update', function (done) {
+        var original = {
+          name: 'updating'
+        };
+
+        socket.emit('todo::update', 23, original, {}, function (error, data) {
+          verify.update(23, original, data);
+
+          done(error);
+        });
+      });
+
+      it('::patch', function (done) {
+        var original = {
+          name: 'patching'
+        };
+
+        socket.emit('todo::patch', 25, original, {}, function (error, data) {
+          verify.patch(25, original, data);
+
+          done(error);
+        });
+      });
+
+      it('::remove', function (done) {
+        socket.emit('todo::remove', 11, {}, function (error, data) {
+          verify.remove(11, data);
+
+          done(error);
+        });
       });
     });
 
-    it('::get', function (done) {
-      socket.emit('todo::get', 'laundry', {}, function (error, data) {
-        verify.get('laundry', data);
+    describe('Events', function () {
+      it('created', function (done) {
+        var original = {
+          name: 'created event'
+        };
 
-        done(error);
+        socket.once('todo created', function (data) {
+          verify.create(original, data);
+          done();
+        });
+
+        socket.emit('todo::create', original, {}, function () {});
+      });
+
+      it('updated', function (done) {
+        var original = {
+          name: 'updated event'
+        };
+
+        socket.once('todo updated', function (data) {
+          verify.update(10, original, data);
+          done();
+        });
+
+        socket.emit('todo::update', 10, original, {}, function () {});
+      });
+
+      it('patched', function(done) {
+        var original = {
+          name: 'patched event'
+        };
+
+        socket.once('todo patched', function (data) {
+          verify.patch(12, original, data);
+          done();
+        });
+
+        socket.emit('todo::patch', 12, original, {}, function () {});
+      });
+
+      it('removed', function (done) {
+        socket.once('todo removed', function (data) {
+          verify.remove(333, data);
+          done();
+        });
+
+        socket.emit('todo::remove', 333, {}, function () {});
       });
     });
 
-    it('::create', function (done) {
-      var original = {
-        name: 'creating'
-      };
+    describe('Event filtering', function() {
+      it('.created', function (done) {
+        var service = app.service('todo');
+        var original = { description: 'created event test' };
+        var oldCreated = service.created;
 
-      socket.emit('todo::create', original, {}, function (error, data) {
-        verify.create(original, data);
+        service.created = function(data, params, callback) {
+          assert.deepEqual(params, socketParams);
+          verify.create(original, data);
 
-        done(error);
-      });
-    });
+          callback(null, _.extend({ processed: true }, data));
+        };
 
-    it('::update', function (done) {
-      var original = {
-        name: 'updating'
-      };
+        socket.emit('todo::create', original, {}, function() {});
 
-      socket.emit('todo::update', 23, original, {}, function (error, data) {
-        verify.update(23, original, data);
-
-        done(error);
-      });
-    });
-
-    it('::patch', function (done) {
-      var original = {
-        name: 'patching'
-      };
-
-      socket.emit('todo::patch', 25, original, {}, function (error, data) {
-        verify.patch(25, original, data);
-
-        done(error);
-      });
-    });
-
-    it('::remove', function (done) {
-      socket.emit('todo::remove', 11, {}, function (error, data) {
-        verify.remove(11, data);
-
-        done(error);
-      });
-    });
-  });
-
-  describe('Events', function () {
-    it('created', function (done) {
-      var original = {
-        name: 'created event'
-      };
-
-      socket.once('todo created', function (data) {
-        verify.create(original, data);
-        done();
+        socket.once('todo created', function (data) {
+          service.created = oldCreated;
+          // Make sure Todo got processed
+          verify.create(_.extend({ processed: true }, original), data);
+          done();
+        });
       });
 
-      socket.emit('todo::create', original, {}, function () {});
-    });
+      it('.updated', function (done) {
+        var original = {
+          name: 'updated event'
+        };
 
-    it('updated', function (done) {
-      var original = {
-        name: 'updated event'
-      };
+        socket.once('todo updated', function (data) {
+          verify.update(10, original, data);
+          done();
+        });
 
-      socket.once('todo updated', function (data) {
-        verify.update(10, original, data);
-        done();
+        socket.emit('todo::update', 10, original, {}, function () {});
       });
 
-      socket.emit('todo::update', 10, original, {}, function () {});
-    });
+      it('.removed', function (done) {
+        var service = app.service('todo');
+        var oldRemoved = service.removed;
 
-    it('patched', function(done) {
-      var original = {
-        name: 'patched event'
-      };
+        service.removed = function(data, params, callback) {
+          assert.deepEqual(params, socketParams);
 
-      socket.once('todo patched', function (data) {
-        verify.patch(12, original, data);
-        done();
-      });
+          if(data.id === 23) {
+            // Only dispatch with given id
+            return callback(null, data);
+          }
 
-      socket.emit('todo::patch', 12, original, {}, function () {});
-    });
+          callback(null, false);
+        };
 
-    it('removed', function (done) {
-      socket.once('todo removed', function (data) {
-        verify.remove(333, data);
-        done();
-      });
+        socket.emit('todo::remove', 1, {}, function() {});
+        socket.emit('todo::remove', 23, {}, function() {});
 
-      socket.emit('todo::remove', 333, {}, function () {});
-    });
-  });
-
-  describe('Event filtering', function() {
-    it('.created', function (done) {
-      var service = app.service('todo');
-      var original = { description: 'created event test' };
-      var oldCreated = service.created;
-
-      service.created = function(data, params, callback) {
-        assert.deepEqual(params, socketParams);
-        verify.create(original, data);
-
-        callback(null, _.extend({ processed: true }, data));
-      };
-
-      socket.emit('todo::create', original, {}, function() {});
-
-      socket.once('todo created', function (data) {
-        service.created = oldCreated;
-        // Make sure Todo got processed
-        verify.create(_.extend({ processed: true }, original), data);
-        done();
-      });
-    });
-
-    it('.updated', function (done) {
-      var original = {
-        name: 'updated event'
-      };
-
-      socket.once('todo updated', function (data) {
-        verify.update(10, original, data);
-        done();
-      });
-
-      socket.emit('todo::update', 10, original, {}, function () {});
-    });
-
-    it('.removed', function (done) {
-      var service = app.service('todo');
-      var oldRemoved = service.removed;
-
-      service.removed = function(data, params, callback) {
-        assert.deepEqual(params, socketParams);
-
-        if(data.id === 23) {
-          // Only dispatch with given id
-          return callback(null, data);
-        }
-
-        callback(null, false);
-      };
-
-      socket.emit('todo::remove', 1, {}, function() {});
-      socket.emit('todo::remove', 23, {}, function() {});
-
-      socket.on('todo removed', function (data) {
-        service.removed = oldRemoved;
-        assert.equal(data.id, 23);
-        done();
-      });
-    });
-  });
-
-
-/* * * * * * * * * Dynamically-Added Services * * * * * * * * */
-
-  describe('Dynamic Service CRUD', function () {
-    it('::find', function (done) {
-      socket.emit('tasks::find', {}, function (error, data) {
-        verify.find(data);
-
-        done(error);
-      });
-    });
-
-    it('::get', function (done) {
-      socket.emit('tasks::get', 'laundry', {}, function (error, data) {
-        verify.get('laundry', data);
-
-        done(error);
-      });
-    });
-
-    it('::create', function (done) {
-      var original = {
-        name: 'creating'
-      };
-
-      socket.emit('tasks::create', original, {}, function (error, data) {
-        verify.create(original, data);
-
-        done(error);
-      });
-    });
-
-    it('::update', function (done) {
-      var original = {
-        name: 'updating'
-      };
-
-      socket.emit('tasks::update', 23, original, {}, function (error, data) {
-        verify.update(23, original, data);
-
-        done(error);
-      });
-    });
-
-    it('::patch', function (done) {
-      var original = {
-        name: 'patching'
-      };
-
-      socket.emit('tasks::patch', 25, original, {}, function (error, data) {
-        verify.patch(25, original, data);
-
-        done(error);
-      });
-    });
-
-    it('::remove', function (done) {
-      socket.emit('tasks::remove', 11, {}, function (error, data) {
-        verify.remove(11, data);
-
-        done(error);
+        socket.on('todo removed', function (data) {
+          service.removed = oldRemoved;
+          assert.equal(data.id, 23);
+          done();
+        });
       });
     });
   });
 
-  describe('Dynamic Service Events', function () {
-    it('created', function (done) {
-      var original = {
-        name: 'created event'
-      };
+  describe('Dynamic Services', function() {
+    describe('CRUD', function () {
+      it('::find', function (done) {
+        socket.emit('tasks::find', {}, function (error, data) {
+          verify.find(data);
 
-      socket.once('tasks created', function (data) {
-        verify.create(original, data);
-        done();
+          done(error);
+        });
       });
 
-      socket.emit('tasks::create', original, {}, function () {});
-    });
+      it('::get', function (done) {
+        socket.emit('tasks::get', 'laundry', {}, function (error, data) {
+          verify.get('laundry', data);
 
-    it('updated', function (done) {
-      var original = {
-        name: 'updated event'
-      };
-
-      socket.once('tasks updated', function (data) {
-        verify.update(10, original, data);
-        done();
+          done(error);
+        });
       });
 
-      socket.emit('tasks::update', 10, original, {}, function () {});
-    });
+      it('::create', function (done) {
+        var original = {
+          name: 'creating'
+        };
 
-    it('patched', function(done) {
-      var original = {
-        name: 'patched event'
-      };
+        socket.emit('tasks::create', original, {}, function (error, data) {
+          verify.create(original, data);
 
-      socket.once('tasks patched', function (data) {
-        verify.patch(12, original, data);
-        done();
+          done(error);
+        });
       });
 
-      socket.emit('tasks::patch', 12, original, {}, function () {});
-    });
+      it('::update', function (done) {
+        var original = {
+          name: 'updating'
+        };
 
-    it('removed', function (done) {
-      socket.once('tasks removed', function (data) {
-        verify.remove(333, data);
-        done();
+        socket.emit('tasks::update', 23, original, {}, function (error, data) {
+          verify.update(23, original, data);
+
+          done(error);
+        });
       });
 
-      socket.emit('tasks::remove', 333, {}, function () {});
-    });
-  });
+      it('::patch', function (done) {
+        var original = {
+          name: 'patching'
+        };
 
-  describe('Dynamic Service Event Filtering', function() {
-    it('.created', function (done) {
-      var service = app.service('tasks');
-      var original = { description: 'created event test' };
-      var oldCreated = service.created;
+        socket.emit('tasks::patch', 25, original, {}, function (error, data) {
+          verify.patch(25, original, data);
 
-      service.created = function(data, params, callback) {
-        assert.deepEqual(params, socketParams);
-        verify.create(original, data);
+          done(error);
+        });
+      });
 
-        callback(null, _.extend({ processed: true }, data));
-      };
+      it('::remove', function (done) {
+        socket.emit('tasks::remove', 11, {}, function (error, data) {
+          verify.remove(11, data);
 
-      socket.emit('tasks::create', original, {}, function() {});
-
-      socket.once('tasks created', function (data) {
-        service.created = oldCreated;
-        // Make sure Todo got processed
-        verify.create(_.extend({ processed: true }, original), data);
-        done();
+          done(error);
+        });
       });
     });
 
-    it('.updated', function (done) {
-      var original = {
-        name: 'updated event'
-      };
+    describe('Events', function () {
+      it('created', function (done) {
+        var original = {
+          name: 'created event'
+        };
 
-      socket.once('tasks updated', function (data) {
-        verify.update(10, original, data);
-        done();
+        socket.once('tasks created', function (data) {
+          verify.create(original, data);
+          done();
+        });
+
+        socket.emit('tasks::create', original, {}, function () {});
       });
 
-      socket.emit('tasks::update', 10, original, {}, function () {});
+      it('updated', function (done) {
+        var original = {
+          name: 'updated event'
+        };
+
+        socket.once('tasks updated', function (data) {
+          verify.update(10, original, data);
+          done();
+        });
+
+        socket.emit('tasks::update', 10, original, {}, function () {});
+      });
+
+      it('patched', function(done) {
+        var original = {
+          name: 'patched event'
+        };
+
+        socket.once('tasks patched', function (data) {
+          verify.patch(12, original, data);
+          done();
+        });
+
+        socket.emit('tasks::patch', 12, original, {}, function () {});
+      });
+
+      it('removed', function (done) {
+        socket.once('tasks removed', function (data) {
+          verify.remove(333, data);
+          done();
+        });
+
+        socket.emit('tasks::remove', 333, {}, function () {});
+      });
     });
 
-    it('.removed', function (done) {
-      var service = app.service('tasks');
-      var oldRemoved = service.removed;
+    describe('Event Filtering', function() {
+      it('.created', function (done) {
+        var service = app.service('tasks');
+        var original = { description: 'created event test' };
+        var oldCreated = service.created;
 
-      service.removed = function(data, params, callback) {
-        assert.deepEqual(params, socketParams);
+        service.created = function(data, params, callback) {
+          assert.deepEqual(params, socketParams);
+          verify.create(original, data);
 
-        if(data.id === 23) {
-          // Only dispatch with given id
-          return callback(null, data);
-        }
+          callback(null, _.extend({ processed: true }, data));
+        };
 
-        callback(null, false);
-      };
+        socket.emit('tasks::create', original, {}, function() {});
 
-      socket.emit('tasks::remove', 1, {}, function() {});
-      socket.emit('tasks::remove', 23, {}, function() {});
+        socket.once('tasks created', function (data) {
+          service.created = oldCreated;
+          // Make sure Todo got processed
+          verify.create(_.extend({ processed: true }, original), data);
+          done();
+        });
+      });
 
-      socket.on('tasks removed', function (data) {
-        service.removed = oldRemoved;
-        assert.equal(data.id, 23);
-        done();
+      it('.updated', function (done) {
+        var original = {
+          name: 'updated event'
+        };
+
+        socket.once('tasks updated', function (data) {
+          verify.update(10, original, data);
+          done();
+        });
+
+        socket.emit('tasks::update', 10, original, {}, function () {});
+      });
+
+      it('.removed', function (done) {
+        var service = app.service('tasks');
+        var oldRemoved = service.removed;
+
+        service.removed = function(data, params, callback) {
+          assert.deepEqual(params, socketParams);
+
+          if(data.id === 23) {
+            // Only dispatch with given id
+            return callback(null, data);
+          }
+
+          callback(null, false);
+        };
+
+        socket.emit('tasks::remove', 1, {}, function() {});
+        socket.emit('tasks::remove', 23, {}, function() {});
+
+        socket.on('tasks removed', function (data) {
+          service.removed = oldRemoved;
+          assert.equal(data.id, 23);
+          done();
+        });
       });
     });
   });

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -254,7 +254,7 @@ describe('SocketIO provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.emit('todo::remove', 1, {}, function() {});
@@ -431,21 +431,16 @@ describe('SocketIO provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.emit('tasks::remove', 1, {}, function() {});
       socket.emit('tasks::remove', 23, {}, function() {});
 
-      var ready = false;
-
       socket.on('tasks removed', function (data) {
         service.removed = oldRemoved;
         assert.equal(data.id, 23);
-        if (ready) {
-          done();
-        }
-        ready = true;
+        done();
       });
     });
   });


### PR DESCRIPTION
After fixing setup() for dynamic services in the last PR (#110), the events mixin's setup() function was adding duplicate events.  This PR wraps `applyEvents` with an `if (!this._serviceEvents) { ... }` check to assure it isn't adding events twice.