### PR TITLE
Throw an error for invalid service paths

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -78,6 +78,10 @@ const application = {
   },
 
   use (path, service, options = {}) {
+    if (typeof path !== 'string' || stripSlashes(path) === '') {
+      throw new Error(`'${path}' is not a valid service path.`);
+    }
+
     const location = stripSlashes(path);
     const isSubApp = typeof service.service === 'function' && service.services;
     const isService = this.methods.concat('setup').some(name =>

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -73,6 +73,28 @@ describe('Feathers application', () => {
   });
 
   describe('Services', () => {
+    it('calling .use with invalid path throws', () => {
+      const app = feathers();
+
+      try {
+        app.use('/', {});
+      } catch (e) {
+        assert.equal(e.message, `'/' is not a valid service path.`);
+      }
+
+      try {
+        app.use('', {});
+      } catch (e) {
+        assert.equal(e.message, `'' is not a valid service path.`);
+      }
+
+      try {
+        app.use({}, {});
+      } catch (e) {
+        assert.equal(e.message, `'[object Object]' is not a valid service path.`);
+      }
+    });
+
     it('calling .use with a non service object throws', () => {
       const app = feathers();
 


### PR DESCRIPTION
For #718 and #728 as well as avoiding the cryptic error of `stripSlashes` trying to run `name.replace` on a non-string.