### PR TITLE
Switch to fixed common versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent",
+  "version": "3.3.1",
   "command": {
     "bootstrap": {
       "hoist": true


### PR DESCRIPTION
Although I tried explaining the advantages of independent versioning and how Feathers is composed of individual (and optional) modules there seems to be recurring confusion about Feathers version names and numbers.

Since the new authentication system contains a lot of changes anyway, this seems like a good time to also move to fixed common versioning of all modules in this repository like Babel and others are doing already.

So Feathers Crow will be `@feathersjs/feathers` and all other `@feathersjs/*` modules version `4.x`, Dove will be `5.x` etc. There will be `4.0.0-pre` prereleases, however since `@feathersjs/transport-commons` is already at version `4.2.1` the final release of all modules will start at `4.3.0`.