### PR TITLE
fix: Add test to make sure different id in adapter query works

### DIFF
--- a/packages/adapter-tests/lib/methods.js
+++ b/packages/adapter-tests/lib/methods.js
@@ -52,17 +52,6 @@ module.exports = (test, app, errors, serviceName, idProp) => {
             'Got a NotFound Feathers error'
           );
         }
-
-        try {
-          await service.get(doug[idProp], {
-            query: { [idProp]: '568225fbfe21222432e836ff' }
-          });
-          throw new Error('Should never get here');
-        } catch (error) {
-          assert.ok(error instanceof errors.NotFound,
-            'Got a NotFound Feathers error'
-          );
-        }
       });
 
       test('.get + NotFound', async () => {
@@ -74,6 +63,26 @@ module.exports = (test, app, errors, serviceName, idProp) => {
             'Error is a NotFound Feathers error'
           );
         }
+      });
+
+      test('.get + id + query id', async () => {
+        const alice = await service.create({
+          name: 'Alice',
+          age: 12
+        });
+
+        try {
+          await service.get(doug[idProp], {
+            query: { [idProp]: alice[idProp] }
+          });
+          throw new Error('Should never get here');
+        } catch (error) {
+          assert.ok(error instanceof errors.NotFound,
+            'Got a NotFound Feathers error'
+          );
+        }
+
+        await service.remove(alice[idProp]);
       });
     });
 
@@ -113,17 +122,6 @@ module.exports = (test, app, errors, serviceName, idProp) => {
             'Got a NotFound Feathers error'
           );
         }
-
-        try {
-          await service.remove(doug[idProp], {
-            query: { [idProp]: '568225fbfe21222432e836ff' }
-          });
-          throw new Error('Should never get here');
-        } catch (error) {
-          assert.ok(error instanceof errors.NotFound,
-            'Got a NotFound Feathers error'
-          );
-        }
       });
 
       test('.remove + multi', async () => {
@@ -155,6 +153,26 @@ module.exports = (test, app, errors, serviceName, idProp) => {
 
         assert.ok(names.includes('Dave'), 'Dave removed');
         assert.ok(names.includes('David'), 'David removed');
+      });
+
+      test('.remove + id + query id', async () => {
+        const alice = await service.create({
+          name: 'Alice',
+          age: 12
+        });
+
+        try {
+          await service.remove(doug[idProp], {
+            query: { [idProp]: alice[idProp] }
+          });
+          throw new Error('Should never get here');
+        } catch (error) {
+          assert.ok(error instanceof errors.NotFound,
+            'Got a NotFound Feathers error'
+          );
+        }
+
+        await service.remove(alice[idProp]);
       });
     });
 
@@ -203,19 +221,6 @@ module.exports = (test, app, errors, serviceName, idProp) => {
             'Got a NotFound Feathers error'
           );
         }
-
-        try {
-          await service.update(doug[idProp], {
-            name: 'Dougler'
-          }, {
-            query: { [idProp]: '568225fbfe21222432e836ff' }
-          });
-          throw new Error('Should never get here');
-        } catch (error) {
-          assert.ok(error instanceof errors.NotFound,
-            'Got a NotFound Feathers error'
-          );
-        }
       });
 
       test('.update + NotFound', async () => {
@@ -225,6 +230,29 @@ module.exports = (test, app, errors, serviceName, idProp) => {
         } catch (error) {
           assert.ok(error instanceof errors.NotFound, 'Error is a NotFound Feathers error');
         }
+      });
+
+      test('.update + id + query id', async () => {
+        const alice = await service.create({
+          name: 'Alice',
+          age: 12
+        });
+
+        try {
+          await service.update(doug[idProp], {
+            name: 'Dougler',
+            age: 33
+          }, {
+            query: { [idProp]: alice[idProp] }
+          });
+          throw new Error('Should never get here');
+        } catch (error) {
+          assert.ok(error instanceof errors.NotFound,
+            'Got a NotFound Feathers error'
+          );
+        }
+
+        await service.remove(alice[idProp]);
       });
     });
 
@@ -262,19 +290,6 @@ module.exports = (test, app, errors, serviceName, idProp) => {
             name: 'id patched doug'
           }, {
             query: { name: 'Tester' }
-          });
-          throw new Error('Should never get here');
-        } catch (error) {
-          assert.ok(error instanceof errors.NotFound,
-            'Got a NotFound Feathers error'
-          );
-        }
-
-        try {
-          await service.patch(doug[idProp], {
-            name: 'id patched doug'
-          }, {
-            query: { [idProp]: '568225fbfe21222432e836ff' }
           });
           throw new Error('Should never get here');
         } catch (error) {
@@ -359,6 +374,28 @@ module.exports = (test, app, errors, serviceName, idProp) => {
             'Error is a NotFound Feathers error'
           );
         }
+      });
+
+      test('.patch + id + query id', async () => {
+        const alice = await service.create({
+          name: 'Alice',
+          age: 12
+        });
+
+        try {
+          await service.patch(doug[idProp], {
+            age: 33
+          }, {
+            query: { [idProp]: alice[idProp] }
+          });
+          throw new Error('Should never get here');
+        } catch (error) {
+          assert.ok(error instanceof errors.NotFound,
+            'Got a NotFound Feathers error'
+          );
+        }
+
+        await service.remove(alice[idProp]);
       });
     });
 

--- a/packages/adapter-tests/package-lock.json
+++ b/packages/adapter-tests/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathersjs/adapter-tests",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -27,6 +27,35 @@
       "dev": true,
       "requires": {
         "debug": "^4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@feathersjs/feathers": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.3.1.tgz",
+      "integrity": "sha512-Mb7Maz03TIIksomXeInmXNb5ykxgsAyBCuJDQHK+oIDrDRR9m+ZbUrslCkMk/s0nr6cW5DmVbWz9s11SCXFW5A==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/commons": "^4.0.0",
+        "debug": "^4.0.0",
+        "events": "^3.0.0",
+        "uberproto": "^2.0.2"
       },
       "dependencies": {
         "debug": {
@@ -99,6 +128,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
       "dev": true
     },
     "feathers-memory": {
@@ -245,6 +280,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "uberproto": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-2.0.4.tgz",
+      "integrity": "sha512-c/5xjTcztW9XVhrkCycHQRBIAxww5JpDKk/q0zc2tVdQn6ZQvnChWgLvQaWAT1Al5JvRyvloUI15ad41m6dYwg==",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/packages/adapter-tests/test/index.test.js
+++ b/packages/adapter-tests/test/index.test.js
@@ -60,7 +60,11 @@ const testSuite = adapterTests([
   '.find + paginate',
   '.find + paginate + $limit + $skip',
   '.find + paginate + $limit 0',
-  '.find + paginate + params'
+  '.find + paginate + params',
+  '.get + id + query id',
+  '.remove + id + query id',
+  '.update + id + query id',
+  '.patch + id + query id'
 ]);
 
 describe('Feathers Memory Service', () => {


### PR DESCRIPTION
Adds an explicit test that makes sure that when a different adapter `id` property is in the query it will not succeed.