### PR TITLE
Make sure error hooks always have the original context information

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -98,7 +98,7 @@ const hookMixin = exports.hookMixin = function hookMixin (service) {
           const hookChain = errorHooks.concat(finallyHooks);
 
           // A shallow copy of the hook object
-          const errorHookObject = Object.assign({}, error.hook || hookObject, {
+          const errorHookObject = Object.assign({}, error.hook, hookObject, {
             type: 'error',
             result: null,
             original: error.hook,


### PR DESCRIPTION
This is a backwards compatible fix for #841