### PR TITLE
Turn argument validation into the first hook

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -35,14 +35,6 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
       const returnHook = args[args.length - 1] === true
         ? args.pop() : false;
 
-      // We have to try/catch this so that argument validation
-      // returns a rejected promise
-      try {
-        validateArguments(method, args);
-      } catch (e) {
-        return Promise.reject(e);
-      }
-
       // A reference to the original method
       const _super = service._super.bind(service);
       // Create the hook object that gets passed through
@@ -51,7 +43,14 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
         service,
         app
       });
-      const beforeHooks = getHooks(app, service, 'before', method);
+      // A hook that validates the arguments and will always be the very first
+      const validateHook = context => {
+        validateArguments(method, args);
+
+        return context;
+      };
+      // The `before` hook chain (including the validation hook)
+      const beforeHooks = [ validateHook, ...getHooks(app, service, 'before', method) ];
 
       // Process all before hooks
       return processHooks.call(service, beforeHooks, hookObject)

--- a/test/hooks/hooks.test.js
+++ b/test/hooks/hooks.test.js
@@ -182,6 +182,21 @@ describe('hooks basics', () => {
       });
     });
 
+    it('on argument validation error', () => {
+      const app = feathers().use('/dummy', {
+        get (id) {
+          return Promise.resolve({ id });
+        }
+      });
+
+      return app.service('dummy').get(undefined, {}, true).catch(context => {
+        assert.equal(context.service, app.service('dummy'));
+        assert.equal(context.type, 'error');
+        assert.equal(context.path, 'dummy');
+        assert.equal(context.error.message, 'An id must be provided to the \'get\' method');
+      });
+    });
+
     it('still swallows error if context.result is set', () => {
       const result = { message: 'this is a test' };
       const app = feathers().use('/dummy', {


### PR DESCRIPTION
Feathers argument validation ran outside the normal hook chain which causes a bug when the hook object is expected to be returned, e.g. in the REST and websocket API transports and it skipped error hooks. The solution was to make it the very first hook in the chain so it will be treated like any other error.

Closes https://github.com/feathersjs/express/issues/19