### PR TITLE
Appending `nsp check` to test script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jshint": "jshint src/. test/. --config",
     "coverage": "istanbul cover _mocha -- test/ --recursive",
     "mocha": "mocha test/ --compilers js:babel-core/register --recursive",
-    "test": "npm run compile && npm run jshint && npm run mocha"
+    "test": "npm run compile && npm run jshint && npm run mocha && nsp check"
   },
   "engines": {
     "node": ">= 0.10.0",
@@ -65,6 +65,7 @@
     "istanbul": "^0.4.0",
     "jshint": "^2.6.3",
     "mocha": "^2.2.0",
+    "nsp": "^2.2.0",
     "q": "^1.0.1",
     "request": "^2.x",
     "socket.io-client": "^1.0.0"


### PR DESCRIPTION
This adds a Node Security Project scan to the end of the tests.