### PR TITLE
Fix pagination type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace feathers {
     total: Number,
     limit: Number,
     skip: Number,
-    data: T
+    data: T[]
   }
 
   interface Service<T> extends events.EventEmitter {


### PR DESCRIPTION
As specified in #520, 

> I've seems to have found an issue. Shouldn't the pagination interface be like
> ```
> interface Pagination <T> {
>    total: Number,
>    limit: Number,
>    skip: Number,
>    data: T[] // As in, with an array instead of a single object?
>}
```