### PR TITLE
[authentication] Consider data.payload in authentication.create

### DIFF
--- a/packages/authentication/lib/service.js
+++ b/packages/authentication/lib/service.js
@@ -12,7 +12,7 @@ class Service {
 
   create (data = {}, params = {}) {
     const defaults = this.app.get('authentication') || this.app.get('auth');
-    const payload = params.payload;
+    const payload = params.payload || data.payload;
 
     // create accessToken
     // TODO (EK): Support refresh tokens


### PR DESCRIPTION
### Summary

The docs state that "Anything included in the data.payload object will be in the JWT's payload. If you include a payload object in params, it's properties will take precedence over data" which was not the case. It only considered payload inside params and not data

https://docs.feathersjs.com/api/authentication/server.html#servicecreatedata

- [x] Are there any open issues that are related to this?
No

- [x] Is this PR dependent on PRs in other repos?
No