### PR TITLE
Properly resolve the promise in error hooks if returnHook is set.

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -110,10 +110,13 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
           return processHooks
             .call(service, hookChain, errorHookObject)
             .then(hook => {
-              if (errorHookObject.returnHook) {
+              if (returnHook) {
+                // Either resolve or reject with the hook object
                 return hook.result ? hook : Promise.reject(hook);
               }
 
+              // Otherwise return either the result if set (to swallow errors)
+              // Or reject with the hook error
               return hook.result ? hook.result : Promise.reject(hook.error);
             });
         });

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,11 +1,11 @@
-const {
-  hooks,
-  validateArguments,
-  isPromise
-} = require('@feathersjs/commons');
+const { hooks, validateArguments, isPromise } = require('@feathersjs/commons');
 
 const {
-  createHookObject, getHooks, processHooks, enableHooks, makeArguments
+  createHookObject,
+  getHooks,
+  processHooks,
+  enableHooks,
+  makeArguments
 } = hooks;
 
 // A service mixin that adds `service.hooks()` method and functionality
@@ -89,7 +89,7 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
         })
         .then(hookObject =>
           // Finally, return the result
-          // Or the hook object if the `__returnHook` flag is set
+          // Or the hook object if the `returnHook` flag is set
           hookObject.returnHook ? hookObject : hookObject.result
         )
         // Handle errors
@@ -111,15 +111,10 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
             .call(service, hookChain, errorHookObject)
             .then(hook => {
               if (errorHookObject.returnHook) {
-                // Return either the complete hook if the `__returnHook` flag is set
-                return Promise.reject(hook);
-              } else if (hook.result) {
-                // Return the result if it is set so you can swallow errors
-                return Promise.resolve(hook.result);
+                return hook.result ? hook : Promise.reject(hook);
               }
 
-              // If none of the above, return the error
-              return Promise.reject(hook.error);
+              return hook.result ? hook.result : Promise.reject(hook.error);
             });
         });
     };

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -48,7 +48,6 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
       // Create the hook object that gets passed through
       const hookObject = createHookObject(method, args, {
         type: 'before', // initial hook object type
-        returnHook,
         service,
         app
       });
@@ -90,7 +89,7 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
         .then(hookObject =>
           // Finally, return the result
           // Or the hook object if the `returnHook` flag is set
-          hookObject.returnHook ? hookObject : hookObject.result
+          returnHook ? hookObject : hookObject.result
         )
         // Handle errors
         .catch(error => {

--- a/test/hooks/hooks.test.js
+++ b/test/hooks/hooks.test.js
@@ -181,5 +181,27 @@ describe('hooks basics', () => {
         assert.equal(context.error.message, 'Something went wrong');
       });
     });
+
+    it('still swallows error if context.result is set', () => {
+      const result = { message: 'this is a test' };
+      const app = feathers().use('/dummy', {
+        get () {
+          return Promise.reject(new Error('Something went wrong'));
+        }
+      });
+
+      app.service('dummy').hooks({
+        error (context) {
+          context.result = result;
+        }
+      });
+
+      return app.service('dummy').get(10, {}, true).then(hook => {
+        assert.ok(hook.error);
+        assert.deepEqual(hook.result, result);
+      }).catch(() => {
+        throw new Error('Should never get here');
+      });
+    });
   });
 });


### PR DESCRIPTION
When returning the hook object previously it was not possible to swallow the error. This should fix it.

Closes https://github.com/feathersjs/feathers/issues/767