### PR TITLE
fix(authentication): Fall back when req.app is not the application …

### DIFF
--- a/packages/authentication-oauth1/lib/index.js
+++ b/packages/authentication-oauth1/lib/index.js
@@ -79,7 +79,7 @@ function init (options = {}) {
       auth.express.authenticate(name, oauth1Settings),
       handler,
       errorHandler,
-      auth.express.emitEvents(authSettings),
+      auth.express.emitEvents(authSettings, app),
       auth.express.setCookie(authSettings),
       auth.express.successRedirect(),
       auth.express.failureRedirect(authSettings),

--- a/packages/authentication-oauth2/lib/index.js
+++ b/packages/authentication-oauth2/lib/index.js
@@ -91,7 +91,7 @@ function init (options = {}) {
       auth.express.authenticate(name, omit(oauth2Settings, 'state')),
       handler,
       errorHandler,
-      auth.express.emitEvents(authSettings),
+      auth.express.emitEvents(authSettings, app),
       auth.express.setCookie(authSettings),
       auth.express.successRedirect(),
       auth.express.failureRedirect(authSettings),

--- a/packages/authentication/lib/express/emit-events.js
+++ b/packages/authentication/lib/express/emit-events.js
@@ -2,7 +2,7 @@ const Debug = require('debug');
 
 const debug = Debug('feathers-authentication:express:emit-events');
 
-module.exports = function emitEvents () {
+module.exports = function emitEvents (settings, _app) {
   return function (req, res, next) {
     const method = res.hook && res.hook.method;
 
@@ -15,7 +15,7 @@ module.exports = function emitEvents () {
     }
 
     if (res.data && res.data.accessToken && event) {
-      const { app } = req;
+      const app = req.app && typeof req.app.emit === 'function' ? req.app : _app;
 
       debug(`Sending '${event}' event for REST provider. Token is`, res.data.accessToken);
 

--- a/packages/authentication/lib/service.js
+++ b/packages/authentication/lib/service.js
@@ -60,7 +60,7 @@ module.exports = function init (options) {
     app.use(
       path,
       new Service(app, options),
-      emitEvents(options),
+      emitEvents(options, app),
       setCookie(options),
       successRedirect(),
       failureRedirect(options)

--- a/packages/authentication/test/express/emit-events.test.js
+++ b/packages/authentication/test/express/emit-events.test.js
@@ -63,6 +63,19 @@ describe('express:emitEvents', () => {
         done();
       });
     });
+
+    it('works with app fallback', done => {
+      const fallback = {
+        emit: sinon.spy()
+      };
+      delete req.app.emit;
+      emitEvents({}, fallback)(req, res, () => {
+        expect(fallback.emit).to.have.been.calledOnce;
+        expect(fallback.emit).to.have.been.calledWith('login', res.data, { provider: 'rest', req, res });
+        req.app.emit = sinon.spy();
+        done();
+      });
+    });
   });
 
   describe('when remove method was called', () => {


### PR DESCRIPTION
When emitting events. Not entirely clear when this might be happening but this adds a fallback to the actual application object when `req.app` is not what we expect.

Closes #1183
