### PR TITLE
Added path and method in to express request for passport

### DIFF
--- a/packages/authentication/lib/hooks/authenticate.js
+++ b/packages/authentication/lib/hooks/authenticate.js
@@ -47,6 +47,8 @@ module.exports = function authenticate (_strategies, options = {}) {
       query: hook.data,
       body: hook.data,
       params: hook.params,
+      path: hook.path,
+      method: hook.method,
       headers: hook.params.headers || {},
       cookies: hook.params.cookies || {},
       session: {}

--- a/packages/authentication/lib/hooks/authenticate.js
+++ b/packages/authentication/lib/hooks/authenticate.js
@@ -43,12 +43,21 @@ module.exports = function authenticate (_strategies, options = {}) {
 
     // NOTE (EK): Passport expects an express/connect
     // like request object. So we need to create one.
+    const methodMap = {
+      find: 'GET',
+      get: 'GET',
+      create: 'POST',
+      update: 'PUT',
+      patch: 'PATCH',
+      remove: 'DELETE'
+    };
+
     let request = {
       query: hook.data,
       body: hook.data,
       params: hook.params,
       path: hook.path,
-      method: hook.method,
+      method: methodMap[hook.method] || hook.method,
       headers: hook.params.headers || {},
       cookies: hook.params.cookies || {},
       session: {}

--- a/packages/authentication/test/hooks/authenticate.test.js
+++ b/packages/authentication/test/hooks/authenticate.test.js
@@ -33,7 +33,9 @@ describe('hooks:authenticate', () => {
         cookies: {
           'feathers-jwt': 'token'
         }
-      }
+      },
+      path: 'test',
+      method: 'POST'
     };
   });
 
@@ -91,6 +93,8 @@ describe('hooks:authenticate', () => {
         query: hook.data,
         body: hook.data,
         params: hook.params,
+        path: hook.path,
+        method: hook.method,
         headers: hook.params.headers,
         cookies: hook.params.cookies,
         session: {}


### PR DESCRIPTION
### Summary

- [ ] This patch is for helping custom authentication strategy based on path and method. Presently we are not able to do it because these attributes are missing in request object. As per express documentation, an express request is supposed to have these fields.

   Method: https://expressjs.com/en/api.html#req.method
   Path: https://expressjs.com/en/api.html#req.path

   But this fields are not included while creating an express like request object for passport in 
   @feathersjs/authentication hook.authenticate() function.

- [ ] Currently there are no open issues for this.
- [ ] This PR has no dependency to other PRs in other repos.