### PR TITLE
Allow flag to return the hook object

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -67,7 +67,9 @@ export function hookMixin (service) {
           });
         })
         // Make a copy of hookObject from `before` hooks and update type
-        .then(hookObject => Object.assign({}, hookObject, { type: 'after' }))
+        .then(hookObject =>
+          Object.assign({}, hookObject, { type: 'after' })
+        )
         // Run through all `after` hooks
         .then(hookObject => {
           const afterHooks = getHooks(app, service, 'after', method, true);
@@ -76,8 +78,10 @@ export function hookMixin (service) {
 
           return processHooks.call(service, hookChain, hookObject);
         })
-        // Finally, return the result
-        .then(hookObject => hookObject.result)
+        // Finally, return the result (or the hook object if a hidden flag is set)
+        .then(hookObject =>
+          hookObject.params.__returnHook ? hookObject : hookObject.result
+        )
         // Handle errors
         .catch(error => {
           const errorHooks = getHooks(app, service, 'error', method, true);

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -58,27 +58,6 @@ describe('Feathers application', () => {
     });
   });
 
-  it('providers are getting called with a service', () => {
-    const app = feathers();
-    let providerRan = false;
-
-    app.providers.push(function (service, location, options) {
-      assert.ok(service.dummy);
-      assert.equal(location, 'dummy');
-      assert.deepEqual(options, {});
-      providerRan = true;
-    });
-
-    app.use('/dummy', {
-      dummy: true,
-      get () {}
-    });
-
-    assert.ok(providerRan);
-
-    app.setup();
-  });
-
   describe('Services', () => {
     it('calling .use with a non service object throws', () => {
       const app = feathers();
@@ -283,6 +262,52 @@ describe('Feathers application', () => {
       });
 
       assert.ok(_setup);
+    });
+  });
+
+  describe('providers', () => {
+    it('are getting called with a service', () => {
+      const app = feathers();
+      let providerRan = false;
+
+      app.providers.push(function (service, location, options) {
+        assert.ok(service.dummy);
+        assert.equal(location, 'dummy');
+        assert.deepEqual(options, {});
+        providerRan = true;
+      });
+
+      app.use('/dummy', {
+        dummy: true,
+        get () {}
+      });
+
+      assert.ok(providerRan);
+
+      app.setup();
+    });
+
+    it('are getting called with a service and options', () => {
+      const app = feathers();
+      const opts = { test: true };
+
+      let providerRan = false;
+
+      app.providers.push(function (service, location, options) {
+        assert.ok(service.dummy);
+        assert.equal(location, 'dummy');
+        assert.deepEqual(options, opts);
+        providerRan = true;
+      });
+
+      app.use('/dummy', {
+        dummy: true,
+        get () {}
+      }, opts);
+
+      assert.ok(providerRan);
+
+      app.setup();
     });
   });
 });

--- a/test/hooks/hooks.test.js
+++ b/test/hooks/hooks.test.js
@@ -153,4 +153,25 @@ describe('hooks basics', () => {
       assert.equal(e.message, `Service method 'get' for 'dummy' service must return a promise`);
     });
   });
+
+  it('allows to return the hook object', () => {
+    const app = feathers().use('/dummy', {
+      get (id, params) {
+        return Promise.resolve({ id, params });
+      }
+    });
+    const params = {
+      __returnHook: true
+    };
+
+    return app.service('dummy').get(10, params).then(context => {
+      assert.equal(context.service, app.service('dummy'));
+      assert.equal(context.type, 'after');
+      assert.equal(context.path, 'dummy');
+      assert.deepEqual(context.result, {
+        id: 10,
+        params
+      });
+    });
+  });
 });


### PR DESCRIPTION
This will be used by the updated providers (primarily to retrieve `hook.dispatch` which will contain the "safe" data to send to a client). Allows to do something like:

```js
app.service('dummy').find({
  __returnHook: true
}).then(hook => {
  // hook is the actual hook object instead of just the result
});
```