### PR TITLE
fix(adapter-commons): Keep Symbols when filtering a query

### DIFF
--- a/packages/adapter-commons/lib/filter-query.js
+++ b/packages/adapter-commons/lib/filter-query.js
@@ -37,19 +37,25 @@ function convertSort (sort) {
 function cleanQuery (query, operators, filters) {
   if (_.isObject(query) && query.constructor === {}.constructor) {
     const result = {};
+
     _.each(query, (value, key) => {
       if (key[0] === '$') {
-        if(filters[key] !== undefined) {
+        if (filters[key] !== undefined) {
           return;
         }
 
-        if(!operators.includes(key)) {
+        if (!operators.includes(key)) {
           throw new BadRequest(`Invalid query parameter ${key}`, query);
         }
       }
 
       result[key] = cleanQuery(value, operators, filters);
     });
+
+    Object.getOwnPropertySymbols(query).forEach(symbol => {
+      result[symbol] = query[symbol];
+    });
+
     return result;
   }
 

--- a/packages/adapter-commons/test/filter-query.test.js
+++ b/packages/adapter-commons/test/filter-query.test.js
@@ -159,6 +159,23 @@ describe('@feathersjs/adapter-commons/filterQuery', () => {
       assert.strictEqual(filters.$select, undefined);
     });
 
+    it('includes Symbols', () => {
+      const TEST = Symbol('testing');
+      const original = {
+        [TEST]: 'message',
+        other: true,
+        sub: { [TEST]: 'othermessage' }
+      };
+
+      const { query } = filterQuery(original);
+
+      assert.deepStrictEqual(query, {
+        [TEST]: 'message',
+        other: true,
+        sub: { [TEST]: 'othermessage' }
+      });
+    });
+
     it('only converts plain objects', () => {
       const userId = ObjectId();
       const original = {
@@ -176,7 +193,7 @@ describe('@feathersjs/adapter-commons/filterQuery', () => {
       try {
         filterQuery({ $select: 1, $known: 1 });
         assert.ok(false, 'Should never get here');
-      } catch(error) {
+      } catch (error) {
         assert.strictEqual(error.message, 'Invalid query parameter $known');
       }
     });

--- a/packages/adapter-commons/test/service.test.js
+++ b/packages/adapter-commons/test/service.test.js
@@ -126,7 +126,7 @@ describe('@feathersjs/adapter-commons/service', () => {
     const withWhitelisted = service.filterQuery({
       query: { $limit: 10, $something: 'else' }
     });
-    
+
     assert.deepStrictEqual(withWhitelisted, {
       paginate: {},
       filters: { $limit: 10 },


### PR DESCRIPTION
This is important for Sequelize which uses internal Symbols to create safe queries.