### PR TITLE
Catch empty hook.params

### DIFF
--- a/packages/authentication-client/lib/hooks/populate-access-token.js
+++ b/packages/authentication-client/lib/hooks/populate-access-token.js
@@ -1,9 +1,17 @@
 module.exports = function populateAccessToken () {
   return function (hook) {
     const app = hook.app;
-
+    
     if (hook.type !== 'before') {
       return Promise.reject(new Error(`The 'populateAccessToken' hook should only be used as a 'before' hook.`));
+    }
+    
+    if (hook.params === 'undefined') {
+      hook.params = {}
+    }
+    
+    if (typeof hook.params !== 'object') {
+      return Promise.reject(new Error(`Invalid hook parameters were passed to the 'populateAccessToken' hook`));
     }
 
     Object.assign(hook.params, { accessToken: app.get('accessToken') });


### PR DESCRIPTION
In case hook.params is undefined, set an empty object. In case hook.params is something else (not an object), throw an error.

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving. #1001 - Feathers attempts to assign the `accessToken` to `hooks.params`, and so errors if `hook.params` is not defined.
- [x] Are there any open issues that are related to this? #1001 
- [x] Is this PR dependent on PRs in other repos? No

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: