### PR TITLE
Fix 404 not being properly thrown by REST provider

### DIFF
--- a/lib/providers/rest/index.js
+++ b/lib/providers/rest/index.js
@@ -46,20 +46,18 @@ module.exports = function (config) {
       debug('Adding REST provider for service `' + path + '` at base route `' + uri + '`');
 
       // GET / -> service.find(cb, params)
-      baseRoute.get.apply(baseRoute, middleware.concat(app.rest.find(service)));
+      baseRoute.get.apply(baseRoute, middleware.concat(app.rest.find(service), handler));
       // POST -> service.create(data, params, cb)
-      baseRoute.post.apply(baseRoute, middleware.concat(app.rest.create(service)));
+      baseRoute.post.apply(baseRoute, middleware.concat(app.rest.create(service), handler));
 
       // GET /:id -> service.get(id, params, cb)
-      idRoute.get.apply(idRoute, middleware.concat(app.rest.get(service)));
+      idRoute.get.apply(idRoute, middleware.concat(app.rest.get(service), handler));
       // PUT /:id -> service.update(id, data, params, cb)
-      idRoute.put.apply(idRoute, middleware.concat(app.rest.update(service)));
+      idRoute.put.apply(idRoute, middleware.concat(app.rest.update(service), handler));
       // PATCH /:id -> service.patch(id, data, params, callback)
-      idRoute.patch.apply(idRoute, middleware.concat(app.rest.patch(service)));
+      idRoute.patch.apply(idRoute, middleware.concat(app.rest.patch(service), handler));
       // DELETE /:id -> service.remove(id, params, cb)
-      idRoute.delete.apply(idRoute, middleware.concat(app.rest.remove(service)));
-
-      app.use(uri, handler);
+      idRoute.delete.apply(idRoute, middleware.concat(app.rest.remove(service), handler));
     });
   };
 };

--- a/test/providers/rest.test.js
+++ b/test/providers/rest.test.js
@@ -263,6 +263,14 @@ describe('REST provider', function () {
       });
     });
 
+    it('throws a 404 for undefined route', function(done) {
+      request('http://localhost:4780/todo/foo/bar', function (error, response) {
+        assert.ok(response.statusCode === 404, 'Got Not Found code');
+
+        done(error);
+      });
+    });
+    
     it('empty response sets 204 status codes', function(done) {
       request('http://localhost:4780/todo', function (error, response) {
         assert.ok(response.statusCode === 204, 'Got empty status code');


### PR DESCRIPTION
The way the routes are created by the REST provider prevent 404 errors being properly thrown.
To reproduce, just run the feathers todo-list demo and browse to an URL like `/todos/foo/bar`, it won’t return a 404 as it should but a 200 without any content (because of the `app.use(uri, handler);` statement catching any URLs starting with `/todos`)