### PR TITLE
Handle advanced rest routes for collection in resource

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -12,7 +12,9 @@ var mixins = require('./mixins');
 module.exports = {
   init: function () {
     _.extend(this, {
-      methods: ['find', 'get', 'create', 'update', 'patch', 'remove'],
+      methods: ['find', 'get', 'create', 'update', 'patch',
+        'remove', 'findInCollection', 'addToCollection',
+        'getInCollection', 'removeFromCollection'],
       mixins: mixins(),
       services: {},
       providers: [],

--- a/lib/mixins/event.js
+++ b/lib/mixins/event.js
@@ -7,8 +7,11 @@ var eventMappings = {
   create: 'created',
   update: 'updated',
   remove: 'removed',
-  patch: 'patched'
+  patch: 'patched',
+  addToCollection: 'updated',
+  removeFromCollection: 'updated'
 };
+var debug = require('debug')('feathers:event');
 
 /**
  * An event mixin that emits events after a service method calls its callback.
@@ -31,15 +34,23 @@ var EventMixin = {
     _.each(eventMappings, function (event, method) {
       var alreadyEmits = self._serviceEvents.indexOf(event) !== -1;
 
-      if (typeof self[method] === 'function' && !alreadyEmits) {
+      // dont'check already emits because new collection methods
+      // (addToCollection and removeFromCollection) also emits an 'update' event
+      if (typeof self[method] === 'function') {
         // The Rubberduck event name (e.g. afterCreate, afterUpdate or afterDestroy)
         var eventName = 'after' + method.charAt(0).toUpperCase() + method.substring(1);
+
+        debug('event propagate:' + eventName);
+
         self._serviceEvents.push(event);
         // Punch the given method
         emitter.punch(method, -1);
         // Pass the event and error event through
         emitter.on(eventName, function (results) {
           if (!results[0]) { // callback without error
+
+            debug('Emit:' + eventName);
+
             self.emit(event, results[1]);
           } else {
             self.emit('serviceError', results[0]);

--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -45,16 +45,16 @@ module.exports = function (config) {
 
       debug('Adding REST provider for service `' + path + '` at base route `' + uri + '`');
 
-      // GET / -> service.find(cb, params)
+      // GET / -> service.find(params, cb)
       baseRoute.get.apply(baseRoute, middleware.concat(app.rest.find(service)));
-      // POST -> service.create(data, params, cb)
+      // POST / -> service.create(data, params, cb)
       baseRoute.post.apply(baseRoute, middleware.concat(app.rest.create(service)));
 
       // GET /:id -> service.get(id, params, cb)
       idRoute.get.apply(idRoute, middleware.concat(app.rest.get(service)));
       // PUT /:id -> service.update(id, data, params, cb)
       idRoute.put.apply(idRoute, middleware.concat(app.rest.update(service)));
-      // PATCH /:id -> service.patch(id, data, params, callback)
+      // PATCH /:id -> service.patch(id, data, params, cb)
       idRoute.patch.apply(idRoute, middleware.concat(app.rest.patch(service)));
       // DELETE /:id -> service.remove(id, params, cb)
       idRoute.delete.apply(idRoute, middleware.concat(app.rest.remove(service)));

--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -61,6 +61,20 @@ module.exports = function (config) {
       // DELETE /:id -> service.remove(id, params, cb)
       idRoute.delete.apply(idRoute, middleware.concat(app.rest.remove(service)));
 
+      // GET /:id/:collection -> service.findInCollection(id, collection, params, cb)
+      collectionRoute.get.apply(collectionRoute,
+        middleware.concat(app.rest.findInCollection(service)));
+      // POST /:id/:collection -> service.addToCollection(id, collection, params, cb)
+      collectionItemRoute.post.apply(collectionItemRoute,
+        middleware.concat(app.rest.addToCollection(service)));
+
+      // GET /:id/:collection/:itemId -> service.getInCollection(id, collection, itemId, params, cb)
+      collectionItemRoute.get.apply(collectionItemRoute,
+        middleware.concat(app.rest.getInCollection(service)));
+      // DELETE /:id/:collection/:itemId -> service.getInCollection(id, collection, itemId, params, cb)
+      collectionItemRoute.delete.apply(collectionItemRoute,
+        middleware.concat(app.rest.removeFromCollection(service)));
+
       app.use(uri, handler);
     });
   };

--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -64,8 +64,8 @@ module.exports = function (config) {
       // GET /:id/:collection -> service.findInCollection(id, collection, params, cb)
       collectionRoute.get.apply(collectionRoute,
         middleware.concat(app.rest.findInCollection(service)));
-      // POST /:id/:collection -> service.addToCollection(id, collection, params, cb)
-      collectionItemRoute.post.apply(collectionItemRoute,
+      // POST /:id/:collection -> service.addToCollection(id, collection, data, params, cb)
+      collectionRoute.post.apply(collectionRoute,
         middleware.concat(app.rest.addToCollection(service)));
 
       // GET /:id/:collection/:documentId -> service.getInCollection(id, collection, documentId, params, cb)

--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -71,7 +71,7 @@ module.exports = function (config) {
       // GET /:id/:collection/:documentId -> service.getInCollection(id, collection, documentId, params, cb)
       collectionItemRoute.get.apply(collectionItemRoute,
         middleware.concat(app.rest.getInCollection(service)));
-      // DELETE /:id/:collection/:documentId -> service.getInCollection(id, collection, documentId, params, cb)
+      // DELETE /:id/:collection/:documentId -> service.removeFromCollection(id, collection, documentId, params, cb)
       collectionItemRoute.delete.apply(collectionItemRoute,
         middleware.concat(app.rest.removeFromCollection(service)));
 

--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -42,6 +42,8 @@ module.exports = function (config) {
       var uri = path.indexOf('/') === 0 ? path : '/' + path;
       var baseRoute = app.route(uri);
       var idRoute = app.route(uri + '/:id');
+      var collectionRoute = app.route(uri + '/:id/:collection');
+      var collectionItemRoute = app.route(uri + '/:id/:collection/:itemId');
 
       debug('Adding REST provider for service `' + path + '` at base route `' + uri + '`');
 

--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
       var baseRoute = app.route(uri);
       var idRoute = app.route(uri + '/:id');
       var collectionRoute = app.route(uri + '/:id/:collection');
-      var collectionItemRoute = app.route(uri + '/:id/:collection/:itemId');
+      var collectionItemRoute = app.route(uri + '/:id/:collection/:documentId');
 
       debug('Adding REST provider for service `' + path + '` at base route `' + uri + '`');
 
@@ -68,10 +68,10 @@ module.exports = function (config) {
       collectionItemRoute.post.apply(collectionItemRoute,
         middleware.concat(app.rest.addToCollection(service)));
 
-      // GET /:id/:collection/:itemId -> service.getInCollection(id, collection, itemId, params, cb)
+      // GET /:id/:collection/:documentId -> service.getInCollection(id, collection, documentId, params, cb)
       collectionItemRoute.get.apply(collectionItemRoute,
         middleware.concat(app.rest.getInCollection(service)));
-      // DELETE /:id/:collection/:itemId -> service.getInCollection(id, collection, itemId, params, cb)
+      // DELETE /:id/:collection/:documentId -> service.getInCollection(id, collection, documentId, params, cb)
       collectionItemRoute.delete.apply(collectionItemRoute,
         middleware.concat(app.rest.removeFromCollection(service)));
 

--- a/lib/providers/rest/wrappers.js
+++ b/lib/providers/rest/wrappers.js
@@ -74,7 +74,13 @@ function reqNoneInCollection (req) {
   return [ req.params.id, req.params.collection ];
 }
 
-// Returns the leading parameters for a `get`, `post`, `delete` request
+// Returns the leading parameters for a `post` request on a collection
+// of the resource (id, collection, data)
+function reqCreateInCollection (req) {
+  return [ req.params.id, req.params.collection, req.body ];
+}
+
+// Returns the leading parameters for a `get` or `delete` request
 // on a collection item of the resource (id, collection, itemId)
 function reqIdInCollection (req) {
   return [ req.params.id, req.params.collection, req.params.itemId ];
@@ -91,7 +97,7 @@ module.exports = {
   patch: getHandler.bind(null, 'patch', reqUpdate),
   remove: getHandler.bind(null, 'remove', reqId),
   findInCollection: getHandler.bind(null, 'findInCollection', reqNoneInCollection),
-  addToCollection: getHandler.bind(null, 'addToCollection', reqNoneInCollection),
+  addToCollection: getHandler.bind(null, 'addToCollection', reqCreateInCollection),
   getInCollection: getHandler.bind(null, 'getInCollection', reqIdInCollection),
   removeFromCollection: getHandler.bind(null, 'removeFromCollection', reqIdInCollection)
 };

--- a/lib/providers/rest/wrappers.js
+++ b/lib/providers/rest/wrappers.js
@@ -44,7 +44,13 @@ function getHandler (method, getArgs, service) {
     };
 
     debug('REST handler calling `' + method + '` from `' + req.url + '`');
-    service[method].apply(service, args.concat([ params, callback ]));
+
+    try {
+      service[method].apply(service, args.concat([params, callback]));
+    } catch (error) {
+      error.code = 422;
+      callback(error);
+    }
   };
 }
 

--- a/lib/providers/rest/wrappers.js
+++ b/lib/providers/rest/wrappers.js
@@ -89,5 +89,9 @@ module.exports = {
   create: getHandler.bind(null, 'create', reqCreate),
   update: getHandler.bind(null, 'update', reqUpdate),
   patch: getHandler.bind(null, 'patch', reqUpdate),
-  remove: getHandler.bind(null, 'remove', reqId)
+  remove: getHandler.bind(null, 'remove', reqId),
+  findInCollection: getHandler.bind(null, 'findInCollection', reqNoneInCollection),
+  addToCollection: getHandler.bind(null, 'addToCollection', reqNoneInCollection),
+  getInCollection: getHandler.bind(null, 'getInCollection', reqIdInCollection),
+  removeFromCollection: getHandler.bind(null, 'removeFromCollection', reqIdInCollection)
 };

--- a/lib/providers/rest/wrappers.js
+++ b/lib/providers/rest/wrappers.js
@@ -68,6 +68,18 @@ function reqCreate (req) {
   return [ req.body ];
 }
 
+// Returns the leading parameters for a `get` request on a collection
+// of the resource (id, collection)
+function reqNoneInCollection (req) {
+  return [ req.params.id, req.params.collection ];
+}
+
+// Returns the leading parameters for a `get`, `post`, `delete` request
+// on a collection item of the resource (id, collection, itemId)
+function reqIdInCollection (req) {
+  return [ req.params.id, req.params.collection, req.params.itemId ];
+}
+
 // Returns wrapped middleware for a service method.
 // Doing some fancy ES 5 .bind argument currying for .getHandler()
 // Basically what you are getting for each is a function(service) {}

--- a/lib/providers/rest/wrappers.js
+++ b/lib/providers/rest/wrappers.js
@@ -81,9 +81,9 @@ function reqAddToCollection (req) {
 }
 
 // Returns the leading parameters for a `get` or `delete` request
-// on a collection item of the resource (id, collection, itemId)
+// on a collection item of the resource (id, collection, documentId)
 function reqIdInCollection (req) {
-  return [ req.params.id, req.params.collection, req.params.itemId ];
+  return [ req.params.id, req.params.collection, req.params.documentId ];
 }
 
 // Returns wrapped middleware for a service method.

--- a/lib/providers/rest/wrappers.js
+++ b/lib/providers/rest/wrappers.js
@@ -76,7 +76,7 @@ function reqNoneInCollection (req) {
 
 // Returns the leading parameters for a `post` request on a collection
 // of the resource (id, collection, data)
-function reqCreateInCollection (req) {
+function reqAddToCollection (req) {
   return [ req.params.id, req.params.collection, req.body ];
 }
 
@@ -97,7 +97,7 @@ module.exports = {
   patch: getHandler.bind(null, 'patch', reqUpdate),
   remove: getHandler.bind(null, 'remove', reqId),
   findInCollection: getHandler.bind(null, 'findInCollection', reqNoneInCollection),
-  addToCollection: getHandler.bind(null, 'addToCollection', reqCreateInCollection),
+  addToCollection: getHandler.bind(null, 'addToCollection', reqAddToCollection),
   getInCollection: getHandler.bind(null, 'getInCollection', reqIdInCollection),
   removeFromCollection: getHandler.bind(null, 'removeFromCollection', reqIdInCollection)
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "express": "^4.12.3",
-    "feathers-commons": "^0.2.0",
+    "feathers-commons": "ebourmalo/feathers-commons",
     "feathers-errors": "^0.2.5",
     "lodash": "^3.1.0",
     "primus": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feathers",
   "description": "Build Better APIs, Faster than Ever.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "http://feathersjs.com",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "express": "^4.12.3",
-    "feathers-commons": "ebourmalo/feathers-commons",
+    "feathers-commons": "ebourmalo/feathers-commons#feat-advanced-routes",
     "feathers-errors": "^0.2.5",
     "lodash": "^3.1.0",
     "primus": "^3.0.2",

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -113,6 +113,17 @@ describe('REST provider', function () {
           done(error);
         });
       });
+
+      it('GET .findInCollection', function (done) {
+        request('http://localhost:4777/todo/1/tasks', function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.findInCollection(1, JSON.parse(body));
+          done(error);
+        });
+      });
+
+
+
     });
 
     describe('Dynamic Services', function() {

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -115,15 +115,31 @@ describe('REST provider', function () {
       });
 
       it('GET .findInCollection', function (done) {
-        request('http://localhost:4777/todo/1/tasks', function (error, response, body) {
+        request('http://localhost:4777/todo/1/subtasks', function (error, response, body) {
           assert.ok(response.statusCode === 200, 'Got OK status code');
           verify.findInCollection(1, JSON.parse(body));
           done(error);
         });
       });
 
+      it('POST .addToCollection', function (done) {
+        var documentToAdd = {
+          id: 2
+        };
 
-
+        request({
+          url: 'http://localhost:4777/todo/1/subtasks',
+          method: 'post',
+          body: JSON.stringify(documentToAdd),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.addToCollection(1, JSON.parse(body));
+          done(error);
+        });
+      });
     });
 
     describe('Dynamic Services', function() {

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -115,20 +115,23 @@ describe('REST provider', function () {
       });
 
       it('GET .findInCollection', function (done) {
-        request('http://localhost:4777/todo/1/subtasks', function (error, response, body) {
+        var collection = 'subtasks';
+
+        request('http://localhost:4777/todo/1/' + collection, function (error, response, body) {
           assert.ok(response.statusCode === 200, 'Got OK status code');
-          verify.findInCollection(1, JSON.parse(body));
+          verify.findInCollection(1, collection, JSON.parse(body));
           done(error);
         });
       });
 
       it('POST .addToCollection', function (done) {
+        var collection = 'subtasks';
         var documentToAdd = {
           id: 2
         };
 
         request({
-          url: 'http://localhost:4777/todo/1/subtasks',
+          url: 'http://localhost:4777/todo/1/' + collection,
           method: 'post',
           body: JSON.stringify(documentToAdd),
           headers: {
@@ -136,7 +139,34 @@ describe('REST provider', function () {
           }
         }, function (error, response, body) {
           assert.ok(response.statusCode === 200, 'Got OK status code');
-          verify.addToCollection(1, JSON.parse(body));
+          verify.addToCollection(1, collection, JSON.parse(body));
+          done(error);
+        });
+      });
+
+      it('GET .getInCollection', function (done) {
+        var collection = 'subtasks';
+        var documentId = 1;
+        var url = 'http://localhost:4777/todo/1/' + collection + '/' + documentId;
+
+        request(url, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.getInCollection(1, collection, documentId, JSON.parse(body));
+          done(error);
+        });
+      });
+
+      it('DELETE .removeFromCollection', function (done) {
+        var collection = 'subtasks';
+        var documentId = 333;
+        var url = 'http://localhost:4777/todo/1/' + collection + '/' + documentId;
+
+        request({
+          url: url,
+          method: 'delete'
+        }, function (error, response, body) {
+          assert.ok(response.statusCode === 200, 'Got OK status code');
+          verify.removeFromCollection(documentId, JSON.parse(body));
           done(error);
         });
       });

--- a/test/providers/service-fixture.js
+++ b/test/providers/service-fixture.js
@@ -5,10 +5,24 @@ var assert = require('assert');
 
 var findAllData = [{
   id: 0,
-  description: 'You have to do something'
+  description: 'You have to do something',
+  tasks: [{
+    id: 0,
+    description: 'play a video game'
+  }, {
+    id: 1,
+    description: 'watch a movie'
+  }]
 }, {
   id: 1,
-  description: 'You have to do laundry'
+  description: 'You have to do laundry',
+  tasks: [{
+    id: 0,
+    description: 'the blue jean'
+  }, {
+    id: 1,
+    description: 'the red shirt'
+  }]
 }];
 
 exports.Service = {
@@ -50,7 +64,33 @@ exports.Service = {
     callback(null, {
       id: id
     });
+  },
+
+  findInCollection: function(id, collection, params, callback) {
+    var collectionData = findAllData[id].tasks;
+    callback(null, collectionData);
+  },
+
+  // POST /resource/:id/:collection/:itemId
+  addToCollection: function(id, collection, params, callback) {
+
+
+    var result = _.clone(data);
+    result.id = 42;
+    result.status = 'created';
+    callback(null, result);
+
   }
+  //
+  //// GET /resource/:id/:collection/:itemId
+  //getInCollection: function(id, collection, itemId, params, callback) {
+  //
+  //},
+  //
+  //// DELETE /resource/:id/:collection/:itemId
+  //removeFromCollection: function(id, collection, itemId, params, callback) {
+  //
+  //}
 };
 
 exports.verify = {
@@ -91,5 +131,25 @@ exports.verify = {
     assert.deepEqual({
       id: id
     }, data, '.remove called');
-  }
+  },
+
+  findInCollection: function(id, currentData) {
+    var expectedData = findAllData[id].tasks;
+    assert.deepEqual(expectedData, currentData, 'Data as expected');
+  },
+
+  // POST /resource/:id/:collection/:itemId
+  addToCollection: function(id, collection, params, callback) {
+
+  },
+  //
+  //// GET /resource/:id/:collection/:itemId
+  //getInCollection: function(id, collection, itemId, params, callback) {
+  //
+  //},
+  //
+  //// DELETE /resource/:id/:collection/:itemId
+  //removeFromCollection: function(id, collection, itemId, params, callback) {
+  //
+  //}
 };

--- a/test/providers/service-fixture.js
+++ b/test/providers/service-fixture.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 var findAllData = [{
   id: 0,
   description: 'You have to do something',
-  tasks: [{
+  subtasks: [{
     id: 0,
     description: 'play a video game'
   }, {
@@ -16,7 +16,7 @@ var findAllData = [{
 }, {
   id: 1,
   description: 'You have to do laundry',
-  tasks: [{
+  subtasks: [{
     id: 0,
     description: 'the blue jean'
   }, {
@@ -67,19 +67,15 @@ exports.Service = {
   },
 
   findInCollection: function(id, collection, params, callback) {
-    var collectionData = findAllData[id].tasks;
+    var collectionData = findAllData[id].subtasks;
     callback(null, collectionData);
   },
 
-  // POST /resource/:id/:collection/:documentId
-  addToCollection: function(id, collection, params, callback) {
-
-
-    var result = _.clone(data);
-    result.id = 42;
-    result.status = 'created';
-    callback(null, result);
-
+  addToCollection: function(id, collection, data, params, callback) {
+    var collectionData = findAllData[id][collection];
+    data.status = 'added';
+    collectionData.push(data);
+    callback(null, data);
   }
   //
   //// GET /resource/:id/:collection/:documentId
@@ -134,13 +130,13 @@ exports.verify = {
   },
 
   findInCollection: function(id, currentData) {
-    var expectedData = findAllData[id].tasks;
+    var expectedData = findAllData[id].subtasks;
     assert.deepEqual(expectedData, currentData, 'Data as expected');
   },
 
-  // POST /resource/:id/:collection/:documentId
-  addToCollection: function(id, collection, params, callback) {
-
+  addToCollection: function(id, current) {
+    var expected = findAllData[id].subtasks[2];
+    assert.deepEqual(expected, current, 'Data ran through .addToCollection as expected');
   },
   //
   //// GET /resource/:id/:collection/:documentId

--- a/test/providers/service-fixture.js
+++ b/test/providers/service-fixture.js
@@ -71,7 +71,7 @@ exports.Service = {
     callback(null, collectionData);
   },
 
-  // POST /resource/:id/:collection/:itemId
+  // POST /resource/:id/:collection/:documentId
   addToCollection: function(id, collection, params, callback) {
 
 
@@ -82,13 +82,13 @@ exports.Service = {
 
   }
   //
-  //// GET /resource/:id/:collection/:itemId
-  //getInCollection: function(id, collection, itemId, params, callback) {
+  //// GET /resource/:id/:collection/:documentId
+  //getInCollection: function(id, collection, documentId, params, callback) {
   //
   //},
   //
-  //// DELETE /resource/:id/:collection/:itemId
-  //removeFromCollection: function(id, collection, itemId, params, callback) {
+  //// DELETE /resource/:id/:collection/:documentId
+  //removeFromCollection: function(id, collection, documentId, params, callback) {
   //
   //}
 };
@@ -138,18 +138,18 @@ exports.verify = {
     assert.deepEqual(expectedData, currentData, 'Data as expected');
   },
 
-  // POST /resource/:id/:collection/:itemId
+  // POST /resource/:id/:collection/:documentId
   addToCollection: function(id, collection, params, callback) {
 
   },
   //
-  //// GET /resource/:id/:collection/:itemId
-  //getInCollection: function(id, collection, itemId, params, callback) {
+  //// GET /resource/:id/:collection/:documentId
+  //getInCollection: function(id, collection, documentId, params, callback) {
   //
   //},
   //
-  //// DELETE /resource/:id/:collection/:itemId
-  //removeFromCollection: function(id, collection, itemId, params, callback) {
+  //// DELETE /resource/:id/:collection/:documentId
+  //removeFromCollection: function(id, collection, documentId, params, callback) {
   //
   //}
 };

--- a/test/providers/service-fixture.js
+++ b/test/providers/service-fixture.js
@@ -73,20 +73,25 @@ exports.Service = {
 
   addToCollection: function(id, collection, data, params, callback) {
     var collectionData = findAllData[id][collection];
-    data.status = 'added';
-    collectionData.push(data);
-    callback(null, data);
+    var result = _.clone(data);
+    result.status = 'added';
+    collectionData.push(result);
+    callback(null, result);
+  },
+
+  getInCollection: function(id, collection, documentId, params, callback) {
+    var result = findAllData[id][collection][documentId];
+    callback(null, result);
+  },
+
+  removeFromCollection: function(id, collection, documentId, params, callback) {
+    var removedDocument = {
+      id: documentId,
+      status: 'removed'
+    };
+
+    callback(null, removedDocument);
   }
-  //
-  //// GET /resource/:id/:collection/:documentId
-  //getInCollection: function(id, collection, documentId, params, callback) {
-  //
-  //},
-  //
-  //// DELETE /resource/:id/:collection/:documentId
-  //removeFromCollection: function(id, collection, documentId, params, callback) {
-  //
-  //}
 };
 
 exports.verify = {
@@ -129,23 +134,27 @@ exports.verify = {
     }, data, '.remove called');
   },
 
-  findInCollection: function(id, currentData) {
-    var expectedData = findAllData[id].subtasks;
-    assert.deepEqual(expectedData, currentData, 'Data as expected');
+  findInCollection: function(id, collection, current) {
+    var expectedData = findAllData[id][collection];
+    assert.deepEqual(expectedData, current, 'Data as expected');
   },
 
-  addToCollection: function(id, current) {
-    var expected = findAllData[id].subtasks[2];
+  addToCollection: function(id, collection, current) {
+    var expected = findAllData[id][collection].pop();
     assert.deepEqual(expected, current, 'Data ran through .addToCollection as expected');
   },
-  //
-  //// GET /resource/:id/:collection/:documentId
-  //getInCollection: function(id, collection, documentId, params, callback) {
-  //
-  //},
-  //
-  //// DELETE /resource/:id/:collection/:documentId
-  //removeFromCollection: function(id, collection, documentId, params, callback) {
-  //
-  //}
+
+  getInCollection: function(id, collection, documentId, current) {
+    var expected = findAllData[id][collection][documentId];
+    assert.deepEqual(expected, current, 'Data ran through .getInCollection as expected');
+  },
+
+  removeFromCollection: function(id, current) {
+    var expected = {
+      id: id,
+      status: 'removed'
+    };
+
+    assert.deepEqual(expected, current, '.removeFromCollection called');
+  }
 };


### PR DESCRIPTION
Handle new routes for updating a collection within a resource:

- Find an item within the collection:
[GET] /:id/:collection 
--> service.findInCollection(id, collection, params, cb)

- Get an item of the collection
[GET] /:id/:collection/:documentId 
--> service.getInCollection(id, collection, documentId, params, cb)

- Add an item to the collection
[POST] /:id/:collection 
--> service.addToCollection(id, collection, data, params, cb)

- Remove an item from the collection
[DELETE] /:id/:collection/:documentId 
--> service.removeFromCollection(id, collection, documentId, params, cb)

Linked with these PRs:
- feathers-commons: https://github.com/feathersjs/feathers-commons/pull/2
- feathers-hooks: https://github.com/feathersjs/feathers-hooks/pull/21