### PR TITLE
Revert update to security links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ Each plugin has it's own minimal example in the repo. To see some more complex e
 
 ## Security
 
-We :heart: the community and take security very seriously. No one wants their app hacked. If you have come across a security concern please [report it responsibly](https://legacy.docs.feathersjs.com/SECURITY.html). Visit the [Security section](https://legacy.docs.feathersjs.com/SECURITY.html) of the docs to learn more about how you can make sure your app is secure.
+We :heart: the community and take security very seriously. No one wants their app hacked. If you have come across a security concern please [report it responsibly](https://docs.feathersjs.com/security#where-should-i-report-security-issues). Visit the [Security section](https://docs.feathersjs.com/SECURITY.html) of the docs to learn more about how you can make sure your app is secure.
 
 ## Long Term Support Schedule
 


### PR DESCRIPTION
### Summary
- [x] Tell us about the problem your pull request is solving.

The commit https://github.com/feathersjs/feathers/commit/60b1f330624a76846e6d6efa0ea6db295c260731 pointed some links in the readme to the legacy security docs, because the security page was down. 

The PR https://github.com/feathersjs/feathers-docs/pull/646 in the feathers-doc repo re-adds the security page.

This negates the point of the first commit, so this PR is to revert https://github.com/feathersjs/feathers/commit/60b1f330624a76846e6d6efa0ea6db295c260731, since it it is no longer necessary.

- [x] Are there any open issues that are related to this?

No

- [x] Is this PR dependent on PRs in other repos?

No, the PR in the feathers-docs repo has already been merged here https://github.com/feathersjs/feathers-docs/pull/646
