### PR TITLE
Update adapter common tests to check for falsy

### DIFF
--- a/packages/adapter-commons/lib/tests/methods.js
+++ b/packages/adapter-commons/lib/tests/methods.js
@@ -38,7 +38,7 @@ module.exports = (test, app, errors, serviceName, idProp) => {
           `${idProp} id property matches`
         );
         assert.strictEqual(data.name, 'Doug', 'data.name matches');
-        assert.strictEqual(data.age, undefined, 'data.age is undefined');
+        assert.ok(!data.age, 'data.age is falsy');
       });
 
       test('.get + id + query', async () => {
@@ -88,7 +88,7 @@ module.exports = (test, app, errors, serviceName, idProp) => {
         });
 
         assert.strictEqual(data.name, 'Doug', 'data.name matches');
-        assert.strictEqual(data.age, undefined, 'data.age is undefined');
+        assert.ok(!data.age, 'data.age is falsy');
       });
 
       test('.remove + id + query', async () => {
@@ -150,7 +150,7 @@ module.exports = (test, app, errors, serviceName, idProp) => {
           `${idProp} id matches`
         );
         assert.strictEqual(data.name, 'Dougler', 'data.name matches');
-        assert.strictEqual(data.age, undefined, 'data.age is undefined');
+        assert.ok(!data.age, 'data.age is falsy');
       });
 
       test('.update + $select', async () => {
@@ -165,7 +165,7 @@ module.exports = (test, app, errors, serviceName, idProp) => {
         });
 
         assert.strictEqual(data.name, 'Dougler', 'data.name matches');
-        assert.strictEqual(data.age, undefined, 'data.age is undefined');
+        assert.ok(!data.age, 'data.age is falsy');
       });
 
       test('.update + id + query', async () => {
@@ -218,7 +218,7 @@ module.exports = (test, app, errors, serviceName, idProp) => {
         });
 
         assert.strictEqual(data.name, 'PatchDoug', 'data.name matches');
-        assert.strictEqual(data.age, undefined, 'data.age is undefined');
+        assert.ok(!data.age, 'data.age is falsy');
       });
 
       test('.patch + id + query', async () => {
@@ -344,7 +344,7 @@ module.exports = (test, app, errors, serviceName, idProp) => {
         });
 
         assert.strictEqual(data.name, 'William', 'data.name matches');
-        assert.strictEqual(data.age, undefined, 'data.age is undefined');
+        assert.ok(!data.age, 'data.age is falsy');
 
         await service.remove(data[idProp]);
       });

--- a/packages/adapter-commons/package-lock.json
+++ b/packages/adapter-commons/package-lock.json
@@ -1,9 +1,190 @@
 {
 	"name": "@feathersjs/adapter-commons",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@feathersjs/commons": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.0.0.tgz",
+			"integrity": "sha512-hyCLse4RiNt7WLPQ0KSudjoVnwiRykhYzIZdtDon9i2usPaoYkFw/fEYZrkE5HVB+sUTwphZoZ1oOntRk1MShg=="
+		},
+		"@feathersjs/errors": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.3.5.tgz",
+			"integrity": "sha512-Nc4SxKJ7xQk5RZ3M68/Oj5c2uB/VrUATd4dLEdSGHf9j+qvajZVmBPjqDPYfY4IeTnYNhvwTmuyCulD0bCL4ZQ==",
+			"requires": {
+				"debug": "^4.0.0"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
+		"commander": {
+			"version": "2.15.1",
+			"resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"debug": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+			"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"dev": true,
+			"requires": {
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
+				"he": "1.1.1",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"supports-color": "5.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"mongodb": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.10.tgz",
@@ -88,6 +269,41 @@
 					}
 				}
 			}
+		},
+		"ms": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		}
 	}
 }


### PR DESCRIPTION
This needs to happen for SQL databases which allow `$select` but return `null` instead of `undefined`.