### PR TITLE
Adding tests to make sure that dispatcher context is set properly.

### DIFF
--- a/test/providers/primus.test.js
+++ b/test/providers/primus.test.js
@@ -259,6 +259,7 @@ describe('Primus provider', function () {
         var oldCreated = service.created;
 
         service.created = function(data, params, callback) {
+          assert.ok(service === this);
           assert.deepEqual(params, socketParams);
           verify.create(original, data);
 
@@ -276,6 +277,8 @@ describe('Primus provider', function () {
       });
 
       it('.updated', function (done) {
+        // TODO this is not testing the right thing
+        // but we will get better event filtering in v2 anyway
         var original = {
           name: 'updated event'
         };
@@ -293,6 +296,7 @@ describe('Primus provider', function () {
         var oldRemoved = service.removed;
 
         service.removed = function(data, params, callback) {
+          assert.ok(service === this);
           assert.deepEqual(params, socketParams);
 
           if(data.id === 23) {

--- a/test/providers/socketio.test.js
+++ b/test/providers/socketio.test.js
@@ -452,6 +452,7 @@ describe('SocketIO provider', function () {
         var oldCreated = service.created;
 
         service.created = function(data, params, callback) {
+          assert.ok(service === this);
           assert.deepEqual(params, socketParams);
           verify.create(original, data);
 
@@ -469,6 +470,8 @@ describe('SocketIO provider', function () {
       });
 
       it('.updated', function (done) {
+        // TODO this is not testing the right thing
+        // but we will get better event filtering in v2 anyway
         var original = {
           name: 'updated event'
         };
@@ -486,6 +489,7 @@ describe('SocketIO provider', function () {
         var oldRemoved = service.removed;
 
         service.removed = function(data, params, callback) {
+          assert.ok(service === this);
           assert.deepEqual(params, socketParams);
 
           if(data.id === 23) {


### PR DESCRIPTION
This pull requests makes sure that `feathers-commons` set the event filter context to the service (see https://github.com/feathersjs/feathers-commons/issues/5). No new release necessary since it should be pulled in automatically on new installations.