### PR TITLE
Allow for removing JWT fields via json configuration.

### DIFF
--- a/packages/authentication/lib/options.js
+++ b/packages/authentication/lib/options.js
@@ -13,6 +13,7 @@ const defaults = {
     httpOnly: false,
     secure: true
   },
+  jwtRemoveOptions: [],
   jwt: {
     header: { typ: 'access' }, // by default is an access token but can be any type
     audience: 'https://yourdomain.com', // The resource server where the token is processed
@@ -24,5 +25,11 @@ const defaults = {
 };
 
 module.exports = function (...otherOptions) {
-  return merge({}, defaults, ...otherOptions);
+  const mergedOptions = merge({}, defaults, ...otherOptions);
+  for (let idx in mergedOptions.jwtRemoveOptions)
+  {
+    let optionName = mergedOptions.jwtRemoveOptions[idx];
+    delete mergedOptions.jwt[optionName];
+  }
+  return mergedOptions;
 };

--- a/packages/authentication/lib/socket/handler.js
+++ b/packages/authentication/lib/socket/handler.js
@@ -119,10 +119,13 @@ module.exports = function setupSocketHandler (app, options, { feathersParams, pr
             lt.clearTimeout(logoutTimer);
           }
 
-          logoutTimer = lt.setTimeout(() => {
-            debug(`Token expired. Logging out.`);
-            logout();
-          }, ms(authSettings.jwt.expiresIn));
+          if (typeof authSettings.jwt.expiresIn != 'undefined')
+          {
+            logoutTimer = lt.setTimeout(() => {
+              debug(`Token expired. Logging out.`);
+              logout();
+            }, ms(authSettings.jwt.expiresIn));
+          }
 
           // TODO (EK): Setup and tear down socket listeners to keep the entity
           // up to date that should be attached to the socket. Need to get the


### PR DESCRIPTION
jsonwebtoken actually supports not setting the following fields:
expiresIn
issuer
subject
audience
iat

And perhaps others.
Taking expiresIn as an example, if this is undefined, it means the JWT should never expire and will not have an exp field:
Furthermore, the option must be completely undefined to achieve this behavior, explicitly setting it to undefined, null, or 0 is not sufficient:
https://github.com/auth0/node-jsonwebtoken/issues/417
This means there needs to be a way of explicitly removing these keys from the jwt options object.

feathers/authentication is always providing default values for these fields,
and didn't seem to any working facility for overwriting them programatically at runtime.
A previously mentioned technique of overriding jwt parameters via context.params.jwt.* (https://github.com/feathersjs/feathers/issues/776)
no longer works because context.params.jwt is not available in the auth/before hook. I don't know why this is the case, and I would have to investigate the git history extensively to find out.

In any case, I thought it would be nice to have a declarative way (rather than programmatic) to remove various jwt options/fields by setting a configuration option, so this commit adds a "jwtRemoveOptions" to the authentication section of the feathers configuration. This should be set to an array of key names to remove from the jwt options.

In addition, a conditional was placed around the setTimeout: if expiresIn is undefined it doesn't set the timeout.
