### PR TITLE
Add placeholders for channel and publish methods

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -4,6 +4,7 @@ const { stripSlashes } = require('@feathersjs/commons');
 const Uberproto = require('uberproto');
 const events = require('./events');
 const hooks = require('./hooks');
+const placeholders = require('./placeholders');
 const version = require('./version');
 
 const Proto = Uberproto.extend({
@@ -26,6 +27,7 @@ const application = {
 
     this.configure(hooks());
     this.configure(events());
+    this.configure(placeholders());
   },
 
   get (name) {

--- a/lib/placeholders.js
+++ b/lib/placeholders.js
@@ -1,0 +1,26 @@
+const Proto = require('uberproto');
+
+module.exports = function () {
+  // Configure placeholders for channel and publishing functionality
+  // that throws an error message if you try to use it but no real-time
+  // transport has been registered
+  return function (app) {
+    Proto.mixin({
+      channel () {
+        throw new Error('app.channel: Channels are only available on a server with a registered real-time transport');
+      },
+
+      publish () {
+        throw new Error('app.publish: Event publishing is only available on a server with a registered real-time transport');
+      }
+    }, app);
+
+    app.mixins.push(service => {
+      service.mixin({
+        publish () {
+          throw new Error('service.publish: Event publishing is only available on a server with a registered real-time transport');
+        }
+      });
+    });
+  };
+};

--- a/test/placeholders.test.js
+++ b/test/placeholders.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const feathers = require('../lib');
+
+describe('Event publishing and channel placeholder error messages', () => {
+  const app = feathers();
+
+  app.use('/todos', {
+    get (id) {
+      return Promise.resolve({ id });
+    }
+  });
+
+  it('throws an error when trying to call app.channel', () => {
+    try {
+      app.channel();
+      assert.ok(false, 'Should never get here');
+    } catch (e) {
+      assert.equal(e.message, 'app.channel: Channels are only available on a server with a registered real-time transport');
+    }
+  });
+
+  it('throws an error when trying to call app.publish', () => {
+    try {
+      app.publish();
+      assert.ok(false, 'Should never get here');
+    } catch (e) {
+      assert.equal(e.message, 'app.publish: Event publishing is only available on a server with a registered real-time transport');
+    }
+  });
+
+  it('throws an error when trying to call service.publish', () => {
+    try {
+      app.service('todos').publish();
+      assert.ok(false, 'Should never get here');
+    } catch (e) {
+      assert.equal(e.message, 'service.publish: Event publishing is only available on a server with a registered real-time transport');
+    }
+  });
+});


### PR DESCRIPTION
This will give a better error message if someone tries to use event channels e.g. on the client or a server that does not have a real-time transport set up.