### PR TITLE
Make sure event hookups happens after method normalization

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -47,7 +47,7 @@ module.exports = {
     });
 
     // If we ran setup already, set this service up explicitly
-    if (this._isSetup) {
+    if (this._isSetup && typeof protoService.setup === 'function') {
       debug('Setting up service for `' + location + '`');
       protoService.setup(this, location);
     }

--- a/lib/mixins/event.js
+++ b/lib/mixins/event.js
@@ -11,60 +11,43 @@ var eventMappings = {
   patch: 'patched'
 };
 
-/**
- * An event mixin that emits events after a service method calls its callback.
- *
- * @type {{setup: Function}}
- */
-var EventMixin = {
-  setup: function () {
-    var emitter = this._rubberDuck = rubberduck.emitter(this);
-    var self = this;
-
-    self._serviceEvents = _.isArray(self.events) ? self.events.slice() : [];
-
-    // Pass the Rubberduck error event through
-    // TODO deal with error events properly
-    emitter.on('error', function (errors) {
-      self.emit('serviceError', errors[0]);
-    });
-
-    _.each(eventMappings, function (event, method) {
-      var alreadyEmits = self._serviceEvents.indexOf(event) !== -1;
-
-      if (typeof self[method] === 'function' && !alreadyEmits) {
-        // The Rubberduck event name (e.g. afterCreate, afterUpdate or afterDestroy)
-        var eventName = 'after' + method.charAt(0).toUpperCase() + method.substring(1);
-        self._serviceEvents.push(event);
-        // Punch the given method
-        emitter.punch(method, -1);
-        // Pass the event and error event through
-        emitter.on(eventName, function (results, args) {
-          if (!results[0]) { // callback without error
-            var hook = hookObject(method, 'after', args);
-            self.emit(event, results[1], hook);
-          } else {
-            self.emit('serviceError', results[0]);
-          }
-        });
-      }
-    });
-
-    return this._super ? this._super.apply(this, arguments) : this;
-  }
-};
-
 module.exports = function (service) {
   var isEmitter = typeof service.on === 'function' &&
     typeof service.emit === 'function';
+  var emitter = service._rubberDuck = rubberduck.emitter(service);
 
   if (typeof service.mixin === 'function') {
     if(!isEmitter) {
       service.mixin(EventEmitter.prototype);
     }
-
-    service.mixin(EventMixin);
   }
-};
 
-module.exports.Mixin = EventMixin;
+  service._serviceEvents = _.isArray(service.events) ? service.events.slice() : [];
+
+  // Pass the Rubberduck error event through
+  // TODO deal with error events properly
+  emitter.on('error', function (errors) {
+    service.emit('serviceError', errors[0]);
+  });
+
+  _.each(eventMappings, function (event, method) {
+    var alreadyEmits = service._serviceEvents.indexOf(event) !== -1;
+
+    if (typeof service[method] === 'function' && !alreadyEmits) {
+      // The Rubberduck event name (e.g. afterCreate, afterUpdate or afterDestroy)
+      var eventName = 'after' + method.charAt(0).toUpperCase() + method.substring(1);
+      service._serviceEvents.push(event);
+      // Punch the given method
+      emitter.punch(method, -1);
+      // Pass the event and error event through
+      emitter.on(eventName, function (results, args) {
+        if (!results[0]) { // callback without error
+          var hook = hookObject(method, 'after', args);
+          service.emit(event, results[1], hook);
+        } else {
+          service.emit('serviceError', results[0]);
+        }
+      });
+    }
+  });
+};

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -302,4 +302,24 @@ describe('Feathers application', function () {
     otherApp.mixins.push(function() {});
     assert.equal(otherApp.mixins.length, 4);
   });
+
+  it('Event punching happens after normalization (#150)', function (done) {
+    var todoService = {
+      create: function (data, params, callback) {
+        callback(null, data);
+      }
+    };
+
+    var app = feathers()
+      .configure(feathers.rest())
+      .use('/todo', todoService);
+
+    var server = app.listen(7001).on('listening', function () {
+      app.service('todo').create({
+        test: 'item'
+      });
+
+      server.close(done);
+    });
+  });
 });

--- a/test/mixins/event.test.js
+++ b/test/mixins/event.test.js
@@ -49,10 +49,9 @@ describe('Event mixin', function () {
       }
     });
 
-    mixinEvent(FixtureService);
-
     var instance = create.call(FixtureService);
-    instance.setup();
+
+    mixinEvent(instance);
 
     instance.on('serviceError', function (error) {
       assert.ok(error instanceof Error);
@@ -79,10 +78,9 @@ describe('Event mixin', function () {
       }
     });
 
-    mixinEvent(FixtureService);
-
     var instance = create.call(FixtureService);
-    instance.setup();
+
+    mixinEvent(instance);
 
     instance.on('created', function (data, args) {
       assert.equal(data.id, 10);
@@ -113,10 +111,9 @@ describe('Event mixin', function () {
       }
     });
 
-    mixinEvent(FixtureService);
-
     var instance = create.call(FixtureService);
-    instance.setup();
+
+    mixinEvent(instance);
 
     instance.on('updated', function (data, args) {
       assert.equal(data.id, 12);
@@ -147,10 +144,9 @@ describe('Event mixin', function () {
       }
     });
 
-    mixinEvent(FixtureService);
-
     var instance = create.call(FixtureService);
-    instance.setup();
+
+    mixinEvent(instance);
 
     instance.on('removed', function (data, args) {
       assert.equal(data.id, 27);
@@ -180,10 +176,10 @@ describe('Event mixin', function () {
     });
 
     FixtureService.mixin(EventEmitter.prototype);
-    mixinEvent(FixtureService);
 
     var instance = create.call(FixtureService);
-    instance.setup();
+
+    mixinEvent(instance);
 
     instance.on('created', function (data) {
       assert.deepEqual(data, { custom: 'event' });


### PR DESCRIPTION
This pull request makes sure that event punching happens after methods normalization. The issue before was that you couldn't call methods on the server without a callback (which isn't necessary).

Closes #150 