### PR TITLE
Remove Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "express": "^4.12.3",
     "feathers-commons": "^0.3.0",
     "feathers-errors": "^1.1.4",
-    "lodash": "^3.1.0",
     "rubberduck": "^1.0.0",
     "uberproto": "^1.2.0"
   },

--- a/src/application.js
+++ b/src/application.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import makeDebug from 'debug';
 import { stripSlashes } from 'feathers-commons';
 import Uberproto from 'uberproto';
@@ -12,7 +11,7 @@ const Proto = Uberproto.extend({
 
 export default {
   init() {
-    _.extend(this, {
+    Object.assign(this, {
       methods,
       mixins: mixins(),
       services: {},
@@ -54,7 +53,7 @@ export default {
   },
 
   use(location) {
-    let service, middleware = _(arguments)
+    let service, middleware = Array.from(arguments)
       .slice(1)
       .reduce(function (middleware, arg) {
         if (typeof arg === 'function') {
@@ -70,7 +69,7 @@ export default {
         after: []
       });
 
-    const hasMethod = methods => _.some(methods, name =>
+    const hasMethod = methods => methods.some(name =>
       (service && typeof service[name] === 'function'));
 
     // Check for service (any object with at least one service method)
@@ -86,7 +85,9 @@ export default {
 
   setup() {
     // Setup each service (pass the app so that they can look up other services etc.)
-    _.each(this.services, (service, path) => {
+    Object.keys(this.services).forEach(path => {
+      const service = this.services[path];
+
       debug(`Setting up service for \`${path}\``);
       if (typeof service.setup === 'function') {
         service.setup(this, path);
@@ -113,7 +114,7 @@ export default {
 
     this.setup(server);
     debug('Feathers application listening');
-    
+
     return server;
   }
 };

--- a/src/feathers.js
+++ b/src/feathers.js
@@ -1,6 +1,5 @@
 if(!global._babelPolyfill) { require('babel-polyfill'); }
 
-import _ from 'lodash';
 import express from 'express';
 import Proto from 'uberproto';
 import Application from './application';
@@ -22,4 +21,4 @@ export default function createApplication() {
 createApplication.version = require('../package.json').version;
 
 // Expose all express methods (like express.engine())
-_.defaults(createApplication, express);
+Object.assign(createApplication, express);

--- a/src/mixins/event.js
+++ b/src/mixins/event.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import rubberduck from 'rubberduck';
 import { EventEmitter } from 'events';
 import { hooks } from 'feathers-commons';
@@ -24,7 +23,7 @@ export default function(service) {
     service.mixin(EventEmitter.prototype);
   }
 
-  service._serviceEvents = _.isArray(service.events) ? service.events.slice() : [];
+  service._serviceEvents = Array.isArray(service.events) ? service.events.slice() : [];
 
   // Pass the Rubberduck error event through
   // TODO deal with error events properly
@@ -32,7 +31,8 @@ export default function(service) {
     service.emit('serviceError', errors[0]);
   });
 
-  _.each(eventMappings, (event, method) => {
+  Object.keys(eventMappings).forEach(method => {
+    const event = eventMappings[method];
     const alreadyEmits = service._serviceEvents.indexOf(event) !== -1;
 
     if (typeof service[method] === 'function' && !alreadyEmits) {

--- a/test/mixins/event.test.js
+++ b/test/mixins/event.test.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import _ from 'lodash';
 import Proto from 'uberproto';
 import { EventEmitter } from 'events';
 import mixinEvent from '../../lib/mixins/event';
@@ -89,7 +88,7 @@ describe('Event mixin', () => {
   it('updated', done => {
     const FixtureService = Proto.extend({
       update(id, data, params, cb) {
-        _.defer(function () {
+        setTimeout(function () {
           cb(null, {
             id: id,
             name: data.name
@@ -123,7 +122,7 @@ describe('Event mixin', () => {
   it('removed', done => {
     const FixtureService = Proto.extend({
       remove(id, params, cb) {
-        _.defer(function () {
+        setTimeout(function () {
           cb(null, {
             id: id
           });
@@ -157,9 +156,9 @@ describe('Event mixin', () => {
     ];
     const FixtureService = Proto.extend({
       create(data, params, cb) {
-        _.defer(function () {
+        setTimeout(function () {
           cb(null, fixture);
-        });
+        }, 20);
       }
     });
 
@@ -183,12 +182,12 @@ describe('Event mixin', () => {
     const FixtureService = Proto.extend({
       events: [ 'created' ],
       create(data, params, cb) {
-        _.defer(function () {
+        setTimeout(function () {
           cb(null, {
             id: 10,
             name: data.name
           });
-        });
+        }, 20);
       }
     });
 


### PR DESCRIPTION
Because ES6 is awesome we don't really need Lodash anymore (`feathers-commons` doesn't use it already). It also makes the client build a lot easier (and smaller).