### PR TITLE
Run Socket configurations before service setup (#131)

### DIFF
--- a/lib/providers/socket/primus.js
+++ b/lib/providers/socket/primus.js
@@ -17,15 +17,22 @@ module.exports = function(config, configurer) {
       service: commons.service,
 
       setup: function(server) {
-        var result = this._super.apply(this, arguments);
-
         if (this.disabled('feathers primus')) {
-          return result;
+          return this._super.apply(this, arguments);
         }
 
         debug('Setting up Primus');
 
         var primus = this.primus = new Primus(server, config);
+
+        primus.use('emitter', Emitter);
+
+        if (typeof configurer === 'function') {
+          debug('Calling Primus configuration function');
+          configurer.call(this, primus);
+        }
+
+        var result = this._super.apply(this, arguments);
 
         commons.setup.call(this, {
           method: 'send',
@@ -39,13 +46,6 @@ module.exports = function(config, configurer) {
             return spark.request.feathers;
           }
         });
-
-        primus.use('emitter', Emitter);
-
-        if (typeof configurer === 'function') {
-          debug('Calling Primus configuration function');
-          configurer.call(this, primus);
-        }
 
         return result;
       }

--- a/lib/providers/socket/socketio.js
+++ b/lib/providers/socket/socketio.js
@@ -16,13 +16,18 @@ module.exports = function (config) {
       service: commons.service,
 
       setup: function (server) {
-        var result = this._super.apply(this, arguments);
-
         if (this.disabled('feathers socketio')) {
-          return result;
+          return this._super.apply(this, arguments);
         }
 
         var io = this.io = socketio.listen(server);
+
+        if (typeof config === 'function') {
+          debug('Calling SocketIO configuration function');
+          config.call(this, io);
+        }
+
+        var result = this._super.apply(this, arguments);
 
         debug('Setting up SocketIO');
 
@@ -38,11 +43,6 @@ module.exports = function (config) {
             return socket.feathers;
           }
         });
-
-        if (typeof config === 'function') {
-          debug('Calling SocketIO configuration function');
-          config.call(this, io);
-        }
 
         return result;
       }

--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -39,6 +39,31 @@ describe('Primus provider', function () {
     server.close(done);
   });
 
+  it('runs primus before setup (#131)', function(done) {
+    var counter = 0;
+    var app = feathers()
+      .configure(feathers.primus({
+        transformer: 'websockets'
+      }, function() {
+        assert.equal(counter, 0);
+        counter++;
+      }))
+      .use('/todos', {
+        find: function(params, callback) {
+          callback(null, []);
+        },
+        setup: function(app) {
+          assert.ok(app.primus);
+          assert.equal(counter, 1, 'SocketIO configuration ran first');
+        }
+      });
+
+    var srv = app.listen(9119);
+    srv.on('listening', function() {
+      srv.close(done);
+    });
+  });
+
   it('Passes handshake as service parameters.', function(done) {
     var service = app.service('todo');
     var old = {

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -38,6 +38,29 @@ describe('SocketIO provider', function () {
     server.close(done);
   });
 
+  it('runs io before setup (#131)', function(done) {
+    var counter = 0;
+    var app = feathers()
+      .configure(feathers.socketio(function() {
+        assert.equal(counter, 0);
+        counter++;
+      }))
+      .use('/todos', {
+        find: function(params, callback) {
+          callback(null, []);
+        },
+        setup: function(app) {
+          assert.ok(app.io);
+          assert.equal(counter, 1, 'SocketIO configuration ran first');
+        }
+      });
+
+    var srv = app.listen(8887);
+    srv.on('listening', function() {
+      srv.close(done);
+    });
+  });
+
   it('passes handshake as service parameters', function(done) {
     var service = app.service('todo');
     var old = {


### PR DESCRIPTION
This pull request makes sure that the SocketIO and Primus configuration callbacks are called *before* the services `.setup` is called so that you can access `app.io` and `app.primus`. Closes #131 