### PR TITLE
Allow case-insensitive for local email (username) authentication

### DIFF
--- a/packages/generator-feathers/generators/service/templates/model/mongoose-user.js
+++ b/packages/generator-feathers/generators/service/templates/model/mongoose-user.js
@@ -6,7 +6,7 @@ module.exports = function (app) {
   const mongooseClient = app.get('mongooseClient');
   const <%= camelName %> = new mongooseClient.Schema({
   <% if(authentication.strategies.indexOf('local') !== -1) { %>
-    email: {type: String, unique: true},
+    email: {type: String, unique: true, lowercase: true},
     password: { type: String },
   <% } %>
   <% authentication.oauthProviders.forEach(provider => { %>


### PR DESCRIPTION
### Summary

In most cases usernames and emails are case-insensitive. Current implementation prevents users from authenticating successfully when the emails do not match exactly (i.e. case sensitive).

### Other Information

This is just a minor change but it makes more sense to the end-user and developer as usernames in most cases do not require you to be case sensitive in the username field.