### PR TITLE
Better logic for returning the hook object from method call

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -29,7 +29,9 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
 
     mixin[method] = function () {
       const service = this;
-      const args = arguments;
+      const args = Array.from(arguments);
+      const returnHook = args[args.length - 1] === true
+        ? args.pop() : false;
 
       // We have to try/catch this so that argument validation
       // returns a rejected promise
@@ -44,6 +46,7 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
       // Create the hook object that gets passed through
       const hookObject = createHookObject(method, args, {
         type: 'before', // initial hook object type
+        returnHook,
         service,
         app
       });
@@ -85,7 +88,7 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
         .then(hookObject =>
           // Finally, return the result
           // Or the hook object if the `__returnHook` flag is set
-          hookObject.params.__returnHook ? hookObject : hookObject.result
+          hookObject.returnHook ? hookObject : hookObject.result
         )
         // Handle errors
         .catch(error => {
@@ -105,7 +108,7 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
           return processHooks
             .call(service, hookChain, errorHookObject)
             .then(hook => {
-              if (errorHookObject.params.__returnHook) {
+              if (errorHookObject.returnHook) {
                 // Return either the complete hook if the `__returnHook` flag is set
                 return Promise.reject(hook);
               } else if (hook.result) {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -30,6 +30,8 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
     mixin[method] = function () {
       const service = this;
       const args = Array.from(arguments);
+      // If the last argument is `true` we want to return
+      // the actual hook object instead of the result
       const returnHook = args[args.length - 1] === true
         ? args.pop() : false;
 

--- a/test/hooks/hooks.test.js
+++ b/test/hooks/hooks.test.js
@@ -148,24 +148,21 @@ describe('hooks basics', () => {
     });
   });
 
-  describe('returns the hook object with __returnHook', () => {
+  describe('returns the hook object when passing true as last parameter', () => {
     it('on normal method call', () => {
       const app = feathers().use('/dummy', {
         get (id, params) {
           return Promise.resolve({ id, params });
         }
       });
-      const params = {
-        __returnHook: true
-      };
 
-      return app.service('dummy').get(10, params).then(context => {
+      return app.service('dummy').get(10, {}, true).then(context => {
         assert.equal(context.service, app.service('dummy'));
         assert.equal(context.type, 'after');
         assert.equal(context.path, 'dummy');
         assert.deepEqual(context.result, {
           id: 10,
-          params
+          params: {}
         });
       });
     });
@@ -176,11 +173,8 @@ describe('hooks basics', () => {
           return Promise.reject(new Error('Something went wrong'));
         }
       });
-      const params = {
-        __returnHook: true
-      };
 
-      return app.service('dummy').get(10, params).catch(context => {
+      return app.service('dummy').get(10, {}, true).catch(context => {
         assert.equal(context.service, app.service('dummy'));
         assert.equal(context.type, 'error');
         assert.equal(context.path, 'dummy');


### PR DESCRIPTION
In some cases - specifically for the service providers - we want to allow to return the hook object instead of only the result from a method call. This used to be possible by setting `params.__returnHook` but it is too easy to blow `params` away in a hook chain.

This new way returns the hook object if the last parameter in a service call is `true`.