### PR TITLE
chore(test): Update assertion format to always use strict equality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -939,27 +939,16 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+			"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
 			"dev": true
 		},
 		"acorn-jsx": {
-			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-			"dev": true,
-			"requires": {
-				"acorn": "^3.0.4"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-					"dev": true
-				}
-			}
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
+			"integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==",
+			"dev": true
 		},
 		"agent-base": {
 			"version": "2.1.1",
@@ -1001,9 +990,9 @@
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
 			"dev": true
 		},
 		"ansi-escapes": {
@@ -2448,6 +2437,23 @@
 				"meow": "^3.3.0"
 			}
 		},
+		"debug": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"dev": true,
+			"requires": {
+				"ms": "^2.1.1"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
 		"debug-log": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
@@ -2554,17 +2560,25 @@
 			}
 		},
 		"deglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
-			"integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
+			"integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
 			"dev": true,
 			"requires": {
 				"find-root": "^1.0.0",
 				"glob": "^7.0.5",
-				"ignore": "^3.0.9",
+				"ignore": "^5.0.0",
 				"pkg-config": "^1.1.0",
 				"run-parallel": "^1.1.2",
 				"uniq": "^1.0.1"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.4.tgz",
+					"integrity": "sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==",
+					"dev": true
+				}
 			}
 		},
 		"del": {
@@ -2753,14 +2767,14 @@
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
+				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"es6-promise": {
@@ -2785,50 +2799,63 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "4.18.2",
-			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
+			"integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
+				"ajv": "^6.5.0",
+				"babel-code-frame": "^6.26.0",
 				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
+				"cross-spawn": "^6.0.5",
 				"debug": "^3.1.0",
 				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
+				"eslint-scope": "^4.0.0",
+				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.2",
-				"esquery": "^1.0.0",
+				"espree": "^4.0.0",
+				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^2.0.0",
 				"functional-red-black-tree": "^1.0.1",
 				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.2",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
+				"inquirer": "^5.2.0",
+				"is-resolvable": "^1.1.0",
+				"js-yaml": "^3.11.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
+				"lodash": "^4.17.5",
+				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
 				"path-is-inside": "^1.0.2",
 				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
+				"regexpp": "^2.0.0",
 				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
+				"semver": "^5.5.0",
 				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
-				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"strip-json-comments": "^2.0.1",
+				"table": "^4.0.3",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.5.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -2840,26 +2867,6 @@
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 					"dev": true
-				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"debug": {
-					"version": "3.2.5",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
 				},
 				"esprima": {
 					"version": "4.0.1",
@@ -2878,6 +2885,12 @@
 						"tmp": "^0.0.33"
 					}
 				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
+				},
 				"glob": {
 					"version": "7.1.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -2892,23 +2905,28 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
 				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"version": "5.2.0",
+					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
 						"cli-cursor": "^2.1.0",
 						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
+						"external-editor": "^2.1.0",
 						"figures": "^2.0.0",
 						"lodash": "^4.3.0",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
+						"rxjs": "^5.5.2",
 						"string-width": "^2.1.0",
 						"strip-ansi": "^4.0.0",
 						"through": "^2.3.6"
@@ -2930,11 +2948,20 @@
 						"esprima": "^4.0.0"
 					}
 				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
+				},
+				"rxjs": {
+					"version": "5.5.12",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+					"dev": true,
+					"requires": {
+						"symbol-observable": "1.0.1"
+					}
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -2958,21 +2985,21 @@
 			}
 		},
 		"eslint-config-semistandard": {
-			"version": "12.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-12.0.1.tgz",
-			"integrity": "sha512-4zaPW5uRFasf2uRZkE19Y+W84KBV3q+oyWYOsgUN+5DQXE5HCsh7ZxeWDXxozk7NPycGm0kXcsJzLe5GZ1jCeg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-13.0.0.tgz",
+			"integrity": "sha512-ZuImKnf/9LeZjr6dtRJ0zEdQbjBwXu0PJR3wXJXoQeMooICMrYPyD70O1tIA9Ng+wutgLjB7UXvZOKYPvzHg+w==",
 			"dev": true
 		},
 		"eslint-config-standard": {
-			"version": "11.0.0",
-			"resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-			"integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+			"integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
 			"dev": true
 		},
 		"eslint-config-standard-jsx": {
-			"version": "5.0.0",
-			"resolved": "http://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz",
-			"integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
+			"integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
 			"dev": true
 		},
 		"eslint-import-resolver-node": {
@@ -3035,22 +3062,32 @@
 				}
 			}
 		},
-		"eslint-plugin-import": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-			"integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+		"eslint-plugin-es": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz",
+			"integrity": "sha512-9XcVyZiQRVeFjqHw8qHNDAZcQLqaHlOGGpeYqzYh8S4JYCWTCO3yzyen8yVmA5PratfzTRWDwCOFphtDEG+w/w==",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.1.1",
+				"eslint-utils": "^1.3.0",
+				"regexpp": "^2.0.0"
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+			"dev": true,
+			"requires": {
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.8",
 				"doctrine": "1.5.0",
 				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.1.1",
+				"eslint-module-utils": "^2.2.0",
 				"has": "^1.0.1",
-				"lodash.cond": "^4.3.0",
+				"lodash": "^4.17.4",
 				"minimatch": "^3.0.3",
-				"read-pkg-up": "^2.0.0"
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.6.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -3123,6 +3160,15 @@
 						"read-pkg": "^2.0.0"
 					}
 				},
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				},
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -3132,17 +3178,25 @@
 			}
 		},
 		"eslint-plugin-node": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+			"integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
 			"dev": true,
 			"requires": {
-				"ignore": "^3.3.6",
+				"eslint-plugin-es": "^1.3.1",
+				"eslint-utils": "^1.3.1",
+				"ignore": "^4.0.2",
 				"minimatch": "^3.0.4",
-				"resolve": "^1.3.3",
-				"semver": "^5.4.1"
+				"resolve": "^1.8.1",
+				"semver": "^5.5.0"
 			},
 			"dependencies": {
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
 				"resolve": {
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -3155,38 +3209,45 @@
 			}
 		},
 		"eslint-plugin-promise": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz",
-			"integrity": "sha512-YQzM6TLTlApAr7Li8vWKR+K3WghjwKcYzY0d2roWap4SLK+kzuagJX/leTetIDWsFcTFnKNJXWupDCD6aZkP2Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+			"integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
 			"dev": true
 		},
 		"eslint-plugin-react": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz",
-			"integrity": "sha512-30aMOHWX/DOaaLJVBHz6RMvYM2qy5GH63+y2PLFdIrYe4YLtODFmT3N1YA7ZqUnaBweVbedr4K4cqxOlWAPjIw==",
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+			"integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
 			"dev": true,
 			"requires": {
-				"doctrine": "^2.0.2",
-				"has": "^1.0.1",
+				"array-includes": "^3.0.3",
+				"doctrine": "^2.1.0",
+				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.0.1",
-				"prop-types": "^15.6.0"
+				"prop-types": "^15.6.2"
 			}
 		},
 		"eslint-plugin-standard": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-			"integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+			"integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-			"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
 			}
+		},
+		"eslint-utils": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+			"dev": true
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -3195,13 +3256,14 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+			"integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "^6.0.2",
+				"acorn-jsx": "^5.0.0",
+				"eslint-visitor-keys": "^1.0.0"
 			}
 		},
 		"esprima": {
@@ -5383,12 +5445,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
-		},
-		"lodash.cond": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -7713,9 +7769,9 @@
 			"dev": true
 		},
 		"progress": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
 			"dev": true
 		},
 		"promise-inflight": {
@@ -7974,6 +8030,12 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+			"dev": true
+		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -8165,21 +8227,6 @@
 				"aproba": "^1.1.1"
 			}
 		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
-			"requires": {
-				"rx-lite": "*"
-			}
-		},
 		"rxjs": {
 			"version": "6.3.2",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
@@ -8258,21 +8305,21 @@
 			}
 		},
 		"semistandard": {
-			"version": "12.0.1",
-			"resolved": "https://registry.npmjs.org/semistandard/-/semistandard-12.0.1.tgz",
-			"integrity": "sha512-+FBRXBCi8GC1Nivc4ruw2KXER31bE1lrNyESo7prn2Sv9I9+H/Iqpt0NOtlV/GUxq34AgJwJViBUpA3/PUGqOw==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/semistandard/-/semistandard-13.0.0.tgz",
+			"integrity": "sha512-7LwesGUFcohemaNGuRNT5sBH6d0MbvFAlLEsLijeuJiugM9Kl7q5KnC/M77qh85rkU/lZCV2uAu78sJbXLb/fQ==",
 			"dev": true,
 			"requires": {
-				"eslint": "~4.18.0",
-				"eslint-config-semistandard": "12.0.1",
-				"eslint-config-standard": "11.0.0",
-				"eslint-config-standard-jsx": "5.0.0",
-				"eslint-plugin-import": "~2.8.0",
-				"eslint-plugin-node": "~6.0.0",
-				"eslint-plugin-promise": "~3.6.0",
-				"eslint-plugin-react": "~7.6.1",
-				"eslint-plugin-standard": "~3.0.1",
-				"standard-engine": "~8.0.0"
+				"eslint": "~5.4.0",
+				"eslint-config-semistandard": "13.0.0",
+				"eslint-config-standard": "12.0.0",
+				"eslint-config-standard-jsx": "6.0.2",
+				"eslint-plugin-import": "~2.14.0",
+				"eslint-plugin-node": "~7.0.1",
+				"eslint-plugin-promise": "~4.0.0",
+				"eslint-plugin-react": "~7.11.1",
+				"eslint-plugin-standard": "~4.0.0",
+				"standard-engine": "~10.0.0"
 			}
 		},
 		"semver": {
@@ -8639,12 +8686,12 @@
 			}
 		},
 		"standard-engine": {
-			"version": "8.0.1",
-			"resolved": "http://registry.npmjs.org/standard-engine/-/standard-engine-8.0.1.tgz",
-			"integrity": "sha512-LA531C3+nljom/XRvdW/hGPXwmilRkaRkENhO3FAGF1Vtq/WtCXzgmnc5S6vUHHsgv534MRy02C1ikMwZXC+tw==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-10.0.0.tgz",
+			"integrity": "sha512-91BjmzIRZbFmyOY73R6vaDd/7nw5qDWsfpJW5/N+BCXFgmvreyfrRg7oBSu4ihL0gFGXfnwCImJm6j+sZDQQyw==",
 			"dev": true,
 			"requires": {
-				"deglob": "^2.1.0",
+				"deglob": "^3.0.0",
 				"get-stdin": "^6.0.0",
 				"minimist": "^1.1.0",
 				"pkg-conf": "^2.0.0"
@@ -8775,30 +8822,60 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"symbol-observable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+			"dev": true
+		},
 		"table": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"version": "4.0.3",
+			"resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+			"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-keywords": "^2.1.0",
+				"ajv": "^6.0.1",
+				"ajv-keywords": "^3.0.0",
 				"chalk": "^2.1.0",
 				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
 				"string-width": "^2.1.1"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.5.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
+				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
 				},
 				"string-width": {
@@ -9177,6 +9254,23 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "install": "lerna bootstrap",
     "publish": "lerna publish",
     "lint": "semistandard \"packages/**/lib/**/*.js\" \"packages/**/test/**/*.js\" --fix",
-    "test": "npm run lint && nyc lerna run test",
+    "test": "npm run lint && nyc lerna run test --ignore @feathersjs/authentication-client",
     "test:client": "grunt"
   },
   "semistandard": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "lerna": "^3.4.0",
     "nyc": "^13.0.1",
-    "semistandard": "^12.0.1",
+    "semistandard": "^13.0.0",
     "grunt": "^1.0.3",
     "grunt-cli": "^1.3.1",
     "grunt-saucelabs": "^9.0.0"

--- a/packages/authentication-local/test/hooks/hash-password.test.js
+++ b/packages/authentication-local/test/hooks/hash-password.test.js
@@ -124,8 +124,8 @@ describe('hooks:hashPassword', () => {
   describe('when password exists in bulk', () => {
     beforeEach(() => {
       hook.data = [
-        {password: 'secret'},
-        {password: 'secret'}
+        { password: 'secret' },
+        { password: 'secret' }
       ];
     });
 
@@ -155,8 +155,8 @@ describe('hooks:hashPassword', () => {
 
     it('hashes with custom options', () => {
       hook.data = [
-        {pass: 'secret'},
-        {pass: 'secret'}
+        { pass: 'secret' },
+        { pass: 'secret' }
       ];
 
       return hashPassword({ passwordField: 'pass' })(hook).then(hook => {

--- a/packages/commons/lib/test/client.js
+++ b/packages/commons/lib/test/client.js
@@ -7,7 +7,7 @@ module.exports = function (app, name) {
   describe('Service base tests', () => {
     it('.find', () => {
       return getService().find().then(todos =>
-        assert.deepEqual(todos, [{
+        assert.deepEqual(todos, [{ // eslint-disable-line
           text: 'some todo',
           complete: false,
           id: 0
@@ -19,11 +19,11 @@ module.exports = function (app, name) {
       const query = {
         some: 'thing',
         other: ['one', 'two'],
-        nested: {a: {b: 'object'}}
+        nested: { a: { b: 'object' } }
       };
 
       return getService().get(0, { query })
-        .then(todo => assert.deepEqual(todo, {
+        .then(todo => assert.deepEqual(todo, { // eslint-disable-line
           id: 0,
           text: 'some todo',
           complete: false,
@@ -33,22 +33,22 @@ module.exports = function (app, name) {
 
     it('.create and created event', done => {
       getService().once('created', function (data) {
-        assert.equal(data.text, 'created todo');
+        assert.strictEqual(data.text, 'created todo');
         assert.ok(data.complete);
         done();
       });
 
-      getService().create({text: 'created todo', complete: true});
+      getService().create({ text: 'created todo', complete: true });
     });
 
     it('.update and updated event', done => {
       getService().once('updated', data => {
-        assert.equal(data.text, 'updated todo');
+        assert.strictEqual(data.text, 'updated todo');
         assert.ok(data.complete);
         done();
       });
 
-      getService().create({text: 'todo to update', complete: false})
+      getService().create({ text: 'todo to update', complete: false })
         .then(todo => getService().update(todo.id, {
           text: 'updated todo',
           complete: true
@@ -57,30 +57,30 @@ module.exports = function (app, name) {
 
     it('.patch and patched event', done => {
       getService().once('patched', data => {
-        assert.equal(data.text, 'todo to patch');
+        assert.strictEqual(data.text, 'todo to patch');
         assert.ok(data.complete);
         done();
       });
 
-      getService().create({text: 'todo to patch', complete: false})
-        .then(todo => getService().patch(todo.id, {complete: true}));
+      getService().create({ text: 'todo to patch', complete: false })
+        .then(todo => getService().patch(todo.id, { complete: true }));
     });
 
     it('.remove and removed event', done => {
       getService().once('removed', data => {
-        assert.equal(data.text, 'todo to remove');
-        assert.equal(data.complete, false);
+        assert.strictEqual(data.text, 'todo to remove');
+        assert.strictEqual(data.complete, false);
         done();
       });
 
-      getService().create({text: 'todo to remove', complete: false})
+      getService().create({ text: 'todo to remove', complete: false })
         .then(todo => getService().remove(todo.id)).catch(done);
     });
 
     it('.get with error', () => {
-      let query = {error: true};
+      let query = { error: true };
 
-      return getService().get(0, {query}).catch(error =>
+      return getService().get(0, { query }).catch(error =>
         assert.ok(error && error.message)
       );
     });

--- a/packages/commons/lib/test/fixture.js
+++ b/packages/commons/lib/test/fixture.js
@@ -74,12 +74,12 @@ exports.Service = {
 
 exports.verify = {
   find (data) {
-    assert.deepEqual(findAllData, data, 'Data as expected');
+    assert.deepStrictEqual(findAllData, data, 'Data as expected');
   },
 
   get (id, data) {
-    assert.equal(data.id, id, 'Got id in data');
-    assert.equal(data.description, `You have to do ${id}!`, 'Got description');
+    assert.strictEqual(data.id, id, 'Got id in data');
+    assert.strictEqual(data.description, `You have to do ${id}!`, 'Got description');
   },
 
   create (original, current) {
@@ -87,7 +87,7 @@ exports.verify = {
       id: 42,
       status: 'created'
     });
-    assert.deepEqual(expected, current, 'Data ran through .create as expected');
+    assert.deepStrictEqual(expected, current, 'Data ran through .create as expected');
   },
 
   update (id, original, current) {
@@ -95,7 +95,7 @@ exports.verify = {
       id: id,
       status: 'updated'
     });
-    assert.deepEqual(expected, current, 'Data ran through .update as expected');
+    assert.deepStrictEqual(expected, current, 'Data ran through .update as expected');
   },
 
   patch (id, original, current) {
@@ -103,10 +103,10 @@ exports.verify = {
       id: id,
       status: 'patched'
     });
-    assert.deepEqual(expected, current, 'Data ran through .patch as expected');
+    assert.deepStrictEqual(expected, current, 'Data ran through .patch as expected');
   },
 
   remove (id, data) {
-    assert.deepEqual({ id }, data, '.remove called');
+    assert.deepStrictEqual({ id }, data, '.remove called');
   }
 };

--- a/packages/commons/test/filter-query.test.js
+++ b/packages/commons/test/filter-query.test.js
@@ -17,7 +17,7 @@ describe('.filterQuery', function () {
     });
 
     it('returns $sort when present in query as an object', function () {
-      const { filters, query } = filter({ $sort: { name: {something: 10} } });
+      const { filters, query } = filter({ $sort: { name: { something: 10 } } });
       expect(filters.$sort.name.something).to.equal(10);
       expect(query).to.deep.equal({});
     });

--- a/packages/configuration/test/config/default.json
+++ b/packages/configuration/test/config/default.json
@@ -1,5 +1,5 @@
 {
-  "port": "3030",
+  "port": 3030,
   "environment": "NODE_ENV",
   "path": "../something",
   "unescaped": "\\NODE_ENV",

--- a/packages/configuration/test/index.test.js
+++ b/packages/configuration/test/index.test.js
@@ -24,43 +24,43 @@ describe('@feathersjs/configuration', () => {
   });
 
   it('exports default', () =>
-    assert.equal(plugin, plugin.default)
+    assert.strictEqual(plugin, plugin.default)
   );
 
   it('initialized app with default data', () =>
-    assert.equal(app.get('port'), 3030)
+    assert.strictEqual(app.get('port'), 3030)
   );
 
   it('initialized with <env>', () =>
-    assert.equal(app.get('from'), 'testing')
+    assert.strictEqual(app.get('from'), 'testing')
   );
 
   it('initialized with <env> derived data module', () =>
-    assert.equal(app.get('derived'), 'Hello World')
+    assert.strictEqual(app.get('derived'), 'Hello World')
   );
 
   it('initialized property with environment variable', () =>
-    assert.equal(app.get('environment'), 'testing')
+    assert.strictEqual(app.get('environment'), 'testing')
   );
 
   it('initialized property with environment variable from <env>', () =>
-    assert.equal(app.get('testEnvironment'), 'testing')
+    assert.strictEqual(app.get('testEnvironment'), 'testing')
   );
 
   it('initialized property with derived environment variable from <env> module', () =>
-    assert.equal(app.get('derivedEnvironment'), 'testing')
+    assert.strictEqual(app.get('derivedEnvironment'), 'testing')
   );
 
   it('uses an escape character', () =>
-    assert.equal(app.get('unescaped'), 'NODE_ENV')
+    assert.strictEqual(app.get('unescaped'), 'NODE_ENV')
   );
 
   it('normalizes relative path names', () =>
-    assert.equal(app.get('path'), join(__dirname, 'something'))
+    assert.strictEqual(app.get('path'), join(__dirname, 'something'))
   );
 
   it('converts environment variables recursively', () =>
-    assert.equal(app.get('deeply').nested.env, 'testing')
+    assert.strictEqual(app.get('deeply').nested.env, 'testing')
   );
 
   it('converts arrays as actual arrays', () =>
@@ -70,11 +70,11 @@ describe('@feathersjs/configuration', () => {
   it('works when called directly', () => {
     const fn = plugin();
 
-    assert.equal(fn().port, '3030');
+    assert.strictEqual(fn().port, 3030);
   });
 
   it('deep merges properties', () =>
-    assert.deepEqual(app.get('deep'), {
+    assert.deepStrictEqual(app.get('deep'), {
       base: false,
       merge: true
     })

--- a/packages/errors/test/error-handler.test.js
+++ b/packages/errors/test/error-handler.test.js
@@ -164,7 +164,7 @@ describe('error-handler', () => {
             expect(_req).to.equal(req);
             expect(_res).to.equal(res);
             done();
-          }}
+          } }
         });
         middleware(err, req, res);
       });
@@ -179,7 +179,7 @@ describe('error-handler', () => {
             expect(_req).to.equal(req);
             expect(_res).to.equal(res);
             done();
-          }}
+          } }
         });
         middleware(err, req, res);
       });
@@ -223,7 +223,7 @@ describe('error-handler', () => {
             expect(_req).to.equal(req);
             expect(_res).to.equal(res);
             done();
-          }}
+          } }
         });
         middleware(err, req, res);
       });
@@ -238,7 +238,7 @@ describe('error-handler', () => {
             expect(_req).to.equal(req);
             expect(_res).to.equal(res);
             done();
-          }}
+          } }
         });
         middleware(err, req, res);
       });

--- a/packages/errors/test/index.test.js
+++ b/packages/errors/test/index.test.js
@@ -5,8 +5,8 @@ const { convert } = errors;
 
 describe('@feathersjs/errors', () => {
   it('is CommonJS compatible', () => {
-    assert.equal(typeof require('../lib'), 'object');
-    assert.equal(typeof require('../lib').FeathersError, 'function');
+    assert.strictEqual(typeof require('../lib'), 'object');
+    assert.strictEqual(typeof require('../lib').FeathersError, 'function');
   });
 
   describe('errors.convert', () => {
@@ -18,8 +18,8 @@ describe('@feathersjs/errors', () => {
       });
 
       assert.ok(error instanceof errors.BadRequest);
-      assert.equal(error.message, 'Hi');
-      assert.equal(error.expando, 'Me');
+      assert.strictEqual(error.message, 'Hi');
+      assert.strictEqual(error.expando, 'Me');
     });
 
     it('converts other object to error', () => {
@@ -28,146 +28,146 @@ describe('@feathersjs/errors', () => {
       });
 
       assert.ok(error instanceof Error);
-      assert.equal(error.message, 'Something went wrong');
+      assert.strictEqual(error.message, 'Something went wrong');
 
       error = convert('Something went wrong');
 
       assert.ok(error instanceof Error);
-      assert.equal(error.message, 'Something went wrong');
+      assert.strictEqual(error.message, 'Something went wrong');
     });
 
     it('converts nothing', () =>
-      assert.equal(convert(null), null)
+      assert.strictEqual(convert(null), null)
     );
   });
 
   describe('error types', () => {
     it('Bad Request', () => {
-      assert.notEqual(typeof errors.BadRequest, 'undefined', 'has BadRequest');
+      assert.notStrictEqual(typeof errors.BadRequest, 'undefined', 'has BadRequest');
     });
 
     it('Not Authenticated', () => {
-      assert.notEqual(typeof errors.NotAuthenticated, 'undefined', 'has NotAuthenticated');
+      assert.notStrictEqual(typeof errors.NotAuthenticated, 'undefined', 'has NotAuthenticated');
     });
 
     it('Payment Error', () => {
-      assert.notEqual(typeof errors.PaymentError, 'undefined', 'has PaymentError');
+      assert.notStrictEqual(typeof errors.PaymentError, 'undefined', 'has PaymentError');
     });
 
     it('Forbidden', () => {
-      assert.notEqual(typeof errors.Forbidden, 'undefined', 'has Forbidden');
+      assert.notStrictEqual(typeof errors.Forbidden, 'undefined', 'has Forbidden');
     });
 
     it('Not Found', () => {
-      assert.notEqual(typeof errors.NotFound, 'undefined', 'has NotFound');
+      assert.notStrictEqual(typeof errors.NotFound, 'undefined', 'has NotFound');
     });
 
     it('Method Not Allowed', () => {
-      assert.notEqual(typeof errors.MethodNotAllowed, 'undefined', 'has MethodNotAllowed');
+      assert.notStrictEqual(typeof errors.MethodNotAllowed, 'undefined', 'has MethodNotAllowed');
     });
 
     it('Not Acceptable', () => {
-      assert.notEqual(typeof errors.NotAcceptable, 'undefined', 'has NotAcceptable');
+      assert.notStrictEqual(typeof errors.NotAcceptable, 'undefined', 'has NotAcceptable');
     });
 
     it('Timeout', () => {
-      assert.notEqual(typeof errors.Timeout, 'undefined', 'has Timeout');
+      assert.notStrictEqual(typeof errors.Timeout, 'undefined', 'has Timeout');
     });
 
     it('Conflict', () => {
-      assert.notEqual(typeof errors.Conflict, 'undefined', 'has Conflict');
+      assert.notStrictEqual(typeof errors.Conflict, 'undefined', 'has Conflict');
     });
 
     it('Length Required', () => {
-      assert.notEqual(typeof errors.LengthRequired, 'undefined', 'has LengthRequired');
+      assert.notStrictEqual(typeof errors.LengthRequired, 'undefined', 'has LengthRequired');
     });
 
     it('Unprocessable', () => {
-      assert.notEqual(typeof errors.Unprocessable, 'undefined', 'has Unprocessable');
+      assert.notStrictEqual(typeof errors.Unprocessable, 'undefined', 'has Unprocessable');
     });
 
     it('Too Many Requests', () => {
-      assert.notEqual(typeof errors.TooManyRequests, 'undefined', 'has TooManyRequests');
+      assert.notStrictEqual(typeof errors.TooManyRequests, 'undefined', 'has TooManyRequests');
     });
 
     it('General Error', () => {
-      assert.notEqual(typeof errors.GeneralError, 'undefined', 'has GeneralError');
+      assert.notStrictEqual(typeof errors.GeneralError, 'undefined', 'has GeneralError');
     });
 
     it('Not Implemented', () => {
-      assert.notEqual(typeof errors.NotImplemented, 'undefined', 'has NotImplemented');
+      assert.notStrictEqual(typeof errors.NotImplemented, 'undefined', 'has NotImplemented');
     });
 
     it('Bad Gateway', () => {
-      assert.notEqual(typeof errors.BadGateway, 'undefined', 'has BadGateway');
+      assert.notStrictEqual(typeof errors.BadGateway, 'undefined', 'has BadGateway');
     });
 
     it('Unavailable', () => {
-      assert.notEqual(typeof errors.Unavailable, 'undefined', 'has Unavailable');
+      assert.notStrictEqual(typeof errors.Unavailable, 'undefined', 'has Unavailable');
     });
 
     it('400', () => {
-      assert.notEqual(typeof errors[400], 'undefined', 'has BadRequest alias');
+      assert.notStrictEqual(typeof errors[400], 'undefined', 'has BadRequest alias');
     });
 
     it('401', () => {
-      assert.notEqual(typeof errors[401], 'undefined', 'has NotAuthenticated alias');
+      assert.notStrictEqual(typeof errors[401], 'undefined', 'has NotAuthenticated alias');
     });
 
     it('402', () => {
-      assert.notEqual(typeof errors[402], 'undefined', 'has PaymentError alias');
+      assert.notStrictEqual(typeof errors[402], 'undefined', 'has PaymentError alias');
     });
 
     it('403', () => {
-      assert.notEqual(typeof errors[403], 'undefined', 'has Forbidden alias');
+      assert.notStrictEqual(typeof errors[403], 'undefined', 'has Forbidden alias');
     });
 
     it('404', () => {
-      assert.notEqual(typeof errors[404], 'undefined', 'has NotFound alias');
+      assert.notStrictEqual(typeof errors[404], 'undefined', 'has NotFound alias');
     });
 
     it('405', () => {
-      assert.notEqual(typeof errors[405], 'undefined', 'has MethodNotAllowed alias');
+      assert.notStrictEqual(typeof errors[405], 'undefined', 'has MethodNotAllowed alias');
     });
 
     it('406', () => {
-      assert.notEqual(typeof errors[406], 'undefined', 'has NotAcceptable alias');
+      assert.notStrictEqual(typeof errors[406], 'undefined', 'has NotAcceptable alias');
     });
 
     it('408', () => {
-      assert.notEqual(typeof errors[408], 'undefined', 'has Timeout alias');
+      assert.notStrictEqual(typeof errors[408], 'undefined', 'has Timeout alias');
     });
 
     it('409', () => {
-      assert.notEqual(typeof errors[409], 'undefined', 'has Conflict alias');
+      assert.notStrictEqual(typeof errors[409], 'undefined', 'has Conflict alias');
     });
 
     it('411', () => {
-      assert.notEqual(typeof errors[411], 'undefined', 'has LengthRequired alias');
+      assert.notStrictEqual(typeof errors[411], 'undefined', 'has LengthRequired alias');
     });
 
     it('422', () => {
-      assert.notEqual(typeof errors[422], 'undefined', 'has Unprocessable alias');
+      assert.notStrictEqual(typeof errors[422], 'undefined', 'has Unprocessable alias');
     });
 
     it('429', () => {
-      assert.notEqual(typeof errors[429], 'undefined', 'has TooManyRequests alias');
+      assert.notStrictEqual(typeof errors[429], 'undefined', 'has TooManyRequests alias');
     });
 
     it('500', () => {
-      assert.notEqual(typeof errors[500], 'undefined', 'has GeneralError alias');
+      assert.notStrictEqual(typeof errors[500], 'undefined', 'has GeneralError alias');
     });
 
     it('501', () => {
-      assert.notEqual(typeof errors[501], 'undefined', 'has NotImplemented alias');
+      assert.notStrictEqual(typeof errors[501], 'undefined', 'has NotImplemented alias');
     });
 
     it('502', () => {
-      assert.notEqual(typeof errors[502], 'undefined', 'has BadGateway alias');
+      assert.notStrictEqual(typeof errors[502], 'undefined', 'has BadGateway alias');
     });
 
     it('503', () => {
-      assert.notEqual(typeof errors[503], 'undefined', 'has Unavailable alias');
+      assert.notStrictEqual(typeof errors[503], 'undefined', 'has Unavailable alias');
     });
 
     it('instantiates every error', () => {
@@ -208,18 +208,18 @@ describe('@feathersjs/errors', () => {
     describe('without custom message', () => {
       it('default error', () => {
         var error = new errors.GeneralError();
-        assert.equal(error.code, 500);
-        assert.equal(error.className, 'general-error');
-        assert.equal(error.message, 'Error');
-        assert.notEqual(error.stack, undefined);
-        assert.equal(error instanceof errors.GeneralError, true);
-        assert.equal(error instanceof errors.FeathersError, true);
+        assert.strictEqual(error.code, 500);
+        assert.strictEqual(error.className, 'general-error');
+        assert.strictEqual(error.message, 'Error');
+        assert.notStrictEqual(error.stack, undefined);
+        assert.strictEqual(error instanceof errors.GeneralError, true);
+        assert.strictEqual(error instanceof errors.FeathersError, true);
       });
 
       it('can wrap an existing error', () => {
         var error = new errors.BadRequest(new Error());
-        assert.equal(error.code, 400);
-        assert.equal(error.message, 'Error');
+        assert.strictEqual(error.code, 400);
+        assert.strictEqual(error.message, 'Error');
       });
 
       it('with multiple errors', () => {
@@ -232,10 +232,10 @@ describe('@feathersjs/errors', () => {
         };
 
         var error = new errors.BadRequest(data);
-        assert.equal(error.code, 400);
-        assert.equal(error.message, 'Error');
-        assert.deepEqual(error.errors, {email: 'Email Taken', password: 'Invalid Password'});
-        assert.deepEqual(error.data, {foo: 'bar'});
+        assert.strictEqual(error.code, 400);
+        assert.strictEqual(error.message, 'Error');
+        assert.deepStrictEqual(error.errors, { email: 'Email Taken', password: 'Invalid Password' });
+        assert.deepStrictEqual(error.data, { foo: 'bar' });
       });
 
       it('with data', () => {
@@ -245,23 +245,23 @@ describe('@feathersjs/errors', () => {
         };
 
         var error = new errors.GeneralError(data);
-        assert.equal(error.code, 500);
-        assert.equal(error.message, 'Error');
-        assert.deepEqual(error.data, data);
+        assert.strictEqual(error.code, 500);
+        assert.strictEqual(error.message, 'Error');
+        assert.deepStrictEqual(error.data, data);
       });
     });
 
     describe('with custom message', () => {
       it('contains our message', () => {
         var error = new errors.BadRequest('Invalid Password');
-        assert.equal(error.code, 400);
-        assert.equal(error.message, 'Invalid Password');
+        assert.strictEqual(error.code, 400);
+        assert.strictEqual(error.message, 'Invalid Password');
       });
 
       it('can wrap an existing error', () => {
         var error = new errors.BadRequest(new Error('Invalid Password'));
-        assert.equal(error.code, 400);
-        assert.equal(error.message, 'Invalid Password');
+        assert.strictEqual(error.code, 400);
+        assert.strictEqual(error.message, 'Invalid Password');
       });
 
       it('with data', () => {
@@ -271,9 +271,9 @@ describe('@feathersjs/errors', () => {
         };
 
         var error = new errors.GeneralError('Custom Error', data);
-        assert.equal(error.code, 500);
-        assert.equal(error.message, 'Custom Error');
-        assert.deepEqual(error.data, data);
+        assert.strictEqual(error.code, 500);
+        assert.strictEqual(error.message, 'Custom Error');
+        assert.deepStrictEqual(error.data, data);
       });
 
       it('with multiple errors', () => {
@@ -286,10 +286,10 @@ describe('@feathersjs/errors', () => {
         };
 
         var error = new errors.BadRequest(data);
-        assert.equal(error.code, 400);
-        assert.equal(error.message, 'Error');
-        assert.deepEqual(error.errors, {email: 'Email Taken', password: 'Invalid Password'});
-        assert.deepEqual(error.data, {foo: 'bar'});
+        assert.strictEqual(error.code, 400);
+        assert.strictEqual(error.message, 'Error');
+        assert.deepStrictEqual(error.errors, { email: 'Email Taken', password: 'Invalid Password' });
+        assert.deepStrictEqual(error.data, { foo: 'bar' });
       });
     });
 
@@ -305,7 +305,7 @@ describe('@feathersjs/errors', () => {
       var expected = '{"name":"GeneralError","message":"Custom Error","code":500,"className":"general-error","data":{"foo":"bar"},"errors":{"email":"Email Taken","password":"Invalid Password"}}';
 
       var error = new errors.GeneralError('Custom Error', data);
-      assert.equal(JSON.stringify(error), expected);
+      assert.strictEqual(JSON.stringify(error), expected);
     });
 
     it('can handle immutable data', () => {
@@ -318,8 +318,8 @@ describe('@feathersjs/errors', () => {
       };
 
       var error = new errors.GeneralError('Custom Error', Object.freeze(data));
-      assert.equal(error.data.errors, undefined);
-      assert.deepEqual(error.data, {foo: 'bar'});
+      assert.strictEqual(error.data.errors, undefined);
+      assert.deepStrictEqual(error.data, { foo: 'bar' });
     });
 
     it('allows arrays as data', () => {
@@ -331,10 +331,10 @@ describe('@feathersjs/errors', () => {
       data.errors = 'Invalid input';
 
       var error = new errors.GeneralError('Custom Error', data);
-      assert.equal(error.data.errors, undefined);
+      assert.strictEqual(error.data.errors, undefined);
       assert.ok(Array.isArray(error.data));
-      assert.deepEqual(error.data, [{hello: 'world'}]);
-      assert.equal(error.errors, 'Invalid input');
+      assert.deepStrictEqual(error.data, [{ hello: 'world' }]);
+      assert.strictEqual(error.errors, 'Invalid input');
     });
 
     it('has proper stack trace (#78)', () => {
@@ -343,7 +343,7 @@ describe('@feathersjs/errors', () => {
       } catch (e) {
         const text = 'NotFound: Not the error you are looking for';
 
-        assert.equal(e.stack.indexOf(text), 0);
+        assert.strictEqual(e.stack.indexOf(text), 0);
 
         assert.ok(e.stack.indexOf('index.test.js') !== -1);
 

--- a/packages/express/test/index.test.js
+++ b/packages/express/test/index.test.js
@@ -16,17 +16,17 @@ describe('@feathersjs/express', () => {
   };
 
   it('exports .default, .original .rest, .notFound and .errorHandler', () => {
-    assert.equal(expressify.default, expressify);
-    assert.equal(expressify.original, express);
-    assert.equal(typeof expressify.rest, 'function');
-    assert.equal(expressify.errorHandler, require('@feathersjs/errors/handler'));
-    assert.equal(expressify.notFound, require('@feathersjs/errors/not-found'));
+    assert.strictEqual(expressify.default, expressify);
+    assert.strictEqual(expressify.original, express);
+    assert.strictEqual(typeof expressify.rest, 'function');
+    assert.strictEqual(expressify.errorHandler, require('@feathersjs/errors/handler'));
+    assert.strictEqual(expressify.notFound, require('@feathersjs/errors/not-found'));
   });
 
   it('returns an Express application', () => {
     const app = expressify(feathers());
 
-    assert.equal(typeof app, 'function');
+    assert.strictEqual(typeof app, 'function');
   });
 
   it('exports `express.rest`', () => {
@@ -36,16 +36,16 @@ describe('@feathersjs/express', () => {
   it('returns a plain express app when no app is provided', () => {
     const app = expressify();
 
-    assert.equal(typeof app.use, 'function');
-    assert.equal(typeof app.service, 'undefined');
-    assert.equal(typeof app.services, 'undefined');
+    assert.strictEqual(typeof app.use, 'function');
+    assert.strictEqual(typeof app.service, 'undefined');
+    assert.strictEqual(typeof app.services, 'undefined');
   });
 
   it('errors when app with wrong version is provided', () => {
     try {
       expressify({});
     } catch (e) {
-      assert.equal(e.message, '@feathersjs/express requires a valid Feathers application instance');
+      assert.strictEqual(e.message, '@feathersjs/express requires a valid Feathers application instance');
     }
 
     try {
@@ -54,7 +54,7 @@ describe('@feathersjs/express', () => {
 
       expressify(app);
     } catch (e) {
-      assert.equal(e.message, '@feathersjs/express requires an instance of a Feathers application version 3.x or later (got 2.9.9)');
+      assert.strictEqual(e.message, '@feathersjs/express requires an instance of a Feathers application version 3.x or later (got 2.9.9)');
     }
 
     try {
@@ -63,7 +63,7 @@ describe('@feathersjs/express', () => {
 
       expressify(app);
     } catch (e) {
-      assert.equal(e.message, '@feathersjs/express requires an instance of a Feathers application version 3.x or later (got unknown)');
+      assert.strictEqual(e.message, '@feathersjs/express requires an instance of a Feathers application version 3.x or later (got unknown)');
     }
   });
 
@@ -72,7 +72,7 @@ describe('@feathersjs/express', () => {
     const child = express();
 
     app.use('/path', child);
-    assert.equal(child.parent, app);
+    assert.strictEqual(child.parent, app);
   });
 
   it('Can use express.static', () => {
@@ -103,7 +103,7 @@ describe('@feathersjs/express', () => {
     });
 
     return app.service('myservice').get(10)
-      .then(data => assert.deepEqual(data, {
+      .then(data => assert.deepStrictEqual(data, {
         id: 10,
         fromHook: true,
         fromAppHook: true
@@ -121,9 +121,9 @@ describe('@feathersjs/express', () => {
 
     const server = app.listen(8787).on('listening', () => {
       app.service('myservice').get(10)
-        .then(data => assert.deepEqual(data, { id: 10 }))
+        .then(data => assert.deepStrictEqual(data, { id: 10 }))
         .then(() => axios.get('http://localhost:8787'))
-        .then(res => assert.deepEqual(res.data, response))
+        .then(res => assert.deepStrictEqual(res.data, response))
         .then(() => server.close(() => done()))
         .catch(done);
     });
@@ -140,8 +140,8 @@ describe('@feathersjs/express', () => {
 
       setup (appParam, path) {
         try {
-          assert.equal(appParam, app);
-          assert.equal(path, 'myservice');
+          assert.strictEqual(appParam, app);
+          assert.strictEqual(path, 'myservice');
           called = true;
         } catch (e) {
           done(e);
@@ -173,9 +173,9 @@ describe('@feathersjs/express', () => {
     };
 
     feathersApp.use = function (path, serviceArg, options) {
-      assert.equal(path, '/myservice');
-      assert.equal(serviceArg, service);
-      assert.deepEqual(options.middleware, {
+      assert.strictEqual(path, '/myservice');
+      assert.strictEqual(serviceArg, service);
+      assert.deepStrictEqual(options.middleware, {
         before: [a, b],
         after: [c]
       });
@@ -197,7 +197,7 @@ describe('@feathersjs/express', () => {
     try {
       app.use('/myservice', service, 'hi');
     } catch (e) {
-      assert.equal(e.message, 'Invalid options passed to app.use');
+      assert.strictEqual(e.message, 'Invalid options passed to app.use');
     }
   });
 
@@ -233,7 +233,7 @@ describe('@feathersjs/express', () => {
 
       instance.get('https://localhost:7889/secureTodos/dishes').then(response => {
         assert.ok(response.status === 200, 'Got OK status code');
-        assert.equal(response.data.description, 'You have to do dishes!');
+        assert.strictEqual(response.data.description, 'You have to do dishes!');
         httpsServer.close(() => done());
       }).catch(done);
     });

--- a/packages/express/test/rest/crud.js
+++ b/packages/express/test/rest/crud.js
@@ -40,7 +40,7 @@ module.exports = function crud (description, name) {
       return axios.put('http://localhost:4777/todo/544', original)
         .then(res => {
           assert.ok(res.status === 200, 'Got OK status code');
-          verify.update(544, original, res.data);
+          verify.update('544', original, res.data);
         });
     });
 
@@ -66,7 +66,7 @@ module.exports = function crud (description, name) {
       return axios.patch('http://localhost:4777/todo/544', original)
         .then(res => {
           assert.ok(res.status === 200, 'Got OK status code');
-          verify.patch(544, original, res.data);
+          verify.patch('544', original, res.data);
         });
     });
 
@@ -87,7 +87,7 @@ module.exports = function crud (description, name) {
       return axios.delete('http://localhost:4777/tasks/233')
         .then(res => {
           assert.ok(res.status === 200, 'Got OK status code');
-          verify.remove(233, res.data);
+          verify.remove('233', res.data);
         });
     });
 

--- a/packages/express/test/rest/index.test.js
+++ b/packages/express/test/rest/index.test.js
@@ -18,7 +18,7 @@ describe('@feathersjs/express/rest provider', () => {
         app.configure(rest());
         assert.ok(false, 'Should never get here');
       } catch (e) {
-        assert.equal(e.message, '@feathersjs/express/rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
+        assert.strictEqual(e.message, '@feathersjs/express/rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
       }
     });
 
@@ -31,7 +31,7 @@ describe('@feathersjs/express/rest provider', () => {
 
         assert.ok(false, 'Should never get here');
       } catch (e) {
-        assert.equal(e.message, '@feathersjs/express/rest requires an instance of a Feathers application version 3.x or later (got 2.9.9)');
+        assert.strictEqual(e.message, '@feathersjs/express/rest requires an instance of a Feathers application version 3.x or later (got 2.9.9)');
       }
     });
 
@@ -58,7 +58,7 @@ describe('@feathersjs/express/rest provider', () => {
 
       return axios.get('http://localhost:4776/todo/dishes')
         .then(res => {
-          assert.equal(res.data, 'The todo is: You have to do dishes');
+          assert.strictEqual(res.data, 'The todo is: You have to do dishes');
         })
         .then(() => server.close());
     });
@@ -80,7 +80,7 @@ describe('@feathersjs/express/rest provider', () => {
       let server = app.listen(5775);
 
       return axios.get('http://localhost:5775/todo-handler/dishes')
-        .then(res => assert.deepEqual(res.data, data))
+        .then(res => assert.deepStrictEqual(res.data, data))
         .then(() => server.close());
     });
   });
@@ -149,7 +149,7 @@ describe('@feathersjs/express/rest provider', () => {
 
         return axios.get('http://localhost:4777/hook/dishes?test=param')
           .then(res => {
-            assert.deepEqual(res.data, {
+            assert.deepStrictEqual(res.data, {
               id: 'dishes',
               params,
               arguments: [
@@ -183,7 +183,7 @@ describe('@feathersjs/express/rest provider', () => {
 
         return axios.get('http://localhost:4777/hook-dispatch/dishes')
           .then(res => {
-            assert.deepEqual(res.data, {
+            assert.deepStrictEqual(res.data, {
               id: 'dishes',
               fromDispatch: true
             });
@@ -204,7 +204,7 @@ describe('@feathersjs/express/rest provider', () => {
         });
 
         return axios.get('http://localhost:4777/hook-status/dishes')
-          .then(res => assert.equal(res.status, 206));
+          .then(res => assert.strictEqual(res.status, 206));
       });
 
       it('sets the hook object in res.hook on error', () => {
@@ -230,7 +230,7 @@ describe('@feathersjs/express/rest provider', () => {
 
         return axios('http://localhost:4777/hook-error/dishes')
           .catch(error => {
-            assert.deepEqual(error.response.data, {
+            assert.deepStrictEqual(error.response.data, {
               hook: {
                 id: 'dishes',
                 params,
@@ -277,7 +277,7 @@ describe('@feathersjs/express/rest provider', () => {
           };
 
           assert.ok(res.status === 200, 'Got OK status code');
-          assert.deepEqual(res.data, expected, 'Got params object back');
+          assert.deepStrictEqual(res.data, expected, 'Got params object back');
         })
         .then(() => server.close());
     });
@@ -313,7 +313,7 @@ describe('@feathersjs/express/rest provider', () => {
 
       return axios(options)
         .then(res => {
-          assert.deepEqual(res.data, data);
+          assert.deepStrictEqual(res.data, data);
           server.close();
         });
     });
@@ -345,7 +345,7 @@ describe('@feathersjs/express/rest provider', () => {
 
       return axios.post('http://localhost:4776/todo', { text: 'Do dishes' })
         .then(res => {
-          assert.deepEqual(res.data, {
+          assert.deepStrictEqual(res.data, {
             text: 'Do dishes',
             before: [ 'before first', 'before second' ],
             after: [ 'after first', 'after second' ]
@@ -373,9 +373,9 @@ describe('@feathersjs/express/rest provider', () => {
 
       const server = app.listen(4776);
 
-      return axios.post('http://localhost:4776/array-middleware', {text: 'Do dishes'})
+      return axios.post('http://localhost:4776/array-middleware', { text: 'Do dishes' })
         .then(res => {
-          assert.deepEqual(res.data, ['first', 'second', 'Do dishes']);
+          assert.deepStrictEqual(res.data, ['first', 'second', 'Do dishes']);
         })
         .then(() => server.close());
     });
@@ -390,7 +390,7 @@ describe('@feathersjs/express/rest provider', () => {
       const server = app.listen(7988);
 
       return axios.get('http://localhost:7988/test')
-        .then(res => assert.deepEqual(res.data, data))
+        .then(res => assert.deepStrictEqual(res.data, data))
         .then(() => server.close());
     });
   });
@@ -443,16 +443,16 @@ describe('@feathersjs/express/rest provider', () => {
       return axios.get('http://localhost:4780/todo/dishes')
         .then(res => {
           assert.ok(res.status === 200, 'Got OK status code for .get');
-          assert.deepEqual(res.data, {
+          assert.deepStrictEqual(res.data, {
             description: 'You have to do dishes'
           }, 'Got expected object');
 
           return axios.post('http://localhost:4780/todo');
         })
         .catch(error => {
-          assert.equal(error.response.headers.allow, 'GET,PATCH');
+          assert.strictEqual(error.response.headers.allow, 'GET,PATCH');
           assert.ok(error.response.status === 405, 'Got 405 for .create');
-          assert.deepEqual(error.response.data, {
+          assert.deepStrictEqual(error.response.data, {
             message: 'Method `create` is not supported by this endpoint.'
           }, 'Error serialized as expected');
         });
@@ -505,7 +505,7 @@ describe('@feathersjs/express/rest provider', () => {
       return axios.get(`http://localhost:6880/theApp/myId/todo/${expected.id}`)
         .then(res => {
           assert.ok(res.status === 200, 'Got OK status code');
-          assert.deepEqual(expected, res.data);
+          assert.deepStrictEqual(expected, res.data);
         });
     });
   });

--- a/packages/feathers/test/application.test.js
+++ b/packages/feathers/test/application.test.js
@@ -5,26 +5,26 @@ const feathers = require('../lib');
 
 describe('Feathers application', () => {
   it('adds an ES module `default` export', () => {
-    assert.equal(feathers, feathers.default);
+    assert.strictEqual(feathers, feathers.default);
   });
 
   it('initializes', () => {
     const app = feathers();
 
-    assert.equal(typeof app.use, 'function');
-    assert.equal(typeof app.service, 'function');
-    assert.equal(typeof app.services, 'object');
+    assert.strictEqual(typeof app.use, 'function');
+    assert.strictEqual(typeof app.service, 'function');
+    assert.strictEqual(typeof app.services, 'object');
   });
 
   it('sets the version on main and app instance', () => {
     const app = feathers();
 
-    assert.equal(feathers.version, '3.0.0-development');
-    assert.equal(app.version, '3.0.0-development');
+    assert.strictEqual(feathers.version, '3.0.0-development');
+    assert.strictEqual(app.version, '3.0.0-development');
   });
 
   it('sets SKIP on main', () => {
-    assert.equal(feathers.SKIP, hooks.SKIP);
+    assert.strictEqual(feathers.SKIP, hooks.SKIP);
   });
 
   it('is an event emitter', done => {
@@ -32,7 +32,7 @@ describe('Feathers application', () => {
     const original = { hello: 'world' };
 
     app.on('test', data => {
-      assert.deepEqual(original, data);
+      assert.deepStrictEqual(original, data);
       done();
     });
 
@@ -45,7 +45,7 @@ describe('Feathers application', () => {
     try {
       app.service('/test', {});
     } catch (e) {
-      assert.equal(e.message, 'Registering a new service with `app.service(path, service)` is no longer supported. Use `app.use(path, service)` instead.');
+      assert.strictEqual(e.message, 'Registering a new service with `app.service(path, service)` is no longer supported. Use `app.use(path, service)` instead.');
     }
   });
 
@@ -55,7 +55,7 @@ describe('Feathers application', () => {
     assert.ok(!app.service('/todos/'));
 
     app.defaultService = function (path) {
-      assert.equal(path, 'todos');
+      assert.strictEqual(path, 'todos');
       return {
         get (id) {
           return Promise.resolve({
@@ -66,7 +66,7 @@ describe('Feathers application', () => {
     };
 
     return app.service('/todos/').get('dishes').then(data => {
-      assert.deepEqual(data, {
+      assert.deepStrictEqual(data, {
         id: 'dishes',
         description: 'You have to do dishes!'
       });
@@ -75,7 +75,7 @@ describe('Feathers application', () => {
 
   it('additionally passes `app` as .configure parameter (#558)', done => {
     feathers().configure(function (app) {
-      assert.equal(this, app);
+      assert.strictEqual(this, app);
       done();
     });
   });
@@ -87,19 +87,19 @@ describe('Feathers application', () => {
       try {
         app.use('/', {});
       } catch (e) {
-        assert.equal(e.message, `'/' is not a valid service path.`);
+        assert.strictEqual(e.message, `'/' is not a valid service path.`);
       }
 
       try {
         app.use('', {});
       } catch (e) {
-        assert.equal(e.message, `'' is not a valid service path.`);
+        assert.strictEqual(e.message, `'' is not a valid service path.`);
       }
 
       try {
         app.use({}, {});
       } catch (e) {
-        assert.equal(e.message, `'[object Object]' is not a valid service path.`);
+        assert.strictEqual(e.message, `'[object Object]' is not a valid service path.`);
       }
     });
 
@@ -110,7 +110,7 @@ describe('Feathers application', () => {
         app.use('/bla', function () {});
         assert.ok(false, 'Should never get here');
       } catch (e) {
-        assert.equal(e.message, 'Invalid service object passed for path `bla`');
+        assert.strictEqual(e.message, 'Invalid service object passed for path `bla`');
       }
     });
 
@@ -132,7 +132,7 @@ describe('Feathers application', () => {
 
       return wrappedService.create({
         message: 'Test message'
-      }).then(data => assert.equal(data.message, 'Test message'));
+      }).then(data => assert.strictEqual(data.message, 'Test message'));
     });
 
     it('services can be re-used (#566)', done => {
@@ -156,7 +156,7 @@ describe('Feathers application', () => {
       });
 
       dummy.on('created', data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           message: 'Hi',
           fromHook: true
         });
@@ -215,17 +215,17 @@ describe('Feathers application', () => {
       it('should set a value', () => {
         var app = feathers();
         app.set('foo', 'bar');
-        assert.equal(app.get('foo'), 'bar');
+        assert.strictEqual(app.get('foo'), 'bar');
       });
 
       it('should return the app', () => {
         var app = feathers();
-        assert.equal(app.set('foo', 'bar'), app);
+        assert.strictEqual(app.set('foo', 'bar'), app);
       });
 
       it('should return the app when undefined', () => {
         var app = feathers();
-        assert.equal(app.set('foo', undefined), app);
+        assert.strictEqual(app.set('foo', undefined), app);
       });
     });
 
@@ -238,14 +238,14 @@ describe('Feathers application', () => {
       it('should otherwise return the value', () => {
         var app = feathers();
         app.set('foo', 'bar');
-        assert.equal(app.get('foo'), 'bar');
+        assert.strictEqual(app.get('foo'), 'bar');
       });
     });
 
     describe('.enable()', () => {
       it('should set the value to true', () => {
         var app = feathers();
-        assert.equal(app.enable('tobi'), app);
+        assert.strictEqual(app.enable('tobi'), app);
         assert.strictEqual(app.get('tobi'), true);
       });
     });
@@ -253,7 +253,7 @@ describe('Feathers application', () => {
     describe('.disable()', () => {
       it('should set the value to false', () => {
         var app = feathers();
-        assert.equal(app.disable('tobi'), app);
+        assert.strictEqual(app.disable('tobi'), app);
         assert.strictEqual(app.get('tobi'), false);
       });
     });
@@ -293,8 +293,8 @@ describe('Feathers application', () => {
       app.use('/dummy', {
         setup (appRef, path) {
           setupCount++;
-          assert.equal(appRef, app);
-          assert.equal(path, 'dummy');
+          assert.strictEqual(appRef, app);
+          assert.strictEqual(path, 'dummy');
         }
       });
 
@@ -307,15 +307,15 @@ describe('Feathers application', () => {
       app.use('/dummy2', {
         setup (appRef, path) {
           setupCount++;
-          assert.equal(appRef, app);
-          assert.equal(path, 'dummy2');
+          assert.strictEqual(appRef, app);
+          assert.strictEqual(path, 'dummy2');
         }
       });
 
       app.setup();
 
       assert.ok(app._isSetup);
-      assert.equal(setupCount, 2);
+      assert.strictEqual(setupCount, 2);
     });
 
     it('registering a service after app.setup will be set up', () => {
@@ -326,8 +326,8 @@ describe('Feathers application', () => {
       app.use('/dummy', {
         setup (appRef, path) {
           assert.ok(app._isSetup);
-          assert.equal(appRef, app);
-          assert.equal(path, 'dummy');
+          assert.strictEqual(appRef, app);
+          assert.strictEqual(path, 'dummy');
         }
       });
     });
@@ -340,8 +340,8 @@ describe('Feathers application', () => {
         get () {},
         _setup (appRef, path) {
           _setup = true;
-          assert.equal(appRef, app);
-          assert.equal(path, 'dummy');
+          assert.strictEqual(appRef, app);
+          assert.strictEqual(path, 'dummy');
         }
       });
 
@@ -356,8 +356,8 @@ describe('Feathers application', () => {
 
       app.providers.push(function (service, location, options) {
         assert.ok(service.dummy);
-        assert.equal(location, 'dummy');
-        assert.deepEqual(options, {});
+        assert.strictEqual(location, 'dummy');
+        assert.deepStrictEqual(options, {});
         providerRan = true;
       });
 
@@ -379,8 +379,8 @@ describe('Feathers application', () => {
 
       app.providers.push(function (service, location, options) {
         assert.ok(service.dummy);
-        assert.equal(location, 'dummy');
-        assert.deepEqual(options, opts);
+        assert.strictEqual(location, 'dummy');
+        assert.deepStrictEqual(options, opts);
         providerRan = true;
       });
 
@@ -421,12 +421,12 @@ describe('Feathers application', () => {
       app.use('/api/', subApp);
 
       app.service('/api/service2').once('created', data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           message: 'This is a test'
         });
 
         subApp.service('service2').once('created', data => {
-          assert.deepEqual(data, {
+          assert.deepStrictEqual(data, {
             message: 'This is another test'
           });
 
@@ -439,11 +439,11 @@ describe('Feathers application', () => {
       });
 
       app.service('/api/service1').get(10).then(data => {
-        assert.equal(data.name, 'service1');
+        assert.strictEqual(data.name, 'service1');
 
         return app.service('/api/service2').get(1);
       }).then(data => {
-        assert.equal(data.name, 'service2');
+        assert.strictEqual(data.name, 'service2');
 
         return subApp.service('service2').create({
           message: 'This is a test'

--- a/packages/feathers/test/events.test.js
+++ b/packages/feathers/test/events.test.js
@@ -7,10 +7,10 @@ describe('Service events', () => {
   it('app is an event emitter', done => {
     const app = feathers();
 
-    assert.equal(typeof app.on, 'function');
+    assert.strictEqual(typeof app.on, 'function');
 
     app.on('test', data => {
-      assert.deepEqual(data, { message: 'app' });
+      assert.deepStrictEqual(data, { message: 'app' });
       done();
     });
     app.emit('test', { message: 'app' });
@@ -25,7 +25,7 @@ describe('Service events', () => {
     };
 
     service.on('created', data => {
-      assert.deepEqual(data, {
+      assert.deepStrictEqual(data, {
         message: 'testing'
       });
       done();
@@ -49,7 +49,7 @@ describe('Service events', () => {
       const service = app.service('creator');
 
       service.on('created', data => {
-        assert.deepEqual(data, { message: 'Hello' });
+        assert.deepStrictEqual(data, { message: 'Hello' });
         done();
       });
 
@@ -66,7 +66,7 @@ describe('Service events', () => {
       const service = app.service('creator');
 
       service.on('updated', data => {
-        assert.deepEqual(data, { id: 10, message: 'Hello' });
+        assert.deepStrictEqual(data, { id: 10, message: 'Hello' });
         done();
       });
 
@@ -83,7 +83,7 @@ describe('Service events', () => {
       const service = app.service('creator');
 
       service.on('patched', data => {
-        assert.deepEqual(data, { id: 12, message: 'Hello' });
+        assert.deepStrictEqual(data, { id: 12, message: 'Hello' });
         done();
       });
 
@@ -100,7 +100,7 @@ describe('Service events', () => {
       const service = app.service('creator');
 
       service.on('removed', data => {
-        assert.deepEqual(data, { id: 22 });
+        assert.deepStrictEqual(data, { id: 22 });
         done();
       });
 
@@ -130,7 +130,7 @@ describe('Service events', () => {
         return new Promise((resolve, reject) => {
           service.on('created', data => {
             if (data.message === element.message) {
-              assert.deepEqual(data, { message: `Hello ${index}` });
+              assert.deepStrictEqual(data, { message: `Hello ${index}` });
               resolve();
             }
           });
@@ -160,7 +160,7 @@ describe('Service events', () => {
         return new Promise((resolve, reject) => {
           service.on('updated', data => {
             if (data.message === element.message) {
-              assert.deepEqual(data, { id: index, message: `Hello ${index}` });
+              assert.deepStrictEqual(data, { id: index, message: `Hello ${index}` });
               resolve();
             }
           });
@@ -190,7 +190,7 @@ describe('Service events', () => {
         return new Promise((resolve, reject) => {
           service.on('patched', data => {
             if (data.message === element.message) {
-              assert.deepEqual(data, { id: index, message: `Hello ${index}` });
+              assert.deepStrictEqual(data, { id: index, message: `Hello ${index}` });
               resolve();
             }
           });
@@ -220,7 +220,7 @@ describe('Service events', () => {
         return new Promise((resolve, reject) => {
           service.on('removed', data => {
             if (data.message === element.message) {
-              assert.deepEqual(data, { id: index, message: `Hello ${index}` });
+              assert.deepStrictEqual(data, { id: index, message: `Hello ${index}` });
               resolve();
             }
           });
@@ -248,11 +248,11 @@ describe('Service events', () => {
       });
 
       service.on('created', (data, hook) => {
-        assert.deepEqual(data, { message: 'Hi' });
+        assert.deepStrictEqual(data, { message: 'Hi' });
         assert.ok(hook.changed);
-        assert.equal(hook.service, service);
-        assert.equal(hook.method, 'create');
-        assert.equal(hook.type, 'after');
+        assert.strictEqual(hook.service, service);
+        assert.strictEqual(hook.method, 'create');
+        assert.strictEqual(hook.type, 'after');
         done();
       });
 
@@ -270,7 +270,7 @@ describe('Service events', () => {
       const service = app.service('creator');
 
       service.on('created', data => {
-        assert.deepEqual(data, { message: 'custom event' });
+        assert.deepStrictEqual(data, { message: 'custom event' });
         done();
       });
 

--- a/packages/feathers/test/hooks/after.test.js
+++ b/packages/feathers/test/hooks/after.test.js
@@ -20,7 +20,7 @@ describe('`after` hooks', () => {
       });
 
       return service.get(10).catch(e => {
-        assert.equal(e.message, 'after hook for \'get\' method returned invalid hook object');
+        assert.strictEqual(e.message, 'after hook for \'get\' method returned invalid hook object');
       });
     });
 
@@ -53,7 +53,7 @@ describe('`after` hooks', () => {
       });
 
       return service.get('laundry', {}).then(data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           id: 'laundry',
           description: 'You have to do laundry',
           ran: true
@@ -62,7 +62,7 @@ describe('`after` hooks', () => {
         return service.find({}).then(() => {
           throw new Error('Should never get here');
         }).catch(error => {
-          assert.equal(error.message, 'You can not see this');
+          assert.strictEqual(error.message, 'You can not see this');
         });
       });
     });
@@ -94,14 +94,14 @@ describe('`after` hooks', () => {
       });
 
       return service.get('laundry').then(data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           id: 'laundry',
           description: 'You have to do laundry',
           ran: true
         });
 
         return service.find().catch(error => {
-          assert.equal(error.message, 'You can not see this');
+          assert.strictEqual(error.message, 'You can not see this');
         });
       });
     });
@@ -121,7 +121,7 @@ describe('`after` hooks', () => {
       service.hooks({
         after: {
           create (hook, next) {
-            assert.equal(hook.type, 'after');
+            assert.strictEqual(hook.type, 'after');
 
             hook.result.some = 'thing';
 
@@ -131,7 +131,7 @@ describe('`after` hooks', () => {
       });
 
       return service.create({ my: 'data' }).then(data => {
-        assert.deepEqual({ my: 'data', some: 'thing' }, data, 'Got modified data');
+        assert.deepStrictEqual({ my: 'data', some: 'thing' }, data, 'Got modified data');
       });
     });
 
@@ -149,7 +149,7 @@ describe('`after` hooks', () => {
         after: {
           create (hook, next) {
             hook.result.appPresent = typeof hook.app !== 'undefined';
-            assert.equal(hook.result.appPresent, true);
+            assert.strictEqual(hook.result.appPresent, true);
 
             next(null, hook);
           }
@@ -157,7 +157,7 @@ describe('`after` hooks', () => {
       });
 
       return service.create({ my: 'data' }).then(data => {
-        assert.deepEqual({ my: 'data', appPresent: true }, data, 'The app was present in the hook.');
+        assert.deepStrictEqual({ my: 'data', appPresent: true }, data, 'The app was present in the hook.');
       });
     });
 
@@ -181,7 +181,7 @@ describe('`after` hooks', () => {
 
       return service.update(1, { my: 'data' }).catch(error => {
         assert.ok(error, 'Got an error');
-        assert.equal(error.message, 'This did not work', 'Got expected error message from hook');
+        assert.strictEqual(error.message, 'This did not work', 'Got expected error message from hook');
       });
     });
 
@@ -205,7 +205,7 @@ describe('`after` hooks', () => {
 
       return service.remove(1, {}).catch(error => {
         assert.ok(error, 'Got error');
-        assert.equal(error.message, 'Error removing item', 'Got error message from service');
+        assert.strictEqual(error.message, 'Error removing item', 'Got error message from service');
       });
     });
 
@@ -239,7 +239,7 @@ describe('`after` hooks', () => {
       });
 
       service.create({ my: 'data' }).then(data => {
-        assert.deepEqual({
+        assert.deepStrictEqual({
           my: 'data',
           some: 'thing',
           other: 'stuff'
@@ -274,7 +274,7 @@ describe('`after` hooks', () => {
       });
 
       return service.create({ my: 'data' }).then(data => {
-        assert.deepEqual({
+        assert.deepStrictEqual({
           my: 'data',
           some: 'thing',
           other: 'stuff'
@@ -316,7 +316,7 @@ describe('`after` hooks', () => {
       });
 
       service.get(10).then(data => {
-        assert.deepEqual(data.items, ['first', 'second', 'third']);
+        assert.deepStrictEqual(data.items, ['first', 'second', 'third']);
       });
     });
 
@@ -388,7 +388,7 @@ describe('`after` hooks', () => {
       });
 
       service.get(10).then(data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           id: 10,
           number: 42,
           test: 43

--- a/packages/feathers/test/hooks/app.test.js
+++ b/packages/feathers/test/hooks/app.test.js
@@ -22,7 +22,7 @@ describe('app.hooks', () => {
   });
 
   it('app has the .hooks method', () => {
-    assert.equal(typeof app.hooks, 'function');
+    assert.strictEqual(typeof app.hooks, 'function');
   });
 
   describe('app.hooks({ before })', () => {
@@ -31,13 +31,13 @@ describe('app.hooks', () => {
 
       app.hooks({
         before (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.params.ran = true;
         }
       });
 
       return service.get('test').then(result => {
-        assert.deepEqual(result, {
+        assert.deepStrictEqual(result, {
           id: 'test',
           params: { ran: true }
         });
@@ -45,7 +45,7 @@ describe('app.hooks', () => {
         const data = { test: 'hi' };
 
         return service.create(data).then(result => {
-          assert.deepEqual(result, {
+          assert.deepStrictEqual(result, {
             data, params: { ran: true }
           });
         });
@@ -55,28 +55,28 @@ describe('app.hooks', () => {
     it('app before hooks always run first', () => {
       app.service('todos').hooks({
         before (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.params.order.push('service.before');
         }
       });
 
       app.service('todos').hooks({
         before (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.params.order.push('service.before 1');
         }
       });
 
       app.hooks({
         before (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.params.order = [];
           hook.params.order.push('app.before');
         }
       });
 
       return app.service('todos').get('test').then(result => {
-        assert.deepEqual(result, {
+        assert.deepStrictEqual(result, {
           id: 'test',
           params: {
             order: [ 'app.before', 'service.before', 'service.before 1' ]
@@ -90,13 +90,13 @@ describe('app.hooks', () => {
     it('basic app after hook', () => {
       app.hooks({
         after (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.result.ran = true;
         }
       });
 
       return app.service('todos').get('test').then(result => {
-        assert.deepEqual(result, {
+        assert.deepStrictEqual(result, {
           id: 'test',
           params: {},
           ran: true
@@ -107,14 +107,14 @@ describe('app.hooks', () => {
     it('app after hooks always run last', () => {
       app.hooks({
         after (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.result.order.push('app.after');
         }
       });
 
       app.service('todos').hooks({
         after (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.result.order = [];
           hook.result.order.push('service.after');
         }
@@ -122,13 +122,13 @@ describe('app.hooks', () => {
 
       app.service('todos').hooks({
         after (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.result.order.push('service.after 1');
         }
       });
 
       return app.service('todos').get('test').then(result => {
-        assert.deepEqual(result, {
+        assert.deepStrictEqual(result, {
           id: 'test',
           params: {},
           order: [ 'service.after', 'service.after 1', 'app.after' ]
@@ -141,40 +141,40 @@ describe('app.hooks', () => {
     it('basic app error hook', () => {
       app.hooks({
         error (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.error = new Error('App hook ran');
         }
       });
 
       return app.service('todos').get('error').catch(error => {
-        assert.equal(error.message, 'App hook ran');
+        assert.strictEqual(error.message, 'App hook ran');
       });
     });
 
     it('app error hooks always run last', () => {
       app.hooks({
         error (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.error = new Error(`${hook.error.message} app.after`);
         }
       });
 
       app.service('todos').hooks({
         error (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.error = new Error(`${hook.error.message} service.after`);
         }
       });
 
       app.service('todos').hooks({
         error (hook) {
-          assert.equal(hook.app, app);
+          assert.strictEqual(hook.app, app);
           hook.error = new Error(`${hook.error.message} service.after 1`);
         }
       });
 
       return app.service('todos').get('error').catch(error => {
-        assert.equal(error.message, 'Something went wrong service.after service.after 1 app.after');
+        assert.strictEqual(error.message, 'Something went wrong service.after service.after 1 app.after');
       });
     });
   });

--- a/packages/feathers/test/hooks/before.test.js
+++ b/packages/feathers/test/hooks/before.test.js
@@ -20,7 +20,7 @@ describe('`before` hooks', () => {
       });
 
       return service.get(10).catch(e => {
-        assert.equal(e.message, 'before hook for \'get\' method returned invalid hook object');
+        assert.strictEqual(e.message, 'before hook for \'get\' method returned invalid hook object');
       });
     });
 
@@ -90,7 +90,7 @@ describe('`before` hooks', () => {
 
       return service.get('dishes').then(() => service.remove(10))
         .catch(error => {
-          assert.equal(error.message, 'This did not work');
+          assert.strictEqual(error.message, 'This did not work');
         });
     });
 
@@ -126,7 +126,7 @@ describe('`before` hooks', () => {
 
       return service.get('dishes').then(() => service.remove(10))
         .catch(error => {
-          assert.equal(error.message, 'This did not work');
+          assert.strictEqual(error.message, 'This did not work');
         });
     });
 
@@ -152,7 +152,7 @@ describe('`before` hooks', () => {
       });
 
       return service.get(10, {}).then(data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           id: 10,
           message: 'Set from hook'
         });
@@ -164,12 +164,12 @@ describe('`before` hooks', () => {
     it('gets mixed into a service and modifies data', () => {
       const dummyService = {
         create (data, params) {
-          assert.deepEqual(data, {
+          assert.deepStrictEqual(data, {
             some: 'thing',
             modified: 'data'
           }, 'Data modified');
 
-          assert.deepEqual(params, {
+          assert.deepStrictEqual(params, {
             modified: 'params'
           }, 'Params modified');
 
@@ -183,7 +183,7 @@ describe('`before` hooks', () => {
       service.hooks({
         before: {
           create (hook, next) {
-            assert.equal(hook.type, 'before');
+            assert.strictEqual(hook.type, 'before');
 
             hook.data.modified = 'data';
 
@@ -197,7 +197,7 @@ describe('`before` hooks', () => {
       });
 
       return service.create({ some: 'thing' }).then(data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           some: 'thing',
           modified: 'data'
         }, 'Data got modified');
@@ -218,14 +218,14 @@ describe('`before` hooks', () => {
         before: {
           create (hook, next) {
             hook.data.appPresent = typeof hook.app !== 'undefined';
-            assert.equal(hook.data.appPresent, true);
+            assert.strictEqual(hook.data.appPresent, true);
             next(null, hook);
           }
         }
       });
 
       return someService.create({ some: 'thing' }).then(data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           some: 'thing',
           appPresent: true
         }, 'App object was present');
@@ -252,15 +252,15 @@ describe('`before` hooks', () => {
 
       return service.update(1, {}).catch(error => {
         assert.ok(error, 'Got an error');
-        assert.equal(error.message, 'You are not allowed to update', 'Got error message');
+        assert.strictEqual(error.message, 'You are not allowed to update', 'Got error message');
       });
     });
 
     it('calling back with no arguments uses the old ones', () => {
       const dummyService = {
         remove (id, params) {
-          assert.equal(id, 1, 'Got id');
-          assert.deepEqual(params, { my: 'param' });
+          assert.strictEqual(id, 1, 'Got id');
+          assert.deepStrictEqual(params, { my: 'param' });
 
           return Promise.resolve({ id });
         }
@@ -283,12 +283,12 @@ describe('`before` hooks', () => {
     it('adds .hooks() and chains multiple hooks for the same method', () => {
       const dummyService = {
         create (data, params) {
-          assert.deepEqual(data, {
+          assert.deepStrictEqual(data, {
             some: 'thing',
             modified: 'second data'
           }, 'Data modified');
 
-          assert.deepEqual(params, {
+          assert.deepStrictEqual(params, {
             modified: 'params'
           }, 'Params modified');
 
@@ -325,12 +325,12 @@ describe('`before` hooks', () => {
     it('chains multiple before hooks using array syntax', () => {
       const dummyService = {
         create (data, params) {
-          assert.deepEqual(data, {
+          assert.deepStrictEqual(data, {
             some: 'thing',
             modified: 'second data'
           }, 'Data modified');
 
-          assert.deepEqual(params, {
+          assert.deepStrictEqual(params, {
             modified: 'params'
           }, 'Params modified');
 
@@ -364,7 +364,7 @@ describe('`before` hooks', () => {
     it('.before hooks run in the correct order (#13)', () => {
       const app = feathers().use('/dummy', {
         get (id, params, callback) {
-          assert.deepEqual(params.items, ['first', 'second', 'third']);
+          assert.deepStrictEqual(params.items, ['first', 'second', 'third']);
 
           return Promise.resolve({
             id: id,
@@ -469,7 +469,7 @@ describe('`before` hooks', () => {
       });
 
       return service.get(10).then(data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           id: 10,
           number: 42,
           test: 44
@@ -502,7 +502,7 @@ describe('`before` hooks', () => {
       });
 
       return service.get(10).then(data => {
-        assert.deepEqual(data, { id: 10 });
+        assert.deepStrictEqual(data, { id: 10 });
       });
     });
   });

--- a/packages/feathers/test/hooks/error.test.js
+++ b/packages/feathers/test/hooks/error.test.js
@@ -17,11 +17,11 @@ describe('`error` hooks', () => {
       service.hooks({
         error: {
           get (hook) {
-            assert.equal(hook.type, 'error');
-            assert.equal(hook.id, 'test');
-            assert.equal(hook.method, 'get');
-            assert.equal(hook.app, app);
-            assert.equal(hook.error.message, 'Something went wrong');
+            assert.strictEqual(hook.type, 'error');
+            assert.strictEqual(hook.id, 'test');
+            assert.strictEqual(hook.method, 'get');
+            assert.strictEqual(hook.app, app);
+            assert.strictEqual(hook.error.message, 'Something went wrong');
           }
         }
       });
@@ -41,7 +41,7 @@ describe('`error` hooks', () => {
       });
 
       return service.get('test').catch(error => {
-        assert.equal(error.message, errorMessage);
+        assert.strictEqual(error.message, errorMessage);
       });
     });
 
@@ -55,7 +55,7 @@ describe('`error` hooks', () => {
       });
 
       return service.get('test').catch(error => {
-        assert.equal(error.message, errorMessage);
+        assert.strictEqual(error.message, errorMessage);
       });
     });
 
@@ -69,7 +69,7 @@ describe('`error` hooks', () => {
       });
 
       return service.get('test').catch(error => {
-        assert.equal(error.message, errorMessage);
+        assert.strictEqual(error.message, errorMessage);
       });
     });
 
@@ -83,7 +83,7 @@ describe('`error` hooks', () => {
       });
 
       return service.get('test').catch(error => {
-        assert.equal(error.message, errorMessage);
+        assert.strictEqual(error.message, errorMessage);
       });
     });
 
@@ -112,7 +112,7 @@ describe('`error` hooks', () => {
       });
 
       return service.get('test').catch(error => {
-        assert.equal(error.message, errorMessage);
+        assert.strictEqual(error.message, errorMessage);
         assert.ok(error.first);
         assert.ok(error.second);
         assert.ok(error.third);
@@ -133,7 +133,7 @@ describe('`error` hooks', () => {
       });
 
       return service.get(10)
-        .then(result => assert.deepEqual(result, data));
+        .then(result => assert.deepStrictEqual(result, data));
     });
 
     it('allows to set `context.result = null` in error hooks (#865)', () => {
@@ -152,7 +152,7 @@ describe('`error` hooks', () => {
       });
 
       return app.service('dummy').get(1)
-        .then(result => assert.equal(result, null));
+        .then(result => assert.strictEqual(result, null));
     });
   });
 
@@ -180,11 +180,11 @@ describe('`error` hooks', () => {
         }
       }).hooks({
         error (hook) {
-          assert.equal(hook.error.hook.type, 'before',
+          assert.strictEqual(hook.error.hook.type, 'before',
             'Original hook still set'
           );
-          assert.equal(hook.id, 'dishes');
-          assert.equal(hook.error.message, errorMessage);
+          assert.strictEqual(hook.id, 'dishes');
+          assert.strictEqual(hook.error.message, errorMessage);
         }
       });
 
@@ -192,7 +192,7 @@ describe('`error` hooks', () => {
         .then(() => {
           throw new Error('Should never get here');
         })
-        .catch(error => assert.equal(error.message, errorMessage));
+        .catch(error => assert.strictEqual(error.message, errorMessage));
     });
 
     it('in after hook', () => {
@@ -202,15 +202,15 @@ describe('`error` hooks', () => {
         },
 
         error (hook) {
-          assert.equal(hook.error.hook.type, 'after',
+          assert.strictEqual(hook.error.hook.type, 'after',
             'Original hook still set'
           );
-          assert.equal(hook.id, 'dishes');
-          assert.deepEqual(hook.original.result, {
+          assert.strictEqual(hook.id, 'dishes');
+          assert.deepStrictEqual(hook.original.result, {
             id: 'dishes',
             text: 'You have to do dishes'
           });
-          assert.equal(hook.error.message, errorMessage);
+          assert.strictEqual(hook.error.message, errorMessage);
         }
       });
 
@@ -218,7 +218,7 @@ describe('`error` hooks', () => {
         .then(() => {
           throw new Error('Should never get here');
         })
-        .catch(error => assert.equal(error.message, errorMessage));
+        .catch(error => assert.strictEqual(error.message, errorMessage));
     });
 
     it('uses the current hook object if thrown in a hook and sets hook.original', () => {
@@ -231,7 +231,7 @@ describe('`error` hooks', () => {
 
         error (hook) {
           assert.ok(hook.modified);
-          assert.equal(hook.original.type, 'after');
+          assert.strictEqual(hook.original.type, 'after');
         }
       });
 
@@ -239,7 +239,7 @@ describe('`error` hooks', () => {
         .then(() => {
           throw new Error('Should never get here');
         })
-        .catch(error => assert.equal(error.message, errorMessage));
+        .catch(error => assert.strictEqual(error.message, errorMessage));
     });
   });
 
@@ -277,13 +277,13 @@ describe('`error` hooks', () => {
       error (context) {
         assert.ok(service1Params !== context.params);
         assert.ok(service2Params === context.params);
-        assert.equal(context.path, 'service2');
-        assert.equal(context.params.foo, 'bar');
+        assert.strictEqual(context.path, 'service2');
+        assert.strictEqual(context.params.foo, 'bar');
       }
     });
 
     return app.service('/service2').find().catch(error => {
-      assert.equal(error.message, 'Error in service1 before hook');
+      assert.strictEqual(error.message, 'Error in service1 before hook');
     });
   });
 });

--- a/packages/feathers/test/hooks/finally.test.js
+++ b/packages/feathers/test/hooks/finally.test.js
@@ -27,7 +27,7 @@ describe('`finally` hooks', () => {
     });
 
     return service.get(42).then(data => {
-      assert.deepEqual(data, {
+      assert.deepStrictEqual(data, {
         id: 42,
         chain: [ 'service after', 'service finally', 'app finally' ]
       });
@@ -64,12 +64,12 @@ describe('`finally` hooks', () => {
     return service.get(42).then(
       () => assert(false, 'Should never get here'),
       error => {
-        assert.deepEqual(error.chain, [
+        assert.deepStrictEqual(error.chain, [
           'service error',
           'service finally',
           'app finally'
         ]);
-        assert.deepEqual(error.message, '42 is not the answer');
+        assert.deepStrictEqual(error.message, '42 is not the answer');
       }
     );
   });

--- a/packages/feathers/test/hooks/hooks.test.js
+++ b/packages/feathers/test/hooks/hooks.test.js
@@ -14,15 +14,15 @@ describe('hooks basics', () => {
     });
 
     return app.service('dummy').get(1, {}, function () {}).catch(e => {
-      assert.equal(e.message, 'Callbacks are no longer supported. Use Promises or async/await instead.');
+      assert.strictEqual(e.message, 'Callbacks are no longer supported. Use Promises or async/await instead.');
 
       return app.service('dummy').get();
     }).catch(e => {
-      assert.equal(e.message, `An id must be provided to the 'get' method`);
+      assert.strictEqual(e.message, `An id must be provided to the 'get' method`);
     }).then(() =>
       app.service('dummy').create()
     ).catch(e => {
-      assert.equal(e.message, `A data object must be provided to the 'create' method`);
+      assert.strictEqual(e.message, `A data object must be provided to the 'create' method`);
     });
   });
 
@@ -49,7 +49,7 @@ describe('hooks basics', () => {
     });
 
     return service.get(10).then(data => {
-      assert.deepEqual(data, { id: 10, user: 'David', after: true });
+      assert.deepStrictEqual(data, { id: 10, user: 'David', after: true });
     });
   });
 
@@ -64,10 +64,10 @@ describe('hooks basics', () => {
 
     service.hooks({
       before (hook) {
-        assert.equal(this, service);
-        assert.equal(hook.service, service);
-        assert.equal(hook.app, app);
-        assert.equal(hook.path, 'dummy');
+        assert.strictEqual(this, service);
+        assert.strictEqual(hook.service, service);
+        assert.strictEqual(hook.app, app);
+        assert.strictEqual(hook.path, 'dummy');
       }
     });
 
@@ -95,7 +95,7 @@ describe('hooks basics', () => {
     });
 
     return service.get(1)
-      .then(result => assert.equal(result, null));
+      .then(result => assert.strictEqual(result, null));
   });
 
   it('invalid type in .hooks throws error', () => {
@@ -111,7 +111,7 @@ describe('hooks basics', () => {
       });
       assert.ok(false);
     } catch (e) {
-      assert.equal(e.message, `'invalid' is not a valid hook type`);
+      assert.strictEqual(e.message, `'invalid' is not a valid hook type`);
     }
   });
 
@@ -130,7 +130,7 @@ describe('hooks basics', () => {
       });
       assert.ok(false);
     } catch (e) {
-      assert.equal(e.message, `'invalid' is not a valid hook method`);
+      assert.strictEqual(e.message, `'invalid' is not a valid hook method`);
     }
   });
 
@@ -152,7 +152,7 @@ describe('hooks basics', () => {
     });
 
     return app.service('dummy').get(1).catch(e => {
-      assert.equal(e.message, `Service method 'get' for 'dummy' service must return a promise`);
+      assert.strictEqual(e.message, `Service method 'get' for 'dummy' service must return a promise`);
     });
   });
 
@@ -165,10 +165,10 @@ describe('hooks basics', () => {
       });
 
       return app.service('dummy').get(10, {}, true).then(context => {
-        assert.equal(context.service, app.service('dummy'));
-        assert.equal(context.type, 'after');
-        assert.equal(context.path, 'dummy');
-        assert.deepEqual(context.result, {
+        assert.strictEqual(context.service, app.service('dummy'));
+        assert.strictEqual(context.type, 'after');
+        assert.strictEqual(context.path, 'dummy');
+        assert.deepStrictEqual(context.result, {
           id: 10,
           params: {}
         });
@@ -183,10 +183,10 @@ describe('hooks basics', () => {
       });
 
       return app.service('dummy').get(10, {}, true).catch(context => {
-        assert.equal(context.service, app.service('dummy'));
-        assert.equal(context.type, 'error');
-        assert.equal(context.path, 'dummy');
-        assert.equal(context.error.message, 'Something went wrong');
+        assert.strictEqual(context.service, app.service('dummy'));
+        assert.strictEqual(context.type, 'error');
+        assert.strictEqual(context.path, 'dummy');
+        assert.strictEqual(context.error.message, 'Something went wrong');
       });
     });
 
@@ -198,10 +198,10 @@ describe('hooks basics', () => {
       });
 
       return app.service('dummy').get(undefined, {}, true).catch(context => {
-        assert.equal(context.service, app.service('dummy'));
-        assert.equal(context.type, 'error');
-        assert.equal(context.path, 'dummy');
-        assert.equal(context.error.message, 'An id must be provided to the \'get\' method');
+        assert.strictEqual(context.service, app.service('dummy'));
+        assert.strictEqual(context.type, 'error');
+        assert.strictEqual(context.path, 'dummy');
+        assert.strictEqual(context.error.message, 'An id must be provided to the \'get\' method');
       });
     });
 
@@ -221,10 +221,10 @@ describe('hooks basics', () => {
       });
 
       return app.service('dummy').get(10, {}, true).catch(context => {
-        assert.equal(context.service, app.service('dummy'));
-        assert.equal(context.type, 'error');
-        assert.equal(context.path, 'dummy');
-        assert.equal(context.error.message, 'Error in error hook');
+        assert.strictEqual(context.service, app.service('dummy'));
+        assert.strictEqual(context.type, 'error');
+        assert.strictEqual(context.path, 'dummy');
+        assert.strictEqual(context.error.message, 'Error in error hook');
       });
     });
 
@@ -244,7 +244,7 @@ describe('hooks basics', () => {
 
       return app.service('dummy').get(10, {}, true).then(hook => {
         assert.ok(hook.error);
-        assert.deepEqual(hook.result, result);
+        assert.deepStrictEqual(hook.result, result);
       }).catch(() => {
         throw new Error('Should never get here');
       });
@@ -289,7 +289,7 @@ describe('hooks basics', () => {
 
     const args = [1, { test: 'ok' }, { provider: 'rest' }];
 
-    assert.deepEqual(app.service('dummy').methods, {
+    assert.deepStrictEqual(app.service('dummy').methods, {
       find: ['params'],
       get: ['id', 'params'],
       create: ['data', 'params'],
@@ -302,13 +302,13 @@ describe('hooks basics', () => {
 
     return app.service('dummy').custom(...args, true)
       .then(hook => {
-        assert.deepEqual(hook.result, args);
-        assert.deepEqual(hook.test, ['all::before', 'custom::before', 'all::after', 'custom::after']);
+        assert.deepStrictEqual(hook.result, args);
+        assert.deepStrictEqual(hook.test, ['all::before', 'custom::before', 'all::after', 'custom::after']);
 
         app.service('dummy').other(...args, true)
           .then(hook => {
-            assert.deepEqual(hook.result, args);
-            assert.deepEqual(hook.test, ['all::before', 'all::after']);
+            assert.deepStrictEqual(hook.result, args);
+            assert.deepStrictEqual(hook.test, ['all::before', 'all::after']);
           });
       });
   });
@@ -339,7 +339,7 @@ describe('hooks basics', () => {
 
     return app.service('dummy').custom(...args)
       .then(result => {
-        assert.deepEqual(result, args);
+        assert.deepStrictEqual(result, args);
       });
   });
 
@@ -351,7 +351,7 @@ describe('hooks basics', () => {
     });
 
     return app.service('dummy').get('test', null).then(result => {
-      assert.deepEqual(result, {
+      assert.deepStrictEqual(result, {
         id: 'test',
         params: {}
       });

--- a/packages/feathers/test/hooks/with-hooks.test.js
+++ b/packages/feathers/test/hooks/with-hooks.test.js
@@ -36,8 +36,8 @@ describe('services withHooks', () => {
       before: testHook
     })(data, params, true)
       .then(hook => {
-        assert.deepEqual(hook.result, data, 'test result');
-        assert.deepEqual(hook, {
+        assert.deepStrictEqual(hook.result, data, 'test result');
+        assert.deepStrictEqual(hook, {
           app,
           params,
           service: svc,
@@ -66,7 +66,7 @@ describe('services withHooks', () => {
       before: testHook
     })(data)
       .then(result => {
-        assert.deepEqual(result, data, 'test result');
+        assert.deepStrictEqual(result, data, 'test result');
       });
   });
 
@@ -84,7 +84,7 @@ describe('services withHooks', () => {
       before: testHook
     })()
       .then(result => {
-        assert.deepEqual(result, data, 'test result');
+        assert.deepStrictEqual(result, data, 'test result');
       });
   });
 
@@ -99,7 +99,7 @@ describe('services withHooks', () => {
       service: svc,
       method: 'find'
     })()().then(result => {
-      assert.deepEqual(result, data, 'test result');
+      assert.deepStrictEqual(result, data, 'test result');
     });
   });
 
@@ -123,7 +123,7 @@ describe('services withHooks', () => {
       }
     })(data)
       .then(result => {
-        assert.deepEqual(result, [{ name: 'John', address: { city: 'Montreal' } }]);
+        assert.deepStrictEqual(result, [{ name: 'John', address: { city: 'Montreal' } }]);
       });
   });
 });

--- a/packages/primus-client/test/index.test.js
+++ b/packages/primus-client/test/index.test.js
@@ -25,7 +25,7 @@ describe('feathers-primus/client', () => {
   });
 
   it('exports default', () => {
-    assert.equal(primus.default, primus);
+    assert.strictEqual(primus.default, primus);
   });
 
   it('throws an error with no connection', () => {
@@ -33,7 +33,7 @@ describe('feathers-primus/client', () => {
       feathers().configure(primus());
       assert.ok(false);
     } catch (e) {
-      assert.equal(e.message, 'Primus connection needs to be provided');
+      assert.strictEqual(e.message, 'Primus connection needs to be provided');
     }
   });
 
@@ -46,7 +46,7 @@ describe('feathers-primus/client', () => {
       app.configure(primus({}));
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, 'Only one default client provider can be configured');
+      assert.strictEqual(e.message, 'Only one default client provider can be configured');
     }
   });
 
@@ -56,7 +56,7 @@ describe('feathers-primus/client', () => {
 
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
-    return todos.find().then(todos => assert.deepEqual(todos, [
+    return todos.find().then(todos => assert.deepEqual(todos, [ // eslint-disable-line
       {
         text: 'some todo',
         complete: false,
@@ -71,7 +71,7 @@ describe('feathers-primus/client', () => {
     notMe.connection = socket;
 
     return notMe.remove(1).catch(e => {
-      assert.equal(e.message, `Service 'not-me' not found`);
+      assert.strictEqual(e.message, `Service 'not-me' not found`);
     });
   });
 

--- a/packages/primus/test/events.js
+++ b/packages/primus/test/events.js
@@ -104,7 +104,8 @@ module.exports = function (name, options) {
       };
 
       socket.once(`${name} log`, verifyEvent(done, data => {
-        assert.deepEqual(data, {
+        // Primus does something that makes strict equal fail
+        assert.deepEqual(data, { // eslint-disable-line
           message: `Custom log event`, data: original
         });
         service.create = old;
@@ -170,7 +171,7 @@ module.exports = function (name, options) {
       );
 
       socket.once(eventName, data => {
-        assert.equal(data.room, 'first');
+        assert.strictEqual(data.room, 'first');
         otherSocket.removeListener(eventName, onError);
         done();
       });
@@ -193,7 +194,7 @@ module.exports = function (name, options) {
       };
       const onEvent = data => {
         counter++;
-        assert.equal(data.room, 'second');
+        assert.strictEqual(data.room, 'second');
 
         if (++counter === 2) {
           otherSocket.removeListener(eventName, onError);

--- a/packages/primus/test/index.test.js
+++ b/packages/primus/test/index.test.js
@@ -64,11 +64,11 @@ describe('@feathersjs/primus', () => {
 
   it('exports default and SOCKET_KEY', () => {
     assert.ok(primus.SOCKET_KEY);
-    assert.equal(primus, primus.default);
+    assert.strictEqual(primus, primus.default);
   });
 
   it('is CommonJS compatible', () => {
-    assert.equal(typeof require('../lib'), 'function');
+    assert.strictEqual(typeof require('../lib'), 'function');
   });
 
   it('throws an error when using an incompatible version of Feathers', () => {
@@ -78,7 +78,7 @@ describe('@feathersjs/primus', () => {
       oldFeathers().configure(primus());
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, '@feathersjs/primus is not compatible with this version of Feathers. Use the latest at @feathersjs/feathers.');
+      assert.strictEqual(e.message, '@feathersjs/primus is not compatible with this version of Feathers. Use the latest at @feathersjs/feathers.');
     }
   });
 
@@ -88,7 +88,7 @@ describe('@feathersjs/primus', () => {
       .configure(primus({
         transformer: 'websockets'
       }, function () {
-        assert.equal(counter, 0);
+        assert.strictEqual(counter, 0);
         counter++;
       }))
       .use('/todos', {
@@ -97,7 +97,7 @@ describe('@feathersjs/primus', () => {
         },
         setup (app) {
           assert.ok(app.primus);
-          assert.equal(counter, 1, 'Primus configuration ran first');
+          assert.strictEqual(counter, 1, 'Primus configuration ran first');
         }
       });
 
@@ -118,7 +118,7 @@ describe('@feathersjs/primus', () => {
 
       request({ url, json: true }, (err, res) => {
         assert.ok(!err);
-        assert.deepEqual(res.body, data);
+        assert.deepStrictEqual(res.body, data);
         srv.close(done);
       });
     });
@@ -134,21 +134,21 @@ describe('@feathersjs/primus', () => {
     };
 
     service.find = function (params) {
-      assert.deepEqual(_.omit(params, 'query', 'route', 'connection'), options.socketParams,
+      assert.deepStrictEqual(_.omit(params, 'query', 'route', 'connection'), options.socketParams,
         'Handshake parameters passed on proper position');
 
       return old.find.apply(this, arguments);
     };
 
     service.create = function (data, params) {
-      assert.deepEqual(_.omit(params, 'query', 'route', 'connection'), options.socketParams,
+      assert.deepStrictEqual(_.omit(params, 'query', 'route', 'connection'), options.socketParams,
         'Passed handshake parameters');
 
       return old.create.apply(this, arguments);
     };
 
     service.update = function (id, data, params) {
-      assert.deepEqual(params, _.extend({
+      assert.deepStrictEqual(params, _.extend({
         connection: options.socketParams,
         route: {},
         query: {
@@ -177,7 +177,7 @@ describe('@feathersjs/primus', () => {
     };
 
     service.find = function (params) {
-      assert.deepEqual(_.omit(params, 'query', 'route', 'connection'), options.socketParams,
+      assert.deepStrictEqual(_.omit(params, 'query', 'route', 'connection'), options.socketParams,
         'Handshake parameters passed on proper position');
 
       return old.find.apply(this, arguments);

--- a/packages/primus/test/methods.js
+++ b/packages/primus/test/methods.js
@@ -17,7 +17,7 @@ module.exports = function (name, options, legacy = false) {
 
   it(`invalid arguments cause an error`, () =>
     call('find', 1, {}).catch(e =>
-      assert.equal(e.message, 'Too many arguments for \'find\' method')
+      assert.strictEqual(e.message, 'Too many arguments for \'find\' method')
     )
   );
 
@@ -32,19 +32,19 @@ module.exports = function (name, options, legacy = false) {
   it('.get with error', () =>
     call('get', 'laundry', { error: true })
       .then(() => assert.ok(false, 'Should never get here'))
-      .catch(error => assert.equal(error.message, 'Something for laundry went wrong'))
+      .catch(error => assert.strictEqual(error.message, 'Something for laundry went wrong'))
   );
 
   it('.get with runtime error', () =>
     call('get', 'laundry', { runtimeError: true })
       .then(() => assert.ok(false, 'Should never get here'))
-      .catch(error => assert.equal(error.message, 'thingThatDoesNotExist is not defined'))
+      .catch(error => assert.strictEqual(error.message, 'thingThatDoesNotExist is not defined'))
   );
 
   it('.get with error in hook', () =>
     call('get', 'laundry', { hookError: true })
       .then(() => assert.ok(false, 'Should never get here'))
-      .catch(error => assert.equal(error.message, 'Error from get, before hook'))
+      .catch(error => assert.strictEqual(error.message, 'Error from get, before hook'))
   );
 
   it(`.create`, () => {

--- a/packages/rest-client/test/angular-http-client.test.js
+++ b/packages/rest-client/test/angular-http-client.test.js
@@ -26,7 +26,7 @@ describe('@angular/common/http REST connector', function () {
   const angularHttpClient = createAngularHTTPClient();
 
   const url = 'http://localhost:8889';
-  const setup = rest(url).angularHttpClient(angularHttpClient, {HttpHeaders});
+  const setup = rest(url).angularHttpClient(angularHttpClient, { HttpHeaders });
   const app = feathers().configure(setup);
   const service = app.service('todos');
 
@@ -45,8 +45,8 @@ describe('@angular/common/http REST connector', function () {
       'Authorization': 'let-me-in'
     };
 
-    return service.get(0, {headers}).then(todo =>
-      assert.deepEqual(todo, {
+    return service.get(0, { headers }).then(todo =>
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -64,7 +64,7 @@ describe('@angular/common/http REST connector', function () {
     };
 
     return service.get(0, { connection }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -79,18 +79,18 @@ describe('@angular/common/http REST connector', function () {
       .angularHttpClient(angularHttpClient));
 
     return app.service('dummy').find().catch(e =>
-      assert.equal(e.message, `Please pass angular's 'httpClient' (instance) and and object with 'HttpHeaders' (class) to feathers-rest`)
+      assert.strictEqual(e.message, `Please pass angular's 'httpClient' (instance) and and object with 'HttpHeaders' (class) to feathers-rest`)
     );
   });
 
   it('can initialize a client instance', () => {
-    const init = rest(url).angularHttpClient(angularHttpClient, {HttpHeaders});
+    const init = rest(url).angularHttpClient(angularHttpClient, { HttpHeaders });
     const todos = init.service('todos');
 
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
     return todos.find({}).then(todos =>
-      assert.deepEqual(todos, [
+      assert.deepStrictEqual(todos, [
         {
           text: 'some todo',
           complete: false,
@@ -101,26 +101,26 @@ describe('@angular/common/http REST connector', function () {
   });
 
   it('supports nested arrays in queries', () => {
-    const query = {test: {$in: [0, 1, 2]}};
+    const query = { test: { $in: [ '0', '1', '2' ] } };
 
-    return service.get(0, {query}).then(data =>
-      assert.deepEqual(data.query, query)
+    return service.get(0, { query }).then(data =>
+      assert.deepStrictEqual(data.query, query)
     );
   });
 
   it('remove many', () => {
     return service.remove(null).then(todo => {
-      assert.equal(todo.id, null);
-      assert.equal(todo.text, 'deleted many');
+      assert.strictEqual(todo.id, null);
+      assert.strictEqual(todo.text, 'deleted many');
     });
   });
 
   it('converts feathers errors (#50)', () => {
-    return service.get(0, {query: {feathersError: true}})
+    return service.get(0, { query: { feathersError: true } })
       .catch(error => {
         assert.ok(error instanceof errors.NotAcceptable);
-        assert.equal(error.message, 'This is a Feathers error');
-        assert.equal(error.code, 406);
+        assert.strictEqual(error.message, 'This is a Feathers error');
+        assert.strictEqual(error.code, 406);
       });
   });
 });

--- a/packages/rest-client/test/angular.test.js
+++ b/packages/rest-client/test/angular.test.js
@@ -32,7 +32,7 @@ describe('angular REST connector', function () {
   const angularHttp = createAngularHTTP();
 
   const url = 'http://localhost:8889';
-  const setup = rest(url).angular(angularHttp, {Headers});
+  const setup = rest(url).angular(angularHttp, { Headers });
   const app = feathers().configure(setup);
   const service = app.service('todos');
 
@@ -50,7 +50,7 @@ describe('angular REST connector', function () {
     const app = feathers().configure(rest(url).angular(angularHttp));
 
     return app.service('dummy').find().catch(e =>
-      assert.equal(e.message, `Please pass angular's 'http' (instance) and and object with 'Headers' (class) to feathers-rest`)
+      assert.strictEqual(e.message, `Please pass angular's 'http' (instance) and and object with 'Headers' (class) to feathers-rest`)
     );
   });
 
@@ -60,7 +60,7 @@ describe('angular REST connector', function () {
     };
 
     return service.get(0, { headers }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -78,7 +78,7 @@ describe('angular REST connector', function () {
     };
 
     return service.get(0, { connection }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -89,13 +89,13 @@ describe('angular REST connector', function () {
   });
 
   it('can initialize a client instance', () => {
-    const init = rest(url).angular(angularHttp, {Headers});
+    const init = rest(url).angular(angularHttp, { Headers });
     const todos = init.service('todos');
 
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
     return todos.find({}).then(todos =>
-      assert.deepEqual(todos, [
+      assert.deepStrictEqual(todos, [
         {
           text: 'some todo',
           complete: false,
@@ -106,26 +106,26 @@ describe('angular REST connector', function () {
   });
 
   it('supports nested arrays in queries', () => {
-    const query = {test: {$in: [0, 1, 2]}};
+    const query = { test: { $in: [ '0', '1', '2' ] } };
 
-    return service.get(0, {query}).then(data =>
-      assert.deepEqual(data.query, query)
+    return service.get(0, { query }).then(data =>
+      assert.deepStrictEqual(data.query, query)
     );
   });
 
   it('remove many', () => {
     return service.remove(null).then(todo => {
-      assert.equal(todo.id, null);
-      assert.equal(todo.text, 'deleted many');
+      assert.strictEqual(todo.id, null);
+      assert.strictEqual(todo.text, 'deleted many');
     });
   });
 
   it('converts feathers errors (#50)', () => {
-    return service.get(0, {query: {feathersError: true}})
+    return service.get(0, { query: { feathersError: true } })
       .catch(error => {
         assert.ok(error instanceof errors.NotAcceptable);
-        assert.equal(error.message, 'This is a Feathers error');
-        assert.equal(error.code, 406);
+        assert.strictEqual(error.message, 'This is a Feathers error');
+        assert.strictEqual(error.code, 406);
       });
   });
 });

--- a/packages/rest-client/test/axios.test.js
+++ b/packages/rest-client/test/axios.test.js
@@ -28,7 +28,7 @@ describe('Axios REST connector', function () {
     };
 
     return service.get(0, { headers }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -46,7 +46,7 @@ describe('Axios REST connector', function () {
     };
 
     return service.get(0, { connection }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -63,7 +63,7 @@ describe('Axios REST connector', function () {
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
     return todos.find({}).then(todos =>
-      assert.deepEqual(todos, [
+      assert.deepStrictEqual(todos, [
         {
           text: 'some todo',
           complete: false,
@@ -74,17 +74,17 @@ describe('Axios REST connector', function () {
   });
 
   it('supports nested arrays in queries', () => {
-    const query = { test: { $in: [ 0, 1, 2 ] } };
+    const query = { test: { $in: [ '0', '1', '2' ] } };
 
     return service.get(0, { query }).then(data =>
-      assert.deepEqual(data.query, query)
+      assert.deepStrictEqual(data.query, query)
     );
   });
 
   it('remove many', () => {
     return service.remove(null).then(todo => {
-      assert.equal(todo.id, null);
-      assert.equal(todo.text, 'deleted many');
+      assert.strictEqual(todo.id, null);
+      assert.strictEqual(todo.text, 'deleted many');
     });
   });
 
@@ -92,8 +92,8 @@ describe('Axios REST connector', function () {
     return service.get(0, { query: { feathersError: true } })
       .catch(error => {
         assert.ok(error instanceof errors.NotAcceptable);
-        assert.equal(error.message, 'This is a Feathers error');
-        assert.equal(error.code, 406);
+        assert.strictEqual(error.message, 'This is a Feathers error');
+        assert.strictEqual(error.code, 406);
       });
   });
 
@@ -105,8 +105,8 @@ describe('Axios REST connector', function () {
     return app.service('something').find().catch(e => {
       const err = JSON.parse(JSON.stringify(e));
 
-      assert.equal(err.name, 'Unavailable');
-      assert.equal(err.message, 'connect ECONNREFUSED 127.0.0.1:60000');
+      assert.strictEqual(err.name, 'Unavailable');
+      assert.strictEqual(err.message, 'connect ECONNREFUSED 127.0.0.1:60000');
       assert.ok(e.data.config);
     });
   });

--- a/packages/rest-client/test/fetch.test.js
+++ b/packages/rest-client/test/fetch.test.js
@@ -28,7 +28,7 @@ describe('fetch REST connector', function () {
     };
 
     return service.get(0, { headers }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         text: 'some todo',
         authorization: 'let-me-in',
@@ -46,7 +46,7 @@ describe('fetch REST connector', function () {
     };
 
     return service.get(0, { connection }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         text: 'some todo',
         authorization: 'let-me-in',
@@ -58,15 +58,15 @@ describe('fetch REST connector', function () {
 
   it('handles errors properly', () => {
     return service.get(-1, {}).catch(error =>
-      assert.equal(error.code, 404)
+      assert.strictEqual(error.code, 404)
     );
   });
 
   it('supports nested arrays in queries', () => {
-    const query = { test: { $in: [ 0, 1, 2 ] } };
+    const query = { test: { $in: [ '0', '1', '2' ] } };
 
     return service.get(0, { query }).then(data =>
-      assert.deepEqual(data.query, query)
+      assert.deepStrictEqual(data.query, query)
     );
   });
 
@@ -77,7 +77,7 @@ describe('fetch REST connector', function () {
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
     return todos.find({}).then(todos =>
-      assert.deepEqual(todos, [
+      assert.deepStrictEqual(todos, [
         {
           text: 'some todo',
           complete: false,
@@ -89,17 +89,17 @@ describe('fetch REST connector', function () {
 
   it('remove many', () => {
     return service.remove(null).then(todo => {
-      assert.equal(todo.id, null);
-      assert.equal(todo.text, 'deleted many');
+      assert.strictEqual(todo.id, null);
+      assert.strictEqual(todo.text, 'deleted many');
     });
   });
 
   it('converts feathers errors (#50)', () => {
     return service.get(0, { query: { feathersError: true } }).catch(error => {
       assert.ok(error instanceof errors.NotAcceptable);
-      assert.equal(error.message, 'This is a Feathers error');
-      assert.equal(error.code, 406);
-      assert.deepEqual(error.data, { data: true });
+      assert.strictEqual(error.message, 'This is a Feathers error');
+      assert.strictEqual(error.code, 406);
+      assert.deepStrictEqual(error.data, { data: true });
       assert.ok(error.response);
     });
   });

--- a/packages/rest-client/test/index.test.js
+++ b/packages/rest-client/test/index.test.js
@@ -9,15 +9,15 @@ describe('REST client tests', function () {
   it('is built correctly', () => {
     const transports = init();
 
-    assert.equal(typeof init, 'function');
-    assert.equal(typeof transports.jquery, 'function');
-    assert.equal(typeof transports.request, 'function');
-    assert.equal(typeof transports.superagent, 'function');
-    assert.equal(typeof transports.fetch, 'function');
+    assert.strictEqual(typeof init, 'function');
+    assert.strictEqual(typeof transports.jquery, 'function');
+    assert.strictEqual(typeof transports.request, 'function');
+    assert.strictEqual(typeof transports.superagent, 'function');
+    assert.strictEqual(typeof transports.fetch, 'function');
   });
 
   it('exports default', () => {
-    assert.equal(init.default, init);
+    assert.strictEqual(init.default, init);
   });
 
   it('base errors (backwards compatibility)', () => {
@@ -25,19 +25,19 @@ describe('REST client tests', function () {
     const service = new Base({ name: 'test' });
 
     return service.get().catch(error => {
-      assert.equal(error.message, `id for 'get' can not be undefined`);
+      assert.strictEqual(error.message, `id for 'get' can not be undefined`);
 
       return service.update();
     }).catch(error => {
-      assert.equal(error.message, `id for 'update' can not be undefined, only 'null' when updating multiple entries`);
+      assert.strictEqual(error.message, `id for 'update' can not be undefined, only 'null' when updating multiple entries`);
 
       return service.patch();
     }).catch(error => {
-      assert.equal(error.message, `id for 'patch' can not be undefined, only 'null' when updating multiple entries`);
+      assert.strictEqual(error.message, `id for 'patch' can not be undefined, only 'null' when updating multiple entries`);
 
       return service.remove();
     }).catch(error => {
-      assert.equal(error.message, `id for 'remove' can not be undefined, only 'null' when removing multiple entries`);
+      assert.strictEqual(error.message, `id for 'remove' can not be undefined, only 'null' when removing multiple entries`);
     });
   });
 
@@ -47,7 +47,7 @@ describe('REST client tests', function () {
     try {
       transports.fetch();
     } catch (e) {
-      assert.equal(e.message, 'fetch has to be provided to feathers-rest');
+      assert.strictEqual(e.message, 'fetch has to be provided to feathers-rest');
     }
   });
 
@@ -68,7 +68,7 @@ describe('REST client tests', function () {
       app.configure(rest('http://localhost:8889').fetch(fetch));
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, 'Only one default client provider can be configured');
+      assert.strictEqual(e.message, 'Only one default client provider can be configured');
     }
   });
 
@@ -79,19 +79,19 @@ describe('REST client tests', function () {
     const service = app.service('todos');
 
     return service.get().catch(error => {
-      assert.equal(error.message, `An id must be provided to the 'get' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'get' method`);
 
       return service.remove();
     }).catch(error => {
-      assert.equal(error.message, `An id must be provided to the 'remove' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'remove' method`);
 
       return service.update();
     }).catch(error => {
-      assert.equal(error.message, `An id must be provided to the 'update' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'update' method`);
 
       return service.patch();
     }).catch(error => {
-      assert.equal(error.message, `An id must be provided to the 'patch' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'patch' method`);
     });
   });
 });

--- a/packages/rest-client/test/jquery.test.js
+++ b/packages/rest-client/test/jquery.test.js
@@ -31,7 +31,7 @@ describe('jQuery REST connector', function () {
     };
 
     return service.get(0, { headers }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -49,7 +49,7 @@ describe('jQuery REST connector', function () {
     };
 
     return service.get(0, { connection }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -66,7 +66,7 @@ describe('jQuery REST connector', function () {
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
     return todos.find({}).then(todos =>
-      assert.deepEqual(todos, [
+      assert.deepStrictEqual(todos, [
         {
           text: 'some todo',
           complete: false,
@@ -77,17 +77,17 @@ describe('jQuery REST connector', function () {
   });
 
   it('supports nested arrays in queries', () => {
-    const query = { test: { $in: [ 0, 1, 2 ] } };
+    const query = { test: { $in: [ '0', '1', '2' ] } };
 
     return service.get(0, { query }).then(data =>
-      assert.deepEqual(data.query, query)
+      assert.deepStrictEqual(data.query, query)
     );
   });
 
   it('remove many', () => {
     return service.remove(null).then(todo => {
-      assert.equal(todo.id, null);
-      assert.equal(todo.text, 'deleted many');
+      assert.strictEqual(todo.id, null);
+      assert.strictEqual(todo.text, 'deleted many');
     });
   });
 
@@ -95,9 +95,9 @@ describe('jQuery REST connector', function () {
     return service.get(0, { query: { feathersError: true } })
       .catch(error => {
         assert.ok(error instanceof errors.NotAcceptable);
-        assert.equal(error.message, 'This is a Feathers error');
-        assert.equal(error.code, 406);
-        assert.deepEqual(error.data, { data: true });
+        assert.strictEqual(error.message, 'This is a Feathers error');
+        assert.strictEqual(error.code, 406);
+        assert.deepStrictEqual(error.data, { data: true });
         assert.ok(error.response);
       });
   });

--- a/packages/rest-client/test/request.test.js
+++ b/packages/rest-client/test/request.test.js
@@ -28,7 +28,7 @@ describe('node-request REST connector', function () {
     };
 
     return service.get(0, { headers }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -46,7 +46,7 @@ describe('node-request REST connector', function () {
     };
 
     return service.get(0, { connection }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -63,7 +63,7 @@ describe('node-request REST connector', function () {
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
     return todos.find({}).then(todos =>
-      assert.deepEqual(todos, [
+      assert.deepStrictEqual(todos, [
         {
           text: 'some todo',
           complete: false,
@@ -78,37 +78,37 @@ describe('node-request REST connector', function () {
     const todos = init.service('todos');
 
     return todos.find().catch(error =>
-      assert.equal(error.message, 'Invalid URI "nowhere/todos"')
+      assert.strictEqual(error.message, 'Invalid URI "nowhere/todos"')
     );
   });
 
   it('supports nested arrays in queries', () => {
-    const query = { test: { $in: [ 0, 1, 2 ] } };
+    const query = { test: { $in: [ '0', '1', '2' ] } };
 
     return service.get(0, { query }).then(data =>
-      assert.deepEqual(data.query, query)
+      assert.deepStrictEqual(data.query, query)
     );
   });
 
   it('converts errors properly', () => {
     return service.get(1, { query: { error: true } }).catch(e =>
-      assert.equal(e.message, 'Something went wrong')
+      assert.strictEqual(e.message, 'Something went wrong')
     );
   });
 
   it('remove many', () => {
     return service.remove(null).then(todo => {
-      assert.equal(todo.id, null);
-      assert.equal(todo.text, 'deleted many');
+      assert.strictEqual(todo.id, null);
+      assert.strictEqual(todo.text, 'deleted many');
     });
   });
 
   it('converts feathers errors (#50)', () => {
     return service.get(0, { query: { feathersError: true } }).catch(error => {
       assert.ok(error instanceof errors.NotAcceptable);
-      assert.equal(error.message, 'This is a Feathers error');
-      assert.equal(error.code, 406);
-      assert.deepEqual(error.data, { data: true });
+      assert.strictEqual(error.message, 'This is a Feathers error');
+      assert.strictEqual(error.code, 406);
+      assert.deepStrictEqual(error.data, { data: true });
       assert.ok(error.response);
     });
   });

--- a/packages/rest-client/test/superagent.test.js
+++ b/packages/rest-client/test/superagent.test.js
@@ -28,7 +28,7 @@ describe('Superagent REST connector', function () {
     };
 
     return service.get(0, { headers }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -44,7 +44,7 @@ describe('Superagent REST connector', function () {
     };
 
     return service.get(0, { connection }).then(todo =>
-      assert.deepEqual(todo, {
+      assert.deepStrictEqual(todo, {
         id: 0,
         authorization: 'let-me-in',
         text: 'some todo',
@@ -61,7 +61,7 @@ describe('Superagent REST connector', function () {
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
     return todos.find({}).then(todos =>
-      assert.deepEqual(todos, [
+      assert.deepStrictEqual(todos, [
         {
           text: 'some todo',
           complete: false,
@@ -72,17 +72,17 @@ describe('Superagent REST connector', function () {
   });
 
   it('supports nested arrays in queries', () => {
-    const query = { test: { $in: [ 0, 1, 2 ] } };
+    const query = { test: { $in: [ '0', '1', '2' ] } };
 
     return service.get(0, { query }).then(data =>
-      assert.deepEqual(data.query, query)
+      assert.deepStrictEqual(data.query, query)
     );
   });
 
   it('remove many', () => {
     return service.remove(null).then(todo => {
-      assert.equal(todo.id, null);
-      assert.equal(todo.text, 'deleted many');
+      assert.strictEqual(todo.id, null);
+      assert.strictEqual(todo.text, 'deleted many');
     });
   });
 
@@ -90,8 +90,8 @@ describe('Superagent REST connector', function () {
     return service.get(0, { query: { feathersError: true } })
       .catch(error => {
         assert.ok(error instanceof errors.NotAcceptable);
-        assert.equal(error.message, 'This is a Feathers error');
-        assert.equal(error.code, 406);
+        assert.strictEqual(error.message, 'This is a Feathers error');
+        assert.strictEqual(error.code, 406);
         assert.ok(error.response);
       });
   });

--- a/packages/socketio-client/test/index.test.js
+++ b/packages/socketio-client/test/index.test.js
@@ -25,7 +25,7 @@ describe('@feathersjs/socketio-client', () => {
   });
 
   it('exports default', () =>
-    assert.equal(socketio.default, socketio)
+    assert.strictEqual(socketio.default, socketio)
   );
 
   it('throws an error with no connection', () => {
@@ -33,7 +33,7 @@ describe('@feathersjs/socketio-client', () => {
       feathers().configure(socketio());
       assert.ok(false);
     } catch (e) {
-      assert.equal(e.message,
+      assert.strictEqual(e.message,
         'Socket.io connection needs to be provided'
       );
     }
@@ -48,7 +48,7 @@ describe('@feathersjs/socketio-client', () => {
       app.configure(socketio(socket));
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, 'Only one default client provider can be configured');
+      assert.strictEqual(e.message, 'Only one default client provider can be configured');
     }
   });
 
@@ -58,7 +58,7 @@ describe('@feathersjs/socketio-client', () => {
 
     assert.ok(todos instanceof init.Service, 'Returned service is a client');
 
-    return todos.find().then(todos => assert.deepEqual(todos, [{
+    return todos.find().then(todos => assert.deepStrictEqual(todos, [{
       text: 'some todo',
       complete: false,
       id: 0
@@ -67,7 +67,7 @@ describe('@feathersjs/socketio-client', () => {
 
   it('return 404 for non-existent service', () => {
     return app.service('not-me').create({}).catch(e =>
-      assert.equal(e.message, 'Service \'not-me\' not found')
+      assert.strictEqual(e.message, 'Service \'not-me\' not found')
     );
   });
 

--- a/packages/socketio/test/events.js
+++ b/packages/socketio/test/events.js
@@ -102,7 +102,7 @@ module.exports = function (name, options) {
       };
 
       socket.once(`${name} log`, verifyEvent(done, data => {
-        assert.deepEqual(data, {
+        assert.deepStrictEqual(data, {
           message: `Custom log event`, data: original
         });
         service.create = old;
@@ -167,7 +167,7 @@ module.exports = function (name, options) {
       );
 
       socket.once(eventName, data => {
-        assert.equal(data.room, 'first');
+        assert.strictEqual(data.room, 'first');
         otherSocket.removeEventListener(eventName, onError);
         done();
       });
@@ -190,7 +190,7 @@ module.exports = function (name, options) {
       };
       const onEvent = data => {
         counter++;
-        assert.equal(data.room, 'second');
+        assert.strictEqual(data.room, 'second');
 
         if (++counter === 2) {
           otherSocket.removeEventListener(eventName, onError);

--- a/packages/socketio/test/index.test.js
+++ b/packages/socketio/test/index.test.js
@@ -76,7 +76,7 @@ describe('@feathersjs/socketio', () => {
 
   it('exports default and SOCKET_KEY', () => {
     assert.ok(socketio.SOCKET_KEY);
-    assert.equal(socketio, socketio.default);
+    assert.strictEqual(socketio, socketio.default);
   });
 
   it('throws an error when using an incompatible version of Feathers', () => {
@@ -86,14 +86,14 @@ describe('@feathersjs/socketio', () => {
       oldFeathers().configure(socketio());
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, '@feathersjs/socketio is not compatible with this version of Feathers. Use the latest at @feathersjs/feathers.');
+      assert.strictEqual(e.message, '@feathersjs/socketio is not compatible with this version of Feathers. Use the latest at @feathersjs/feathers.');
     }
   });
 
   it('runs io before setup (#131)', done => {
     let counter = 0;
     let app = feathers().configure(socketio(() => {
-      assert.equal(counter, 0);
+      assert.strictEqual(counter, 0);
       counter++;
     }));
 
@@ -106,7 +106,7 @@ describe('@feathersjs/socketio', () => {
     ));
 
     let srv = app.listen(8987).on('listening', () => {
-      assert.equal(app.io.sockets.getMaxListeners(), 100);
+      assert.strictEqual(app.io.sockets.getMaxListeners(), 100);
       srv.close(done);
     });
   });
@@ -121,13 +121,13 @@ describe('@feathersjs/socketio', () => {
 
       request(url, (err, res) => {
         assert.ok(!err);
-        assert.equal(res.statusCode, 200);
+        assert.strictEqual(res.statusCode, 200);
 
         const url = 'http://localhost:8992/test';
 
         request({ url, json: true }, (err, res) => {
           assert.ok(!err);
-          assert.deepEqual(res.body, data);
+          assert.deepStrictEqual(res.body, data);
           srv.close(done);
         });
       });
@@ -144,7 +144,7 @@ describe('@feathersjs/socketio', () => {
 
       // eslint-disable-next-line handle-callback-err
       request(url, (err, res) => {
-        assert.equal(res.statusCode, 200);
+        assert.strictEqual(res.statusCode, 200);
         srv.close(done);
       });
     });
@@ -158,12 +158,12 @@ describe('@feathersjs/socketio', () => {
     };
 
     service.create = function (data, params) {
-      assert.deepEqual(_.omit(params, 'query', 'route', 'connection'), socketParams, 'Passed handshake parameters');
+      assert.deepStrictEqual(_.omit(params, 'query', 'route', 'connection'), socketParams, 'Passed handshake parameters');
       return old.create.apply(this, arguments);
     };
 
     service.update = function (id, data, params) {
-      assert.deepEqual(params, _.extend({
+      assert.deepStrictEqual(params, _.extend({
         route: {},
         connection: socketParams,
         query: {
@@ -191,7 +191,7 @@ describe('@feathersjs/socketio', () => {
     let old = { find: service.find };
 
     service.find = function (params) {
-      assert.deepEqual(_.omit(params, 'query', 'route', 'connection'), socketParams, 'Handshake parameters passed on proper position');
+      assert.deepStrictEqual(_.omit(params, 'query', 'route', 'connection'), socketParams, 'Handshake parameters passed on proper position');
       return old.find.apply(this, arguments);
     };
 

--- a/packages/socketio/test/methods.js
+++ b/packages/socketio/test/methods.js
@@ -17,7 +17,7 @@ module.exports = function (name, options, legacy = false) {
 
   it(`invalid arguments cause an error`, () =>
     call('find', 1, {}).catch(e =>
-      assert.equal(e.message, 'Too many arguments for \'find\' method')
+      assert.strictEqual(e.message, 'Too many arguments for \'find\' method')
     )
   );
 
@@ -32,19 +32,19 @@ module.exports = function (name, options, legacy = false) {
   it('.get with error', () =>
     call('get', 'laundry', { error: true })
       .then(() => assert.ok(false, 'Should never get here'))
-      .catch(error => assert.equal(error.message, 'Something for laundry went wrong'))
+      .catch(error => assert.strictEqual(error.message, 'Something for laundry went wrong'))
   );
 
   it('.get with runtime error', () =>
     call('get', 'laundry', { runtimeError: true })
       .then(() => assert.ok(false, 'Should never get here'))
-      .catch(error => assert.equal(error.message, 'thingThatDoesNotExist is not defined'))
+      .catch(error => assert.strictEqual(error.message, 'thingThatDoesNotExist is not defined'))
   );
 
   it('.get with error in hook', () =>
     call('get', 'laundry', { hookError: true })
       .then(() => assert.ok(false, 'Should never get here'))
-      .catch(error => assert.equal(error.message, 'Error from get, before hook'))
+      .catch(error => assert.strictEqual(error.message, 'Error from get, before hook'))
   );
 
   it(`.create`, () => {

--- a/packages/transport-commons/test/channels/channel.test.js
+++ b/packages/transport-commons/test/channels/channel.test.js
@@ -16,7 +16,7 @@ describe('app.channel', () => {
   describe('base channels', () => {
     it('creates a new channel, app.channels has names', () => {
       assert.ok(app.channel('test') instanceof Channel);
-      assert.deepEqual(app.channels, ['test']);
+      assert.deepStrictEqual(app.channels, ['test']);
     });
 
     it('.join', () => {
@@ -25,20 +25,20 @@ describe('app.channel', () => {
       const c2 = { id: 2 };
       const c3 = { id: 3 };
 
-      assert.equal(test.length, 0, 'Initial channel is empty');
+      assert.strictEqual(test.length, 0, 'Initial channel is empty');
 
       test.join(c1);
       test.join(c1);
 
-      assert.equal(test.length, 1, 'Joining twice only runs once');
+      assert.strictEqual(test.length, 1, 'Joining twice only runs once');
 
       test.join(c2, c3);
 
-      assert.equal(test.length, 3, 'New connections joined');
+      assert.strictEqual(test.length, 3, 'New connections joined');
 
       test.join(c1, c2, c3);
 
-      assert.equal(test.length, 3, 'Joining multiple times does nothing');
+      assert.strictEqual(test.length, 3, 'Joining multiple times does nothing');
     });
 
     it('.leave', () => {
@@ -46,17 +46,17 @@ describe('app.channel', () => {
       const c1 = { id: 1 };
       const c2 = { id: 2 };
 
-      assert.equal(test.length, 0);
+      assert.strictEqual(test.length, 0);
 
       test.join(c1, c2);
 
-      assert.equal(test.length, 2);
+      assert.strictEqual(test.length, 2);
 
       test.leave(c2);
       test.leave(c2);
 
-      assert.equal(test.length, 1);
-      assert.equal(test.connections.indexOf(c2), -1);
+      assert.strictEqual(test.length, 1);
+      assert.strictEqual(test.connections.indexOf(c2), -1);
     });
 
     it('.leave conditional', () => {
@@ -67,12 +67,12 @@ describe('app.channel', () => {
 
       test.join(c1, c2, c3);
 
-      assert.equal(test.length, 3);
+      assert.strictEqual(test.length, 3);
 
       test.leave(connection => connection.leave);
 
-      assert.equal(test.length, 2);
-      assert.equal(test.connections.indexOf(c1), -1);
+      assert.strictEqual(test.length, 2);
+      assert.strictEqual(test.connections.indexOf(c1), -1);
     });
 
     it('.filter', () => {
@@ -87,7 +87,7 @@ describe('app.channel', () => {
 
       assert.ok(filtered !== test, 'Returns a new channel instance');
       assert.ok(filtered instanceof Channel);
-      assert.equal(filtered.length, 1);
+      assert.strictEqual(filtered.length, 1);
     });
 
     it('.send', () => {
@@ -97,7 +97,7 @@ describe('app.channel', () => {
       const withData = test.send(data);
 
       assert.ok(test !== withData);
-      assert.deepEqual(withData.data, data);
+      assert.deepStrictEqual(withData.data, data);
     });
 
     describe('empty channels', () => {
@@ -106,7 +106,7 @@ describe('app.channel', () => {
 
         return new Promise((resolve) => {
           channel.once('message', data => {
-            assert.equal(data, 'hello');
+            assert.strictEqual(data, 'hello');
             resolve();
           });
 
@@ -134,11 +134,11 @@ describe('app.channel', () => {
         channel.join(c1);
 
         assert.ok(appChannels.test);
-        assert.equal(Object.keys(appChannels).length, 1);
+        assert.strictEqual(Object.keys(appChannels).length, 1);
         channel.leave(c1);
 
         assert.ok(app[CHANNELS].test === undefined);
-        assert.equal(Object.keys(appChannels).length, 0);
+        assert.strictEqual(Object.keys(appChannels).length, 0);
       });
 
       it('removes all event listeners from an empty channel', () => {
@@ -146,15 +146,15 @@ describe('app.channel', () => {
         const connection = { id: 1 };
 
         channel.on('something', () => {});
-        assert.equal(channel.listenerCount('something'), 1);
-        assert.equal(channel.listenerCount('empty'), 1);
+        assert.strictEqual(channel.listenerCount('something'), 1);
+        assert.strictEqual(channel.listenerCount('empty'), 1);
 
         channel.join(connection).leave(connection);
 
         assert.ok(app[CHANNELS].testing === undefined);
 
-        assert.equal(channel.listenerCount('something'), 0);
-        assert.equal(channel.listenerCount('empty'), 0);
+        assert.strictEqual(channel.listenerCount('something'), 0);
+        assert.strictEqual(channel.listenerCount('empty'), 0);
       });
     });
   });
@@ -163,9 +163,9 @@ describe('app.channel', () => {
     it('combines multiple channels', () => {
       const combined = app.channel('test', 'again');
 
-      assert.deepEqual(app.channels, ['test', 'again']);
+      assert.deepStrictEqual(app.channels, ['test', 'again']);
       assert.ok(combined instanceof CombinedChannel);
-      assert.equal(combined.length, 0);
+      assert.strictEqual(combined.length, 0);
     });
 
     it('de-dupes connections', () => {
@@ -178,7 +178,7 @@ describe('app.channel', () => {
       const combined = app.channel('test', 'again');
 
       assert.ok(combined instanceof CombinedChannel);
-      assert.equal(combined.length, 2);
+      assert.strictEqual(combined.length, 2);
     });
 
     it('.join all child channels', () => {
@@ -189,9 +189,9 @@ describe('app.channel', () => {
 
       combined.join(c1, c2);
 
-      assert.equal(combined.length, 2);
-      assert.equal(app.channel('test').length, 2);
-      assert.equal(app.channel('again').length, 2);
+      assert.strictEqual(combined.length, 2);
+      assert.strictEqual(app.channel('test').length, 2);
+      assert.strictEqual(app.channel('again').length, 2);
     });
 
     it('.leave all child channels', () => {
@@ -205,8 +205,8 @@ describe('app.channel', () => {
 
       combined.leave(c1);
 
-      assert.equal(app.channel('test').length, 1);
-      assert.equal(app.channel('again').length, 0);
+      assert.strictEqual(app.channel('test').length, 1);
+      assert.strictEqual(app.channel('again').length, 0);
     });
 
     it('.leave all child channels conditionally', () => {
@@ -216,8 +216,8 @@ describe('app.channel', () => {
 
       combined.leave(connection => connection.leave);
 
-      assert.equal(app.channel('test').length, 1);
-      assert.equal(app.channel('again').length, 1);
+      assert.strictEqual(app.channel('test').length, 1);
+      assert.strictEqual(app.channel('again').length, 1);
     });
 
     it('app.channel(app.channels)', () => {
@@ -229,7 +229,7 @@ describe('app.channel', () => {
 
       const combined = app.channel(app.channels);
 
-      assert.deepEqual(combined.connections, [ c1, c2 ]);
+      assert.deepStrictEqual(combined.connections, [ c1, c2 ]);
     });
   });
 });

--- a/packages/transport-commons/test/channels/dispatch.test.js
+++ b/packages/transport-commons/test/channels/dispatch.test.js
@@ -21,7 +21,7 @@ describe('app.publish', () => {
       app.service('test').publish('bla', function () {});
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, `'bla' is not a valid service event`);
+      assert.strictEqual(e.message, `'bla' is not a valid service event`);
     }
   });
 
@@ -46,11 +46,11 @@ describe('app.publish', () => {
       app.service('test').publish('created', () => app.channel('testing'));
 
       app.once('publish', function (event, channel, hook) {
-        assert.equal(event, 'created');
-        assert.equal(hook.path, 'test');
-        assert.equal(hook.type, 'after');
-        assert.deepEqual(hook.result, data);
-        assert.deepEqual(channel.connections, [ c1 ]);
+        assert.strictEqual(event, 'created');
+        assert.strictEqual(hook.path, 'test');
+        assert.strictEqual(hook.type, 'after');
+        assert.deepStrictEqual(hook.result, data);
+        assert.deepStrictEqual(channel.connections, [ c1 ]);
         done();
       });
 
@@ -92,8 +92,8 @@ describe('app.publish', () => {
       );
 
       app.once('publish', (event, channel, hook) => {
-        assert.deepEqual(hook.result, data);
-        assert.deepEqual(channel.connections, [ c1, c2 ]);
+        assert.deepStrictEqual(hook.result, data);
+        assert.deepStrictEqual(channel.connections, [ c1, c2 ]);
         done();
       });
 
@@ -111,14 +111,14 @@ describe('app.publish', () => {
       app.service('test').publish('foo', () => app.channel('testing'));
 
       app.once('publish', (event, channel, hook) => {
-        assert.equal(event, 'foo');
-        assert.deepEqual(hook, {
+        assert.strictEqual(event, 'foo');
+        assert.deepStrictEqual(hook, {
           app,
           path: 'test',
           service: app.service('test'),
           result: eventData
         });
-        assert.deepEqual(channel.connections, [ c1 ]);
+        assert.deepStrictEqual(channel.connections, [ c1 ]);
         done();
       });
 
@@ -162,8 +162,8 @@ describe('app.publish', () => {
       ]);
 
       app.once('publish', (event, channel, hook) => {
-        assert.deepEqual(hook.result, data);
-        assert.deepEqual(channel.connections, [ c1, c2 ]);
+        assert.deepStrictEqual(hook.result, data);
+        assert.deepStrictEqual(channel.connections, [ c1, c2 ]);
         done();
       });
 
@@ -184,10 +184,10 @@ describe('app.publish', () => {
       ]);
 
       app.once('publish', (event, channel, hook) => {
-        assert.deepEqual(hook.result, data);
-        assert.deepEqual(channel.dataFor(c1), c1data);
+        assert.deepStrictEqual(hook.result, data);
+        assert.deepStrictEqual(channel.dataFor(c1), c1data);
         assert.ok(channel.dataFor(c2) === null);
-        assert.deepEqual(channel.connections, [ c1, c2 ]);
+        assert.deepStrictEqual(channel.connections, [ c1, c2 ]);
         done();
       });
 
@@ -219,8 +219,8 @@ describe('app.publish', () => {
       });
 
       app.once('publish', (event, channel, hook) => {
-        assert.equal(channel.dataFor(c1), null);
-        assert.deepEqual(channel.connections, [ c1 ]);
+        assert.strictEqual(channel.dataFor(c1), null);
+        assert.deepStrictEqual(channel.connections, [ c1 ]);
         done();
       });
 

--- a/packages/transport-commons/test/channels/index.test.js
+++ b/packages/transport-commons/test/channels/index.test.js
@@ -6,9 +6,9 @@ describe('feathers-channels', () => {
   it('has app.channel', () => {
     const app = feathers().configure(channels());
 
-    assert.equal(typeof app.channel, 'function');
-    assert.equal(typeof app[channels.keys.CHANNELS], 'object');
-    assert.equal(app.channels.length, 0);
+    assert.strictEqual(typeof app.channel, 'function');
+    assert.strictEqual(typeof app[channels.keys.CHANNELS], 'object');
+    assert.strictEqual(app.channels.length, 0);
   });
 
   it('throws an error when called with nothing', () => {
@@ -18,7 +18,7 @@ describe('feathers-channels', () => {
       app.channel();
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, 'app.channel needs at least one channel name');
+      assert.strictEqual(e.message, 'app.channel needs at least one channel name');
     }
   });
 

--- a/packages/transport-commons/test/client.test.js
+++ b/packages/transport-commons/test/client.test.js
@@ -35,25 +35,25 @@ describe('client', () => {
       service.eventNames();
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, 'Can not call \'eventNames\' on the client service connection');
+      assert.strictEqual(e.message, 'Can not call \'eventNames\' on the client service connection');
     }
 
     try {
       service.on();
       assert.ok(false, 'Should never get here');
     } catch (e) {
-      assert.equal(e.message, 'Can not call \'on\' on the client service connection');
+      assert.strictEqual(e.message, 'Can not call \'on\' on the client service connection');
     }
   });
 
   it('allows chaining event listeners', () => {
-    assert.equal(service, service.on('thing', () => {}));
-    assert.equal(service, service.once('other thing', () => {}));
+    assert.strictEqual(service, service.on('thing', () => {}));
+    assert.strictEqual(service, service.once('other thing', () => {}));
   });
 
   it('initializes and emits namespaced events', done => {
     connection.once('todos test', data => {
-      assert.deepEqual(data, testData);
+      assert.deepStrictEqual(data, testData);
       done();
     });
     service.emit('test', testData);
@@ -65,7 +65,7 @@ describe('client', () => {
 
   it('can receive pathed events', done => {
     service.once('thing', data => {
-      assert.deepEqual(data, testData);
+      assert.deepStrictEqual(data, testData);
       done();
     });
 
@@ -89,25 +89,25 @@ describe('client', () => {
         connection.once('get', idCb);
 
         return service.get(1)
-          .then(res => assert.deepEqual(res, { id: 1 }));
+          .then(res => assert.deepStrictEqual(res, { id: 1 }));
       })
       .then(() => {
         connection.once('remove', idCb);
 
         return service.remove(12)
-          .then(res => assert.deepEqual(res, { id: 12 }));
+          .then(res => assert.deepStrictEqual(res, { id: 12 }));
       })
       .then(() => {
         connection.once('update', idDataCb);
 
         return service.update(12, testData)
-          .then(res => assert.deepEqual(res, testData));
+          .then(res => assert.deepStrictEqual(res, testData));
       })
       .then(() => {
         connection.once('patch', idDataCb);
 
         return service.patch(12, testData)
-          .then(res => assert.deepEqual(res, testData));
+          .then(res => assert.deepStrictEqual(res, testData));
       })
       .then(() => {
         connection.once('find', (path, params, callback) =>
@@ -115,7 +115,7 @@ describe('client', () => {
         );
 
         return service.find({ query: { test: true } }).then(res =>
-          assert.deepEqual(res, {
+          assert.deepStrictEqual(res, {
             params: { test: true }
           })
         );
@@ -126,7 +126,7 @@ describe('client', () => {
     return service.remove(10).then(() => {
       throw new Error('Should never get here');
     }).catch(error =>
-      assert.equal(error.message, 'Timeout of 50ms exceeded calling remove on todos')
+      assert.strictEqual(error.message, 'Timeout of 50ms exceeded calling remove on todos')
     );
   });
 
@@ -134,7 +134,7 @@ describe('client', () => {
     return service.remove(10).then(() => {
       throw new Error('Should never get here');
     }).catch(error =>
-      assert.equal(error.name, 'Timeout')
+      assert.strictEqual(error.name, 'Timeout')
     );
   });
 
@@ -145,10 +145,10 @@ describe('client', () => {
 
     return service.create(testData).catch(error => {
       assert.ok(error instanceof errors.NotAuthenticated);
-      assert.equal(error.name, 'NotAuthenticated');
-      assert.equal(error.message, 'Test');
-      assert.equal(error.code, 401);
-      assert.deepEqual(error.data, { hi: 'me' });
+      assert.strictEqual(error.name, 'NotAuthenticated');
+      assert.strictEqual(error.message, 'Test');
+      assert.strictEqual(error.code, 401);
+      assert.deepStrictEqual(error.data, { hi: 'me' });
     });
   });
 
@@ -159,17 +159,17 @@ describe('client', () => {
 
     return service.create(testData).catch(error => {
       assert.ok(error instanceof Error);
-      assert.equal(error.message, 'Something went wrong');
+      assert.strictEqual(error.message, 'Something went wrong');
     });
   });
 
   it('has all EventEmitter methods', done => {
     const testData = { hello: 'world' };
     const callback = data => {
-      assert.deepEqual(data, testData);
-      assert.equal(service.listenerCount('test'), 1);
+      assert.deepStrictEqual(data, testData);
+      assert.strictEqual(service.listenerCount('test'), 1);
       service.removeListener('test', callback);
-      assert.equal(service.listenerCount('test'), 0);
+      assert.strictEqual(service.listenerCount('test'), 0);
       done();
     };
 
@@ -182,12 +182,12 @@ describe('client', () => {
     const testData = { hello: 'world' };
 
     const callback1 = data => {
-      assert.deepEqual(data, testData);
-      assert.equal(service.listenerCount('test'), 3);
+      assert.deepStrictEqual(data, testData);
+      assert.strictEqual(service.listenerCount('test'), 3);
       service.off('test', callback1);
-      assert.equal(service.listenerCount('test'), 2);
+      assert.strictEqual(service.listenerCount('test'), 2);
       service.removeAllListeners('test');
-      assert.equal(service.listenerCount('test'), 0);
+      assert.strictEqual(service.listenerCount('test'), 0);
       done();
     };
     const callback2 = () => {
@@ -206,7 +206,7 @@ describe('client', () => {
     const connection = new EventEmitter();
 
     connection.off = name => {
-      assert.equal(name, 'todos test');
+      assert.strictEqual(name, 'todos test');
       done();
     };
 

--- a/packages/transport-commons/test/routing.test.js
+++ b/packages/transport-commons/test/routing.test.js
@@ -20,32 +20,32 @@ describe('app.router', () => {
   });
 
   it('has app.lookup and ROUTER symbol', () => {
-    assert.equal(typeof app.lookup, 'function');
+    assert.strictEqual(typeof app.lookup, 'function');
     assert.ok(app[routing.ROUTER]);
   });
 
   it('returns null when nothing is found', () => {
     const result = app.lookup('me/service');
 
-    assert.equal(result, null);
+    assert.strictEqual(result, null);
   });
 
   it('returns null for invalid service path', () => {
-    assert.equal(app.lookup(null), null);
-    assert.equal(app.lookup({}), null);
+    assert.strictEqual(app.lookup(null), null);
+    assert.strictEqual(app.lookup({}), null);
   });
 
   it('can look up and strips slashes', () => {
     const result = app.lookup('my/service');
 
-    assert.equal(result.service, app.service('/my/service'));
+    assert.strictEqual(result.service, app.service('/my/service'));
   });
 
   it('can look up with id', () => {
     const result = app.lookup('/my/service/1234');
 
-    assert.equal(result.service, app.service('/my/service'));
-    assert.deepEqual(result.params, {
+    assert.strictEqual(result.service, app.service('/my/service'));
+    assert.deepStrictEqual(result.params, {
       __id: '1234'
     });
   });
@@ -61,8 +61,8 @@ describe('app.router', () => {
 
     const result = app.lookup('/test/me/my/::special/testing');
 
-    assert.equal(result.service, app.service(path));
-    assert.deepEqual(result.params, {
+    assert.strictEqual(result.service, app.service(path));
+    assert.deepStrictEqual(result.params, {
       __id: 'testing',
       first: 'me',
       second: '::special'

--- a/packages/transport-commons/test/socket/index.test.js
+++ b/packages/transport-commons/test/socket/index.test.js
@@ -38,7 +38,7 @@ describe('@feathersjs/transport-commons', () => {
     const socket = new EventEmitter();
 
     app.once('connection', data => {
-      assert.equal(connection, data);
+      assert.strictEqual(connection, data);
       done();
     });
 
@@ -54,7 +54,7 @@ describe('@feathersjs/transport-commons', () => {
       socket.emit('get', 'myservice', 10, (error, result) => {
         try {
           assert.ok(!error);
-          assert.deepEqual(result, {
+          assert.deepStrictEqual(result, {
             id: 10,
             params: Object.assign({
               query: {},
@@ -75,8 +75,8 @@ describe('@feathersjs/transport-commons', () => {
       provider.emit('connection', socket);
 
       socket.emit('get', null, (error, result) => {
-        assert.equal(error.name, 'NotFound');
-        assert.equal(error.message, `Service 'null' not found`);
+        assert.strictEqual(error.name, 'NotFound');
+        assert.strictEqual(error.message, `Service 'null' not found`);
         done();
       });
     });
@@ -100,7 +100,7 @@ describe('@feathersjs/transport-commons', () => {
           }, connection);
 
           assert.ok(!error);
-          assert.deepEqual(result, Object.assign({ params }, data));
+          assert.deepStrictEqual(result, Object.assign({ params }, data));
           done();
         } catch (e) {
           done(e);
@@ -118,7 +118,7 @@ describe('@feathersjs/transport-commons', () => {
       socket.emit('myservice::get', 10, (error, result) => {
         try {
           assert.ok(!error);
-          assert.deepEqual(result, {
+          assert.deepStrictEqual(result, {
             id: 10,
             params: Object.assign({
               connection,
@@ -152,7 +152,7 @@ describe('@feathersjs/transport-commons', () => {
 
         try {
           assert.ok(!error);
-          assert.deepEqual(result, Object.assign({ params }, data));
+          assert.deepStrictEqual(result, Object.assign({ params }, data));
           done();
         } catch (e) {
           done(e);

--- a/packages/transport-commons/test/socket/utils.test.js
+++ b/packages/transport-commons/test/socket/utils.test.js
@@ -16,7 +16,7 @@ describe('socket commons utils', () => {
       const message = 'Something went wrong';
       const e = new Error(message);
 
-      assert.deepEqual(normalizeError(e), {
+      assert.deepStrictEqual(normalizeError(e), {
         message,
         stack: e.stack.toString()
       });
@@ -25,7 +25,7 @@ describe('socket commons utils', () => {
     it('calls .toJSON', () => {
       const json = { message: 'toJSON called' };
 
-      assert.deepEqual(normalizeError({
+      assert.deepStrictEqual(normalizeError({
         toJSON () {
           return json;
         }
@@ -37,7 +37,7 @@ describe('socket commons utils', () => {
         hook: true
       };
 
-      assert.deepEqual(normalizeError(e), {});
+      assert.deepStrictEqual(normalizeError(e), {});
       assert.ok(e.hook, 'Does not mutate the original object');
     });
 
@@ -50,7 +50,7 @@ describe('socket commons utils', () => {
       const e = new Error(message);
       const normalized = normalizeError(e);
 
-      assert.equal(normalized.message, message);
+      assert.strictEqual(normalized.message, message);
       assert.ok(!normalized.stack);
 
       process.env.NODE_ENV = oldEnv;
@@ -59,7 +59,7 @@ describe('socket commons utils', () => {
 
   describe('.getDispatcher', () => {
     it('returns a dispatcher function', () =>
-      assert.equal(typeof getDispatcher(), 'function')
+      assert.strictEqual(typeof getDispatcher(), 'function')
     );
 
     describe('dispatcher logic', () => {
@@ -81,7 +81,7 @@ describe('socket commons utils', () => {
 
       it('dispatches a basic event', done => {
         dummySocket.once('testing', data => {
-          assert.equal(data, 'hi');
+          assert.strictEqual(data, 'hi');
           done();
         });
 
@@ -92,7 +92,7 @@ describe('socket commons utils', () => {
         dummyHook.path = 'myservice';
 
         dummySocket.once('myservice testing', data => {
-          assert.equal(data, 'hi');
+          assert.strictEqual(data, 'hi');
           done();
         });
 
@@ -105,7 +105,7 @@ describe('socket commons utils', () => {
         dummyHook.dispatch = message;
 
         dummySocket.once('testing', data => {
-          assert.equal(data, message);
+          assert.strictEqual(data, message);
           done();
         });
 
@@ -125,9 +125,9 @@ describe('socket commons utils', () => {
         dummyHook.result = [ data1, data2 ];
 
         dummySocket.once('testing', data => {
-          assert.deepEqual(data, data1);
+          assert.deepStrictEqual(data, data1);
           dummySocket.once('testing', data => {
-            assert.deepEqual(data, data2);
+            assert.deepStrictEqual(data, data2);
             done();
           });
         });
@@ -145,7 +145,7 @@ describe('socket commons utils', () => {
         dummyHook.result = result;
 
         dummySocket.once('otherEvent', data => {
-          assert.deepEqual(data, result);
+          assert.deepStrictEqual(data, result);
           done();
         });
 
@@ -176,7 +176,7 @@ describe('socket commons utils', () => {
             return done(error);
           }
 
-          assert.deepEqual(result, { id: 10 });
+          assert.deepStrictEqual(result, { id: 10 });
           done();
         };
 
@@ -192,7 +192,7 @@ describe('socket commons utils', () => {
             return done(error);
           }
 
-          assert.deepEqual(result, {
+          assert.deepStrictEqual(result, {
             id: 10,
             params: {
               connection,
@@ -219,7 +219,7 @@ describe('socket commons utils', () => {
             return done(error);
           }
 
-          assert.deepEqual(result, { id: 10 });
+          assert.deepStrictEqual(result, { id: 10 });
           done();
         };
 
@@ -229,7 +229,7 @@ describe('socket commons utils', () => {
       it('with params but missing callback', done => {
         app.use('/otherservice', {
           get (id) {
-            assert.equal(id, 'dishes');
+            assert.strictEqual(id, 'dishes');
 
             return Promise.resolve({ id }).then(res => {
               done();
@@ -244,7 +244,7 @@ describe('socket commons utils', () => {
       it('with params and callback missing', done => {
         app.use('/otherservice', {
           get (id) {
-            assert.equal(id, 'laundry');
+            assert.strictEqual(id, 'laundry');
 
             return Promise.resolve({ id }).then(res => {
               done();
@@ -260,7 +260,7 @@ describe('socket commons utils', () => {
     it('throws NotFound for invalid service', done => {
       const callback = error => {
         try {
-          assert.deepEqual(error, { name: 'NotFound',
+          assert.deepStrictEqual(error, { name: 'NotFound',
             message: 'Service \'ohmyservice\' not found',
             code: 404,
             className: 'not-found',
@@ -279,7 +279,7 @@ describe('socket commons utils', () => {
     it('throws MethodNotAllowed undefined method', done => {
       const callback = error => {
         try {
-          assert.deepEqual(error, {
+          assert.deepStrictEqual(error, {
             name: 'MethodNotAllowed',
             message: 'Method \'create\' not allowed on service \'myservice\'',
             code: 405,
@@ -299,7 +299,7 @@ describe('socket commons utils', () => {
     it('throws MethodNotAllowed for invalid service method', done => {
       const callback = error => {
         try {
-          assert.deepEqual(error, {
+          assert.deepStrictEqual(error, {
             name: 'MethodNotAllowed',
             message: 'Method \'blabla\' not allowed on service \'myservice\'',
             code: 405,
@@ -319,7 +319,7 @@ describe('socket commons utils', () => {
     it('method error calls back with normalized error', done => {
       const callback = (error, result) => {
         try {
-          assert.deepEqual(error, {
+          assert.deepStrictEqual(error, {
             name: 'NotAuthenticated',
             message: 'None shall pass',
             data: undefined,


### PR DESCRIPTION
Except for some of the Primus tests because it seems to do something odd with the prototype that makes strict object equality fail.

Closes #1080