### PR TITLE
Always run stripSlashes() in use().

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -22,17 +22,17 @@ module.exports = {
     });
   },
 
-  service: function(location, service, options) {
-    location = stripSlashes(location);
+  service: function(path, service, options) {
+    path = stripSlashes(path);
 
     if(!service) {
-      return this.services[location];
+      return this.services[path];
     }
 
     var protoService = Proto.extend(service);
     var self = this;
 
-    debug('Registering new service at `' + location + '`');
+    debug('Registering new service at `' + path + '`');
 
     // Add all the mixins
     _.each(this.mixins, function (fn) {
@@ -40,27 +40,27 @@ module.exports = {
     });
 
     if(typeof protoService._setup === 'function') {
-      protoService._setup(this, location);
+      protoService._setup(this, path);
     }
 
     // Run the provider functions to register the service
     _.each(this.providers, function (provider) {
-      provider(location, protoService, options || {});
+      provider(path, protoService, options || {});
     });
 
     // If we ran setup already, set this service up explicitly
     if (this._isSetup) {
-      debug('Setting up service for `' + location + '`');
-      protoService.setup(this, location);
+      debug('Setting up service for `' + path + '`');
+      protoService.setup(this, path);
     }
 
-    this.services[location] = protoService;
+    this.services[path] = protoService;
     return protoService;
   },
 
   use: function () {
     var args = _.toArray(arguments);
-    var location = args.shift();
+    var path = args.shift();
     var service = args.pop();
     var hasMethod = function(methods) {
       return _.some(methods, function(name) {
@@ -73,7 +73,7 @@ module.exports = {
       return this._super.apply(this, arguments);
     }
 
-    this.service(stripSlashes(location), service, {
+    this.service(stripSlashes(path), service, {
       // Any arguments left over are other middleware that we want to pass to the providers
       middleware: args
     });

--- a/lib/application.js
+++ b/lib/application.js
@@ -73,7 +73,7 @@ module.exports = {
       return this._super.apply(this, arguments);
     }
 
-    this.service(location, service, {
+    this.service(stripSlashes(location), service, {
       // Any arguments left over are other middleware that we want to pass to the providers
       middleware: args
     });

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -26,7 +26,8 @@ describe('Feathers application', function () {
       }
     };
 
-    var app = feathers().use('/dummy/service/', dummyService);
+    var app = feathers().configure(feathers.socketio())
+      .use('/dummy/service/', dummyService);
 
     app.listen(8012, function(){
       app.use('/another/dummy/service/', dummyService);


### PR DESCRIPTION
This fixes #119.  Paths weren't being escaped inside the socket commons.js.  In `application.js`, Running `stripSlashes()` inside both `use()` and `service()` fixes the issue.  I thought it best to go here so the individual providers don't need to do it.