### PR TITLE
Remove JSON loading from the client version

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -5,4 +5,4 @@ export default function createApplication(... args) {
   return feathers(express(... args));
 }
 
-createApplication.version = require('../../package.json').version;
+createApplication.version = '2.0.1';


### PR DESCRIPTION
Some loaders (like Webpack) can not require JSON by default so it is best to take out requiring the package to get the version. This will also make built versions a little smaller. The drawback is that we will have to update those versions manually (maybe remove them entirely in 3.0).