### PR TITLE
fix: Do not inherit app object from Object prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 
 # Distributables
 dist/
+.nyc_output/

--- a/packages/feathers/lib/index.js
+++ b/packages/feathers/lib/index.js
@@ -3,9 +3,12 @@ const Proto = require('uberproto');
 const Application = require('./application');
 const version = require('./version');
 const { ACTIVATE_HOOKS, activateHooks } = require('./hooks');
+// A base object Prototype that does not inherit from a
+// potentially polluted Object prototype
+const baseObject = Object.create(null);
 
 function createApplication () {
-  const app = Object.create(null);
+  const app = Object.create(baseObject);
 
   // Mix in the base application
   Proto.mixin(Application, app);


### PR DESCRIPTION
It appears that some browsers (or plugins or something) override the Object prototype, specifically the `init` property, which we use to call to initialize the application (causing `.init is not a function` errors). The best way to avoid this is to inherit from `null` instead of the Object prototype.