### PR TITLE
Fix typescript defnition of Service. All the service methods should be

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,41 +26,41 @@ declare namespace feathers {
      * Retrieves a list of all resources from the service.
      * Provider parameters will be passed as params.query
      */
-    find(params?: Params, callback?: any): Promise<T[] | Pagination<T>>;
+    find?(params?: Params, callback?: any): Promise<T[] | Pagination<T>>;
 
     /**
      * Retrieves a single resource with the given id from the service.
      */
-    get(id: number | string, params?: Params, callback?: any): Promise<T>;
+    get?(id: number | string, params?: Params, callback?: any): Promise<T>;
 
     /**
      * Creates a new resource with data. 
      */
-    create(data: T | T[], params?: Params, callback?: any): Promise<T | T[]>;
+    create?(data: T | T[], params?: Params, callback?: any): Promise<T | T[]>;
 
     /**
      * Replaces the resource identified by id with data.
      * Update multiples resources with id equal `null` 
      */
-    update(id: NullableId, data: T, params?: Params, callback?: any): Promise<T>;
+    update?(id: NullableId, data: T, params?: Params, callback?: any): Promise<T>;
 
     /**
      * Merges the existing data of the resource identified by id with the new data.
      * Implement patch additionally to update if you want to separate between partial and full updates and support the PATCH HTTP method.
      * Patch multiples resources with id equal `null`
      */
-    patch(id: NullableId, data: any, params?: Params, callback?: any): Promise<T>;
+    patch?(id: NullableId, data: any, params?: Params, callback?: any): Promise<T>;
 
     /**
      * Removes the resource with id.
      * Delete multiple resources with id equal `null`
      */
-    remove(id: NullableId, params?: Params, callback?: any): Promise<T>;
+    remove?(id: NullableId, params?: Params, callback?: any): Promise<T>;
 
     /**
      * Initialize your service with any special configuration or if connecting services that are very tightly coupled 
      */
-    setup(app?: Application, path?: string): void;
+    setup?(app?: Application, path?: string): void;
   }
 
   interface FeathersUseHandler<T> extends expressCore.IRouterHandler<T>, express.IRouterMatcher<T> {


### PR DESCRIPTION
optional

### Summary

As per the [current type definition of Service ](https://github.com/feathersjs/feathers/blob/master/index.d.ts#L23), all the service methods are required methods. 

But according to documentation, service methods are optional . 
See 
![image](https://cloud.githubusercontent.com/assets/1652903/25846526/bc068e4e-34cf-11e7-976d-76f885f299e0.png)


So, service definition should be something like below
```typescript
  interface Service<T> extends events.EventEmitter {
    find?(params?: Params, callback?: any): Promise<T[] | Pagination<T>>;
    get?(id: number | string, params?: Params, callback?: any): Promise<T>;
    create?(data: T | T[], params?: Params, callback?: any): Promise<T | T[]>;
    update?(id: NullableId, data: T, params?: Params, callback?: any): Promise<T>;
    patch?(id: NullableId, data: any, params?: Params, callback?: any): Promise<T>;
    remove?(id: NullableId, params?: Params, callback?: any): Promise<T>;
    setup?(app?: Application, path?: string): void;
  }
```

I think, This pull request don't need any sort of test cases because it won't affect any other part of the application.

