### PR TITLE
Re-enable tests for generators in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: node_js
 install: npm install
-script: npm run ci
+script:
+  - npm test
+  - npm run test:generators
 services: mongodb
 node_js:
   - node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 install: npm install
-test: npm test && npm run test:generators
+script: npm run ci
 services: mongodb
 node_js:
   - node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 sudo: false
 language: node_js
 install: npm install
+test: npm test && npm run test:generators
+services: mongodb
 node_js:
   - node
   - '6'
 addons:
+  rethinkdb: 2.3
   code_climate:
     repo_token: 9840b8b56f6d10209b3478d41f7ba5102d02981435df129bb18554a529359c62
 before_script:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "install": "lerna bootstrap",
     "lint": "semistandard packages/**/*.js --fix",
     "test": "npm run lint && nyc lerna run test --ignore generator-**",
-    "test:generators": "lerna run test --scope generator-**"
+    "test:generators": "lerna run test --scope generator-**",
+    "ci": "npm test && npm run test:generators"
   },
   "semistandard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "install": "lerna bootstrap",
     "lint": "semistandard packages/**/*.js --fix",
-    "test": "npm run lint && nyc lerna run test --ignore generator-**"
+    "test": "npm run lint && nyc lerna run test --ignore generator-**",
+    "test:generators": "lerna run test --scope generator-**"
   },
   "semistandard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "install": "lerna bootstrap",
     "lint": "semistandard packages/**/*.js --fix",
     "test": "npm run lint && nyc lerna run test --ignore generator-**",
-    "test:generators": "lerna run test --scope generator-**"
+    "test:generators": "lerna run test --scope generator-** --stream --concurrency 1"
   },
   "semistandard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "install": "lerna bootstrap",
     "lint": "semistandard packages/**/*.js --fix",
     "test": "npm run lint && nyc lerna run test --ignore generator-**",
-    "test:generators": "lerna run test --scope generator-**",
-    "ci": "npm test && npm run test:generators"
+    "test:generators": "lerna run test --scope generator-**"
   },
   "semistandard": {
     "env": [

--- a/packages/generator-feathers-plugin/package.json
+++ b/packages/generator-feathers-plugin/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/feathersjs/feathers.git"
   },
   "scripts": {
-    "test": "../../node_modules/.bin/mocha"
+    "test": "../../node_modules/.bin/mocha --opts ../../mocha.opts"
   },
   "dependencies": {
     "yeoman-generator": "^3.0.0"

--- a/packages/generator-feathers-plugin/test/test-creation.js
+++ b/packages/generator-feathers-plugin/test/test-creation.js
@@ -24,7 +24,7 @@ describe('feathers-plugin generator', function () {
         name: 'feathers-tmp',
         repository: 'feathersjs/feathers-tmp',
         description: 'Plugin description here',
-        client: true
+        client: false
       })
       .on('end', function () {
         assert.ok(fs.existsSync(path.join(tmpDir, '.npmignore')));

--- a/packages/generator-feathers/package.json
+++ b/packages/generator-feathers/package.json
@@ -30,7 +30,7 @@
     "node": ">= 6.0.0"
   },
   "scripts": {
-    "test": "../../node_modules/.bin/mocha"
+    "test": "../../node_modules/.bin/mocha --opts ../../mocha.opts"
   },
   "dependencies": {
     "@feathersjs/jscodeshift": "^0.5.0",

--- a/packages/generator-feathers/package.json
+++ b/packages/generator-feathers/package.json
@@ -30,7 +30,7 @@
     "node": ">= 6.0.0"
   },
   "scripts": {
-    "test": "../../node_modules/.bin/mocha --opts ../../mocha.opts"
+    "test": "../../node_modules/.bin/mocha --opts ../../mocha.opts --timeout 30000"
   },
   "dependencies": {
     "@feathersjs/jscodeshift": "^0.5.0",


### PR DESCRIPTION
They are not running by default with `npm test` because it takes a while and you need several databases installed. They should run on CI however.