### PR TITLE
Normalize params to object even when it is falsy

### DIFF
--- a/packages/feathers/lib/hooks/base.js
+++ b/packages/feathers/lib/hooks/base.js
@@ -3,11 +3,14 @@ const { _ } = require('@feathersjs/commons');
 const assignArguments = context => {
   const { service, method } = context;
   const parameters = service.methods[method];
-
   const argsObject = context.arguments.reduce((result, value, index) => {
     result[parameters[index]] = value;
     return result;
-  }, { params: {} });
+  }, {});
+
+  if (!argsObject.params) {
+    argsObject.params = {};
+  }
 
   Object.assign(context, argsObject);
 

--- a/packages/feathers/test/hooks/hooks.test.js
+++ b/packages/feathers/test/hooks/hooks.test.js
@@ -100,8 +100,8 @@ describe('hooks basics', () => {
 
   it('invalid type in .hooks throws error', () => {
     const app = feathers().use('/dummy', {
-      get (id, params, callback) {
-        callback(null, { id, params });
+      get (id, params) {
+        return Promise.resolve({ id, params });
       }
     });
 
@@ -117,8 +117,8 @@ describe('hooks basics', () => {
 
   it('invalid hook method throws error', () => {
     const app = feathers().use('/dummy', {
-      get (id, params, callback) {
-        callback(null, { id, params });
+      get (id, params) {
+        return Promise.resolve({ id, params });
       }
     });
 
@@ -341,5 +341,20 @@ describe('hooks basics', () => {
       .then(result => {
         assert.deepEqual(result, args);
       });
+  });
+
+  it('normalizes params to object even when it is falsy (#1001)', () => {
+    const app = feathers().use('/dummy', {
+      get (id, params) {
+        return Promise.resolve({ id, params });
+      }
+    });
+
+    return app.service('dummy').get('test', null).then(result => {
+      assert.deepEqual(result, {
+        id: 'test',
+        params: {}
+      });
+    });
   });
 });


### PR DESCRIPTION
This is a regression where things like `.find(null)` previously still turned `params` into an object. The new argument normalization overwrote it with any other value.

Closes #1001, closes #1011, closes https://github.com/feathersjs/authentication-client/issues/114