### PR TITLE
Allow to register remote services

### DIFF
--- a/lib/mixins/event.js
+++ b/lib/mixins/event.js
@@ -29,7 +29,9 @@ var EventMixin = {
     });
 
     _.each(eventMappings, function (event, method) {
-      if (typeof self[method] === 'function') {
+      var alreadyEmits = self._serviceEvents.indexOf(event) !== -1;
+
+      if (typeof self[method] === 'function' && !alreadyEmits) {
         // The Rubberduck event name (e.g. afterCreate, afterUpdate or afterDestroy)
         var eventName = 'after' + method.charAt(0).toUpperCase() + method.substring(1);
         self._serviceEvents.push(event);
@@ -50,10 +52,15 @@ var EventMixin = {
   }
 };
 
-_.extend(EventMixin, EventEmitter.prototype);
-
 module.exports = function (service) {
+  var isEmitter = typeof service.on === 'function' &&
+    typeof service.emit === 'function';
+
   if (typeof service.mixin === 'function') {
+    if(!isEmitter) {
+      service.mixin(EventEmitter.prototype);
+    }
+
     service.mixin(EventMixin);
   }
 };

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "uberproto": "^1.1.0"
   },
   "devDependencies": {
+    "feathers-client": "^0.1.1",
     "jshint": "^2.6.3",
     "mocha": "^2.2.0",
     "q": "^1.0.1",

--- a/test/distributed.test.js
+++ b/test/distributed.test.js
@@ -1,0 +1,41 @@
+var assert = require('assert');
+var client = require('feathers-client');
+var io = require('socket.io-client');
+var feathers = require('../lib/feathers');
+
+describe('Distributed Feathers applications test', function () {
+  before(function(done) {
+    var app = feathers()
+      .configure(feathers.socketio())
+      .use('todos', {
+        create: function(data, params, callback) {
+          data.id = 42;
+          callback(null, data);
+        }
+      });
+
+    app.listen(8888, done);
+  });
+
+  it('passes created event between servers', function (done) {
+    var socket = io('http://localhost:8888');
+    var remoteApp = client().configure(client.socketio(socket));
+    var todo = { text: 'Created on alpha server', complete: false };
+    var beta = feathers()
+      .configure(feathers.rest())
+      .use('todos', remoteApp.service('todos'));
+
+    beta.listen(9999, function() {
+      beta.service('todos').on('created', function(newTodo) {
+        assert.deepEqual(newTodo, {
+          id: 42,
+          text: 'Created on alpha server',
+          complete: false
+        });
+        done();
+      });
+
+      socket.emit('todos::create', todo);
+    });
+  });
+});


### PR DESCRIPTION
This pull request allows to register services that are already event emitters. Works great with [feathers-client](https://github.com/feathersjs/feathers-client/) which makes it possible to use remote services from other servers.

Closes #118 