### PR TITLE
feat: Allow registering a service at the root level

### DIFF
--- a/packages/express/test/rest/index.test.js
+++ b/packages/express/test/rest/index.test.js
@@ -102,6 +102,7 @@ describe('@feathersjs/express/rest provider', () => {
             return Promise.resolve(data);
           }
         })
+        .use('/', Service)
         .use('todo', Service);
 
       server = app.listen(4777, () => app.use('tasks', Service));
@@ -110,6 +111,7 @@ describe('@feathersjs/express/rest provider', () => {
     after(done => server.close(done));
 
     testCrud('Services', 'todo');
+    testCrud('Root Service', '/');
     testCrud('Dynamic Services', 'tasks');
 
     describe('res.hook', () => {

--- a/packages/feathers/lib/application.js
+++ b/packages/feathers/lib/application.js
@@ -66,7 +66,7 @@ const application = {
       throw new Error('Registering a new service with `app.service(path, service)` is no longer supported. Use `app.use(path, service)` instead.');
     }
 
-    const location = stripSlashes(path);
+    const location = stripSlashes(path) || '/';
     const current = this.services[location];
 
     if (typeof current === 'undefined' && typeof this.defaultService === 'function') {
@@ -78,11 +78,11 @@ const application = {
   },
 
   use (path, service, options = {}) {
-    if (typeof path !== 'string' || stripSlashes(path) === '') {
+    if (typeof path !== 'string') {
       throw new Error(`'${path}' is not a valid service path.`);
     }
 
-    const location = stripSlashes(path);
+    const location = stripSlashes(path) || '/';
     const isSubApp = typeof service.service === 'function' && service.services;
     const isService = this.methods.concat('setup').some(name =>
       (service && typeof service[name] === 'function')

--- a/packages/feathers/test/application.test.js
+++ b/packages/feathers/test/application.test.js
@@ -85,15 +85,9 @@ describe('Feathers application', () => {
       const app = feathers();
 
       try {
-        app.use('/', {});
+        app.use(null, {});
       } catch (e) {
-        assert.strictEqual(e.message, `'/' is not a valid service path.`);
-      }
-
-      try {
-        app.use('', {});
-      } catch (e) {
-        assert.strictEqual(e.message, `'' is not a valid service path.`);
+        assert.strictEqual(e.message, `'null' is not a valid service path.`);
       }
 
       try {
@@ -133,6 +127,17 @@ describe('Feathers application', () => {
       return wrappedService.create({
         message: 'Test message'
       }).then(data => assert.strictEqual(data.message, 'Test message'));
+    });
+
+    it('can use a root level service', () => {
+      const app = feathers().use('/', {
+        get (id) {
+          return Promise.resolve({ id });
+        }
+      });
+
+      return app.service('/').get('test')
+        .then(result => assert.deepStrictEqual(result, { id: 'test' }));
     });
 
     it('services can be re-used (#566)', done => {

--- a/packages/socketio-client/test/index.test.js
+++ b/packages/socketio-client/test/index.test.js
@@ -72,4 +72,5 @@ describe('@feathersjs/socketio-client', () => {
   });
 
   baseTests(app, 'todos');
+  baseTests(app, '/');
 });

--- a/packages/socketio-client/test/server.js
+++ b/packages/socketio-client/test/server.js
@@ -32,19 +32,25 @@ class TodoService extends Service {
 module.exports = function () {
   const app = feathers()
     .configure(socketio())
+    .use('/', new TodoService())
     .use('/todos', new TodoService());
   const service = app.service('todos');
+  const rootService = app.service('/');
+  const publisher = () => app.channel('general');
+  const data = {
+    text: 'some todo',
+    complete: false
+  };
 
   app.on('connection', connection =>
     app.channel('general').join(connection)
   );
 
-  service.create({
-    text: 'some todo',
-    complete: false
-  });
+  rootService.create(data);
+  rootService.publish(publisher);
 
-  service.publish(() => app.channel('general'));
+  service.create(data);
+  service.publish(publisher);
 
   return app;
 };

--- a/packages/transport-commons/lib/routing.js
+++ b/packages/transport-commons/lib/routing.js
@@ -17,7 +17,7 @@ module.exports = function () {
           return null;
         }
 
-        return this[ROUTER].lookup(stripSlashes('' + path));
+        return this[ROUTER].lookup(stripSlashes('' + path) || '/');
       }
     });
 


### PR DESCRIPTION
This pull request allows to register a root service via

```
app.use('/', myService);
```

Closes #1077 and related to #718, #728 and #729