### PR TITLE
Allows error hooks to swallow error by setting the result

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -92,13 +92,22 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
 
           const errorHookObject = Object.assign({}, error.hook || hookObject, {
             type: 'error',
+            result: null,
             original: error.hook,
             error
           });
 
           return processHooks
             .call(service, hookChain, errorHookObject)
-            .then(hook => Promise.reject(hook.error));
+            .then(hook => {
+              if (errorHookObject.params.__returnHook) {
+                return Promise.reject(hook);
+              } else if (hook.result) {
+                return Promise.resolve(hook.result);
+              }
+
+              return Promise.reject(hook.error);
+            });
         });
     };
   });

--- a/test/hooks/after.test.js
+++ b/test/hooks/after.test.js
@@ -185,7 +185,7 @@ describe('`after` hooks', () => {
       });
     });
 
-    it('does not run after hook when there is an error', done => {
+    it('does not run after hook when there is an error', () => {
       const dummyService = {
         remove () {
           return Promise.reject(new Error('Error removing item'));
@@ -203,10 +203,9 @@ describe('`after` hooks', () => {
         }
       });
 
-      service.remove(1, {}).catch(error => {
+      return service.remove(1, {}).catch(error => {
         assert.ok(error, 'Got error');
         assert.equal(error.message, 'Error removing item', 'Got error message from service');
-        done();
       });
     });
 


### PR DESCRIPTION
This allows error hooks to normally resolve by setting `hook.result` instead of always throwing the error.

Closes https://github.com/feathersjs/feathers-hooks/issues/151