### PR TITLE
chore: Only run Saucelabs tests once in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 install: npm install
 script:
   - npm test
-  - if [ ! -z "$SAUCE_ACCESS_KEY" ]; then npm run test:client; fi
+  - if [[ "$TRAVIS_NODE_VERSION" > 11 ]]; then if [ -n "$SAUCE_ACCESS_KEY" ]; then npm run test:client; fi; fi;
 node_js:
   - node
   - 10


### PR DESCRIPTION
Saucelabs tests for the client build only need to run once for a CI build not for every Node version.