### PR TITLE
fix: added '$and' operator in filter-query

### DIFF
--- a/packages/adapter-commons/lib/filter-query.js
+++ b/packages/adapter-commons/lib/filter-query.js
@@ -89,7 +89,7 @@ const FILTERS = {
   $select: (value) => value
 };
 
-const OPERATORS = ['$in', '$nin', '$lt', '$lte', '$gt', '$gte', '$ne', '$or'];
+const OPERATORS = ['$in', '$nin', '$lt', '$lte', '$gt', '$gte', '$ne', '$or', '$and'];
 
 // Converts Feathers special query parameters and pagination settings
 // and returns them separately a `filters` and the rest of the query


### PR DESCRIPTION
### Summary

Added '$and' operator in filter-query operators.

- [ ] Tell us about the problem your pull request is solving.
     - According to the manual, https://docs.mongodb.com/manual/reference/operator/query/and/   '$and' 
       is a permitted operator, but not listed in the `@feathersjs/adapter-commons/lib/filter-query.js`
       `const OPERATORS = ['$in', '$nin', '$lt', '$lte', '$gt', '$gte', '$ne', '$or'];`
- [ ] Are there any open issues that are related to this? - NO
- [ ] Is this PR dependent on PRs in other repos? - NO

### Other Information

Say, i wanted to check for a condition like columnA value must not-be '1.5' but the value must be greater than 0 and the columnA must be less than 5, then i would like to form a `and condition` which i dynamically build using `jQuery builder` like below:

`service.find( { $and: [ { columnA: { $ne: 1.5 } }, { columnA: { $gt: 0 } }, { columnA: { $lt: 5 } } ] } )`

This is currently not possible as '$and' throws 'Invalid query parameter '$and' '