### PR TITLE
Fix duplicate events setup

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -47,11 +47,11 @@ module.exports = {
 
     // If already _setup, just add this single service.
     if (this._setup) {
+      protoService.setup(this, location);
       // If we're using a socket provider, register the service on it.
       if (this.addService) {
         this.addService(protoService, location);
       }
-      protoService.setup(this, location);
     }
 
     this.services[location] = protoService;

--- a/lib/providers/socket/commons.js
+++ b/lib/providers/socket/commons.js
@@ -18,7 +18,6 @@ exports.addService = function addService(service, path){
   }, this);
 
   // Setup events for the service.
-  eventsMixin.applyEvents.call(service);
   exports.setupEventHandlers.call(this, service, path);
 };
 

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -255,7 +255,7 @@ describe('Primus provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.send('todo::remove', 1, {}, function() {});
@@ -432,21 +432,16 @@ describe('Primus provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.send('tasks::remove', 1, {}, function() {});
       socket.send('tasks::remove', 23, {}, function() {});
 
-      var ready = false;
-
       socket.on('tasks removed', function (data) {
         service.removed = oldRemoved;
         assert.equal(data.id, 23);
-        if (ready) {
-          done();
-        }
-        ready = true;
+        done();
       });
     });
   });

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -254,7 +254,7 @@ describe('SocketIO provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.emit('todo::remove', 1, {}, function() {});
@@ -431,21 +431,16 @@ describe('SocketIO provider', function () {
           return callback(null, data);
         }
 
-        callback();
+        callback(null, false);
       };
 
       socket.emit('tasks::remove', 1, {}, function() {});
       socket.emit('tasks::remove', 23, {}, function() {});
 
-      var ready = false;
-
       socket.on('tasks removed', function (data) {
         service.removed = oldRemoved;
         assert.equal(data.id, 23);
-        if (ready) {
-          done();
-        }
-        ready = true;
+        done();
       });
     });
   });


### PR DESCRIPTION
This fixes duplicate events by removing applyEvents in commons.js and moving service.setup() before addService().