### PR TITLE
use minimal RegExp matching for more performance

### DIFF
--- a/packages/commons/lib/utils.js
+++ b/packages/commons/lib/utils.js
@@ -1,6 +1,6 @@
 // Removes all leading and trailing slashes from a path
 exports.stripSlashes = function stripSlashes (name) {
-  return name.replace(/^(\/*)|(\/*)$/g, '');
+  return name.replace(/^(\/+)|(\/+)$/g, '');
 };
 
 // A set of lodash-y utility functions that use ES6


### PR DESCRIPTION
### Summary

A minimal matching is very faster than a wildcard matching in RegExp object, specially for long string case.

A test case gist at: https://gist.github.com/xixilive/99f4dc4dc175ca0386cb6e34d5f24ac1

this test case output on my machine:

Strip with wildcard matching
Time of strip1:: `540.535ms`
Strip with minimal matching
Time of strip2:: `272.998ms`

Closes https://github.com/feathersjs/feathers/issues/976