### PR TITLE
Fix mixing execution order by reversing it

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -38,7 +38,7 @@ export default {
     debug(`Registering new service at \`${location}\``);
 
     // Add all the mixins
-    this.mixins.forEach(fn => fn.call(this, protoService));
+    this.mixins.slice(0).reverse().forEach(fn => fn.call(this, protoService));
 
     if(typeof protoService._setup === 'function') {
       protoService._setup(this, location);
@@ -46,7 +46,8 @@ export default {
 
     // Run the provider functions to register the service
     this.providers.forEach(provider =>
-      provider.call(this, location, protoService, options));
+      provider.call(this, location, protoService, options)
+    );
 
     // If we ran setup already, set this service up explicitly
     if (this._isSetup && typeof protoService.setup === 'function') {
@@ -75,7 +76,8 @@ export default {
       });
 
     const hasMethod = methods => methods.some(name =>
-      (service && typeof service[name] === 'function'));
+      (service && typeof service[name] === 'function')
+    );
 
     // Check for service (any object with at least one service method)
     if(hasMethod(['handle', 'set']) || !hasMethod(this.methods)) {

--- a/src/feathers.js
+++ b/src/feathers.js
@@ -1,5 +1,6 @@
 import Proto from 'uberproto';
 import Application from './application';
+import { version } from '../package.json';
 
 /**
  * Create a Feathers application that extends Express.
@@ -10,5 +11,8 @@ import Application from './application';
 export default function createApplication(app) {
   Proto.mixin(Application, app);
   app.init();
+  app.VERSION = version;
   return app;
 }
+
+createApplication.version = version;

--- a/src/mixins/event.js
+++ b/src/mixins/event.js
@@ -14,7 +14,7 @@ function upperCase(name) {
   return name.charAt(0).toUpperCase() + name.substring(1);
 }
 
-export default function(service) {
+export default function eventMixin(service) {
   const isEmitter = typeof service.on === 'function' &&
     typeof service.emit === 'function';
   const emitter = service._rubberDuck = rubberduck.emitter(service);

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,16 +1,9 @@
 export default function() {
   const mixins = [
-    require('./promise'),
+    require('./normalizer'),
     require('./event'),
-    require('./normalizer')
+    require('./promise')
   ];
-
-  // Override push to make sure that normalize is always the last
-  mixins.push = function() {
-    const args = [ this.length - 1, 0].concat(Array.from(arguments));
-    this.splice.apply(this, args);
-    return this.length;
-  };
-
+  
   return mixins;
 }

--- a/src/mixins/normalizer.js
+++ b/src/mixins/normalizer.js
@@ -1,6 +1,6 @@
 import { getArguments } from 'feathers-commons';
 
-export default function (service) {
+export default function normalizerMixin(service) {
   if (typeof service.mixin === 'function') {
     const mixin = {};
 

--- a/src/mixins/promise.js
+++ b/src/mixins/promise.js
@@ -13,7 +13,7 @@ function wrapper() {
   return result;
 }
 
-export default function (service) {
+export default function promiseMixin(service) {
   if (typeof service.mixin === 'function') {
     const mixin = {};
 

--- a/test/mixins/normalizer.test.js
+++ b/test/mixins/normalizer.test.js
@@ -1,21 +1,8 @@
 import assert from 'assert';
 import Proto from 'uberproto';
 import normalizer from '../../src/mixins/normalizer';
-import mixins from '../../src/mixins';
 
 describe('Argument normalizer mixin', () => {
-  it('normalizer mixin is always the last to run', () => {
-    const arr = mixins();
-    const dummy = function() { };
-
-    assert.equal(arr.length, 3);
-
-    arr.push(dummy);
-
-    assert.equal(arr[arr.length - 1], normalizer, 'Last mixin is still the normalizer');
-    assert.equal(arr[arr.length - 2], dummy, 'Dummy got added before last');
-  });
-
   // The normalization is already tests in all variations in `getArguments`
   // so we just so we only test two random samples
 


### PR DESCRIPTION
Because of [Uberproto's](https://github.com/daffl/uberproto) mixin order, the last mixin gets always executed first which is why we had to had the normalized to always be on the end.

The correct fix is to reverse the mixin array when a service is registered so that they run in the expected order. This should also fix a bug with service event data that were being sent before hooks are executed.