### PR TITLE
chore: Add Lock bot configuration

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,26 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 90
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This issue has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue
+  with a link to this issue for related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
Adds the configuration for the [lock-threads GitHub bot](https://github.com/dessant/lock-threads) that automatically locks closed issues. Comments on closed issues usually will not get a reply and should be opened as new issues instead.