### PR TITLE
Config path from package.json

### DIFF
--- a/packages/generator-feathers/generators/app/configs/package.json.js
+++ b/packages/generator-feathers/generators/app/configs/package.json.js
@@ -2,6 +2,8 @@ const semver = require('semver');
 
 module.exports = function(generator) {
   const major = semver.major(process.version);
+  const envConfigDir = process.env['NODE_CONFIG_DIR'];
+  const configDirectory = envConfigDir ? p.join(envConfigDir) : 'config/';
   const { props } = generator;
   const lib = props.src;
   const [ packager, version ] = props.packager.split('@');
@@ -22,7 +24,8 @@ module.exports = function(generator) {
     bugs: {},
     directories: {
       lib,
-      test: 'test/'
+      test: 'test/',
+      config: configDirectory
     },
     engines: {
       node: `^${major}.0.0`,

--- a/packages/generator-feathers/generators/app/index.js
+++ b/packages/generator-feathers/generators/app/index.js
@@ -160,12 +160,12 @@ module.exports = class AppGenerator extends Generator {
     )
 
     this.fs.writeJSON(
-      this.destinationPath('config', 'default.json'),
+      this.destinationPath(this.configDirectory, 'default.json'),
       makeConfig.configDefault(this)
     );
 
     this.fs.writeJSON(
-      this.destinationPath('config', 'production.json'),
+      this.destinationPath(this.configDirectory, 'production.json'),
       makeConfig.configProduction(this)
     );
   }

--- a/packages/generator-feathers/generators/authentication/index.js
+++ b/packages/generator-feathers/generators/authentication/index.js
@@ -135,7 +135,7 @@ module.exports = class AuthGenerator extends Generator {
 
     this.conflicter.force = true;
     this.fs.writeJSON(
-      this.destinationPath('config', 'default.json'),
+      this.destinationPath(this.configDirectory, 'default.json'),
       config
     );
   }
@@ -167,7 +167,7 @@ module.exports = class AuthGenerator extends Generator {
         dependencies.push(`@feathersjs/authentication-${strategy}`);
       }
     });
-    
+
     if(!this.fs.exists(this.destinationPath(this.libDirectory, 'services', context.kebabEntity, `${context.kebabEntity}.service.js`))) {
       // Create the users service
       this.composeWith(require.resolve('../service'), {

--- a/packages/generator-feathers/generators/connection/index.js
+++ b/packages/generator-feathers/generators/connection/index.js
@@ -136,10 +136,9 @@ module.exports = class ConnectionGenerator extends Generator {
 
     if (!config[database]) {
       config[database] = configuration;
-
       this.conflicter.force = true;
       this.fs.writeJSON(
-        this.destinationPath('config', 'default.json'),
+        this.destinationPath(this.configDirectory, 'default.json'),
         config
       );
     }

--- a/packages/generator-feathers/lib/generator.js
+++ b/packages/generator-feathers/lib/generator.js
@@ -7,7 +7,7 @@ module.exports = class BaseGenerator extends Generator {
   constructor(args, opts) {
     super(args, opts);
 
-    const defaultConfig = this.destinationPath('config', 'default.json');
+    const defaultConfig = this.destinationPath(this.configDirectory, 'default.json');
 
     this.generatorPkg = this.fs.readJSON(path.join(__dirname, '..', 'package.json'));
     this.pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
@@ -53,8 +53,11 @@ module.exports = class BaseGenerator extends Generator {
     return (this.pkg.directories && this.pkg.directories.test) || 'test';
   }
 
+  get configDirectory() {
+    return (this.pkg && this.pkg.directories && this.pkg.directories.config) || 'config';
+  }
   _packagerInstall(deps, options) {
-    const packager = this.pkg.engines && this.pkg.engines.yarn ? 
+    const packager = this.pkg.engines && this.pkg.engines.yarn ?
       'yarn' : 'npm';
     const method = `${packager}Install`;
     const isDev = options.saveDev;


### PR DESCRIPTION
Hello,

This pull request is created because of #987 

It lets the CLI use a custom config folder.

Based on the discussions on the issue, the following changes were made to generating a new project
- When creating a project, the package.json is created with a value for a config directory
- The value is read from `NODE_CONFIG_DIR` env variable since it is used by default
- If the value is not set, it is set to `config/` (the current hardcoded value)

Generator uses this new customizable value. It falls back to `config/` on run time to maintain backwards compatibility.

Thanks for a great framework and happy Hactober!