### PR TITLE
fix: Add whitelist and filter support to common adapter service

### DIFF
--- a/packages/adapter-commons/lib/service.js
+++ b/packages/adapter-commons/lib/service.js
@@ -34,11 +34,16 @@ module.exports = class AdapterService {
     return this.options.events;
   }
 
-  filterQuery (params = {}, options = {}) {
+  filterQuery (params = {}, opts = {}) {
     const paginate = typeof params.paginate !== 'undefined'
       ? params.paginate : this.options.paginate;
     const { query = {} } = params;
-    const result = filterQuery(query, Object.assign({ paginate }, options));
+    const options = Object.assign({
+      operators: this.options.whitelist || [],
+      filters: this.options.filters,
+      paginate
+    }, opts);
+    const result = filterQuery(query, options);
 
     return Object.assign(result, { paginate });
   }

--- a/packages/adapter-commons/test/service.test.js
+++ b/packages/adapter-commons/test/service.test.js
@@ -100,8 +100,10 @@ describe('@feathersjs/adapter-commons/service', () => {
     });
   });
 
-  it('getFilters', () => {
-    const service = new CustomService();
+  it('filterQuery', () => {
+    const service = new CustomService({
+      whitelist: [ '$something' ]
+    });
     const filtered = service.filterQuery({
       query: { $limit: 10, test: 'me' }
     });
@@ -110,6 +112,16 @@ describe('@feathersjs/adapter-commons/service', () => {
       paginate: {},
       filters: { $limit: 10 },
       query: { test: 'me' }
+    });
+
+    const withWhitelisted = service.filterQuery({
+      query: { $limit: 10, $something: 'else' }
+    });
+    
+    assert.deepStrictEqual(withWhitelisted, {
+      paginate: {},
+      filters: { $limit: 10 },
+      query: { $something: 'else' }
     });
   });
 });


### PR DESCRIPTION
So that the same thing doesn't have to be done in every sub-class.