### PR TITLE
Tests for socket message validation and errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
+  - "node"
+  - "iojs"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "grunt"
+    "test": "grunt --stack"
   },
   "engines": {
     "node": ">= 0.10.0",
@@ -37,8 +37,8 @@
     "body-parser": "^1.0.2",
     "debug": "^2.1.1",
     "express": "^4.0.0",
-    "feathers-commons": "^0.1.0",
-    "feathers-errors": ">=0.2.0",
+    "feathers-commons": "^0.2.0",
+    "feathers-errors": "^0.2.5",
     "lodash": "^3.1.0",
     "primus": "^2.4.0",
     "primus-emitter": "^3.0.2",

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -93,8 +93,15 @@ describe('Primus provider', function () {
   });
 
   describe('Services', function() {
+    it('invalid arguments cause an error', function (done) {
+      socket.send('todo::find', 1, {}, function(error) {
+        assert.equal(error.message, 'Too many arguments for \'find\' service method');
+        done();
+      });
+    });
 
     describe('CRUD', function () {
+
       it('::find', function (done) {
         socket.send('todo::find', {}, function (error, data) {
           verify.find(data);
@@ -120,6 +127,20 @@ describe('Primus provider', function () {
           verify.create(original, data);
 
           done(error);
+        });
+      });
+
+      it('::create without parameters and callback', function (done) {
+        var original = {
+          name: 'creating'
+        };
+
+        socket.send('todo::create', original);
+
+        socket.once('todo created', function(data) {
+          verify.create(original, data);
+
+          done();
         });
       });
 

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -92,6 +92,13 @@ describe('SocketIO provider', function () {
   });
 
   describe('Services', function() {
+    it('invalid arguments cause an error', function (done) {
+      socket.emit('todo::find', 1, {}, function(error) {
+        assert.equal(error.message, 'Too many arguments for \'find\' service method');
+        done();
+      });
+    });
+
     describe('CRUD', function () {
       it('::find', function (done) {
         socket.emit('todo::find', {}, function (error, data) {
@@ -118,6 +125,20 @@ describe('SocketIO provider', function () {
           verify.create(original, data);
 
           done(error);
+        });
+      });
+
+      it('::create without parameters and callback', function (done) {
+        var original = {
+          name: 'creating'
+        };
+
+        socket.emit('todo::create', original);
+
+        socket.once('todo created', function(data) {
+          verify.create(original, data);
+
+          done();
         });
       });
 


### PR DESCRIPTION
This pull request adds tests for the latest [feathers-commons](https://github.com/feathersjs/feathers-commons) functionality which allows Socket message validation and to omit parameters and calls back with an error when wrong arguments are submitted. Closes #96 and closes #113. /cc @marshallswain