### PR TITLE
feat(env): make codeclimate conform to rule of three

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,9 +30,13 @@ checks:
   identical-code:
     config:
       threshold: 25
+plugins:
+  duplication:
+    enabled: true
+    config:
+      count_threshold: 3
 exclude_patterns:
   - "**/test/*"
   - "**/dist/*"
   - "**/*.dist.js"
   - "**/templates/*"
-  


### PR DESCRIPTION
### Summary

Makes codeclimate a bit more relaxed. Rejects duplicates after three instances have been found instead of three.

I ran into this issue when submitting another pull request: https://github.com/feathersjs/feathers/pull/1075 but this concerns all code in general. The code in the other pull request could be reformatted but I feel it is not justified to be generized. There is strong prior agrumentation for the case: https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)

Happy Hactober!