### PR TITLE
[generator-feathers] Support Logger swallowing

### DIFF
--- a/packages/generator-feathers/generators/app/templates/src/hooks/log.js
+++ b/packages/generator-feathers/generators/app/templates/src/hooks/log.js
@@ -17,7 +17,7 @@ module.exports = function () {
       logger.debug('Hook Context', util.inspect(context, {colors: false}));
     }
     
-    if(context.error) {
+    if(context.error && !context.result) {
       logger.error(context.error.stack);
     }
   };


### PR DESCRIPTION
When you swallow an error you expect silence... this common built in hook makes it noisy regardless. It looks almost exactly like an uncaught error and is very deceiving

This results in handled errors looking like this:

```
info: error: mailer - Method: create: getaddrinfo ENOTFOUND smtp.mailgun.org 
```

Instead of this:
```
info: error: mailer - Method: create: getaddrinfo ENOTFOUND smtp.mailgun.org smtp.mailgun.org:2525
error:  Error: getaddrinfo ENOTFOUND smtp.mailgun.org smtp.mailgun.org:2525
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:50:26)
```
which I much prefer.

MOVED TO MONOREPO FROM: https://github.com/feathersjs/generator-feathers/pull/392#issuecomment-420408312