### PR TITLE
[WIP] TypeScript: Add ability to define and retrieve properly typed services

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import * as express from 'express';
-import * as expressCore from "express-serve-static-core";
+import * as expressCore from 'express-serve-static-core';
 import * as events from 'events';
 
-declare function feathers(): feathers.Application;
+declare function feathers<ServiceListInterface = {}>(): feathers.Application<ServiceListInterface>;
 
 declare namespace feathers {
   export var static: typeof express.static;
@@ -15,69 +15,98 @@ declare namespace feathers {
   }
 
   interface Pagination <T> {
-    total: Number,
-    limit: Number,
-    skip: Number,
-    data: T[]
+    total: Number;
+    limit: Number;
+    skip: Number;
+    data: T[];
   }
 
-  interface Service<T> extends events.EventEmitter {
-
+  interface FindService<T> {
     /**
      * Retrieves a list of all resources from the service.
      * Provider parameters will be passed as params.query
      */
-    find?(params?: Params, callback?: any): Promise<T[] | Pagination<T>>;
+    find(params?: Params, callback?: any): Promise<T[] | Pagination<T>>;
+  }
 
+  interface GetService<T> {
     /**
      * Retrieves a single resource with the given id from the service.
      */
-    get?(id: number | string, params?: Params, callback?: any): Promise<T>;
+    get(id: number | string, params?: Params, callback?: any): Promise<T>;
+  }
 
+  interface CreateService<T> {
     /**
      * Creates a new resource with data.
      */
-    create?(data: T[], params?: Params, callback?: any): Promise<T[]>;
-    create?(data: T , params?: Params, callback?: any): Promise<T>;
-    
+    create(data: T[], params?: Params, callback?: any): Promise<T[]>;
+    create(data: T, params?: Params, callback?: any): Promise<T>;
+  }
+
+  interface UpdateService<T> {
     /**
      * Replaces the resource identified by id with data.
      * Update multiples resources with id equal `null`
      */
-    update?(id: NullableId, data: T, params?: Params, callback?: any): Promise<T>;
+    update(id: NullableId, data: T, params?: Params, callback?: any): Promise<T>;
+  }
 
+  interface PatchService<T> {
     /**
      * Merges the existing data of the resource identified by id with the new data.
      * Implement patch additionally to update if you want to separate between partial and full updates and support the PATCH HTTP method.
      * Patch multiples resources with id equal `null`
      */
-    patch?(id: NullableId, data: any, params?: Params, callback?: any): Promise<T>;
+    patch(id: NullableId, data: any, params?: Params, callback?: any): Promise<T>;
+  }
 
+  interface RemoveService<T> {
     /**
      * Removes the resource with id.
      * Delete multiple resources with id equal `null`
      */
-    remove?(id: NullableId, params?: Params, callback?: any): Promise<T>;
-
-    /**
-     * Initialize your service with any special configuration or if connecting services that are very tightly coupled
-     */
-    setup?(app?: Application, path?: string): void;
-
-    before(any?: any): this;
-    after(any?: any): this;
-    filter(any?: any): this;
-    
+    remove(id: NullableId, params?: Params, callback?: any): Promise<T>;
   }
+
+  interface FullService<T> extends GetService<T>, FindService<T>, CreateService<T>, UpdateService<T>, PatchService<T>, RemoveService<T> {}
+
+  interface OptionalMethods <T> {
+    find?(params?: Params, callback?: any): Promise<T[] | Pagination<T>>;
+    get?(id: number | string, params?: Params, callback?: any): Promise<T>;
+    create?(data: T[], params?: Params, callback?: any): Promise<T[]>;
+    create?(data: T, params?: Params, callback?: any): Promise<T>;
+    update?(id: NullableId, data: T, params?: Params, callback?: any): Promise<T>;
+    patch?(id: NullableId, data: any, params?: Params, callback?: any): Promise<T>;
+    remove?(id: NullableId, params?: Params, callback?: any): Promise<T>;
+  }
+
+  interface Setup {
+    setup?(app?: Application<any>, path?: string): void;
+  }
+
+  interface ServiceDefinition<T> extends OptionalMethods<T>, Setup {}
+
+  interface ServiceAddons extends events.EventEmitter {
+    filter(any?: any): this;
+  }
+
+  interface Service<T> extends OptionalMethods<T>, ServiceAddons {}
 
   interface FeathersUseHandler<T> extends expressCore.IRouterHandler<T>, express.IRouterMatcher<T> {
-    (location: string, service: Service<any>): T
+    (location: string, service: ServiceDefinition<any>): T;
   }
 
-  interface Application extends express.Application {
+  interface Application<ServiceListInterface> extends express.Application {
+    /**
+     * Register a service object
+     */
+    use: FeathersUseHandler<this>;
+
     /**
      * It either returns the Feathers wrapped service object for the given path
      */
+    service<K extends keyof ServiceListInterface>(location: K): ServiceListInterface[K] & ServiceAddons;
     service<T>(location: string): Service<T>;
 
     /**
@@ -89,11 +118,6 @@ declare namespace feathers {
      *  Initialize all services by calling each services .setup(app, path) method (if available)
      */
     setup(): this;
-
-    /**
-     * Register a service object
-     */
-    use: FeathersUseHandler<this>;
 
     /**
      * Runs a callback function with the application as the context (this). It can be used to initialize plugins or services.


### PR DESCRIPTION
Grants the ability to type static services.

Services returned from app.service() will have the correct type now. Dynamic services will obviously still need casting. Examples:

```ts
import * as feathers from 'feathers';

import {
  GetService, // only implements .get()
  CreateService, // .create()
  FullService // implements all service methods
} from 'feathers';

interface MyInterface {
  id: number
}

interface Services {
  full: FullService<MyInterface>
  getty: GetService<MyInterface> & CreateService<MyInterface> // service implements .get() and .create()
}

const app = feathers<Services>();

app.service('full').find();   // OK
app.service('getty').get(1).then((result: MyInterface) => {});  // OK

app.service('getty').find();                                // TS2339:Property 'find' does not exist on type 'GetService<MyInterface> & CreateService<MyInterface> & ServiceAddons'.
app.service('getty').get(1).then((result: string) => {});   // TS2345: [...] Type 'MyInterface' is not assignable to type 'string'.

// Getting an untyped Service will return type Service<{}> 
// and needs casting (unchanged behaviour)
app.service('anotherService').find();                                  // TS2532:Object is possibly 'undefined'.
```