### PR TITLE
feat: Remove (hook, next) signature and SKIP support

### DIFF
--- a/packages/authentication/lib/service.js
+++ b/packages/authentication/lib/service.js
@@ -56,7 +56,7 @@ module.exports = class AuthenticationService extends AuthenticationCore {
         if (authResult.accessToken) {
           return authResult;
         }
-        
+
         debug('Creating JWT with', payload, jwtOptions);
 
         return this.createJWT(payload, jwtOptions, params.secret)

--- a/packages/commons/test/hooks.test.js
+++ b/packages/commons/test/hooks.test.js
@@ -274,67 +274,14 @@ describe('hook utilities', () => {
           return Promise.resolve(hook);
         },
 
-        function (hook, next) {
-          hook.chain.push('second');
-
-          next();
-        },
-
         hook => {
-          hook.chain.push('third');
+          hook.chain.push('second');
         },
 
         function (hook) {
-          hook.chain.push('fourth');
-
-          return hook;
-        }
-      ], dummyHook);
-
-      return promise.then(result => {
-        expect(result).to.deep.equal({
-          type: 'dummy',
-          method: 'something',
-          chain: [ 'first', 'second', 'third', 'fourth' ]
-        });
-      });
-    });
-
-    it('skip further hooks', () => {
-      const dummyHook = {
-        type: 'dummy',
-        method: 'something'
-      };
-
-      const promise = hooks.processHooks([
-        function (hook) {
-          hook.chain = [ 'first' ];
-
-          return Promise.resolve(hook);
-        },
-
-        function (hook, next) {
-          hook.chain.push('second');
-
-          next();
-        },
-
-        hook => {
           hook.chain.push('third');
 
-          return hooks.SKIP;
-        },
-
-        function (hook) {
-          hook.chain.push('fourth');
-
           return hook;
-        },
-
-        function (hook, next) {
-          hook.chain.push('fourth');
-
-          next();
         }
       ], dummyHook);
 
@@ -344,30 +291,6 @@ describe('hook utilities', () => {
           method: 'something',
           chain: [ 'first', 'second', 'third' ]
         });
-      });
-    });
-
-    it('next and next with error', () => {
-      const dummyHook = {
-        type: 'dummy',
-        method: 'something'
-      };
-
-      const promise = hooks.processHooks([
-        function (hook, next) {
-          hook.test = 'first ran';
-
-          next();
-        },
-
-        function (hook, next) {
-          next(new Error('This did not work'));
-        }
-      ], dummyHook);
-
-      return promise.catch(error => {
-        expect(error.message).to.equal('This did not work');
-        expect(error.hook.test).to.equal('first ran');
       });
     });
 

--- a/packages/feathers/lib/index.js
+++ b/packages/feathers/lib/index.js
@@ -1,4 +1,3 @@
-const { hooks } = require('@feathersjs/commons');
 const Proto = require('uberproto');
 const Application = require('./application');
 const version = require('./version');

--- a/packages/feathers/lib/index.js
+++ b/packages/feathers/lib/index.js
@@ -19,7 +19,6 @@ function createApplication () {
 }
 
 createApplication.version = version;
-createApplication.SKIP = hooks.SKIP;
 createApplication.ACTIVATE_HOOKS = ACTIVATE_HOOKS;
 createApplication.activateHooks = activateHooks;
 

--- a/packages/feathers/test/application.test.js
+++ b/packages/feathers/test/application.test.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 const Proto = require('uberproto');
-const { hooks } = require('@feathersjs/commons');
 const feathers = require('../lib');
 
 describe('Feathers application', () => {

--- a/packages/feathers/test/application.test.js
+++ b/packages/feathers/test/application.test.js
@@ -23,10 +23,6 @@ describe('Feathers application', () => {
     assert.strictEqual(app.version, '3.0.0-development');
   });
 
-  it('sets SKIP on main', () => {
-    assert.strictEqual(feathers.SKIP, hooks.SKIP);
-  });
-
   it('is an event emitter', done => {
     const app = feathers();
     const original = { hello: 'world' };

--- a/packages/feathers/test/hooks/after.test.js
+++ b/packages/feathers/test/hooks/after.test.js
@@ -120,12 +120,12 @@ describe('`after` hooks', () => {
 
       service.hooks({
         after: {
-          create (hook, next) {
+          create (hook) {
             assert.strictEqual(hook.type, 'after');
 
             hook.result.some = 'thing';
 
-            next(null, hook);
+            return hook;
           }
         }
       });
@@ -147,11 +147,11 @@ describe('`after` hooks', () => {
 
       service.hooks({
         after: {
-          create (hook, next) {
+          create (hook) {
             hook.result.appPresent = typeof hook.app !== 'undefined';
             assert.strictEqual(hook.result.appPresent, true);
 
-            next(null, hook);
+            return hook;
           }
         }
       });
@@ -173,8 +173,8 @@ describe('`after` hooks', () => {
 
       service.hooks({
         after: {
-          update (hook, next) {
-            next(new Error('This did not work'));
+          update () {
+            throw new Error('This did not work');
           }
         }
       });
@@ -221,19 +221,18 @@ describe('`after` hooks', () => {
 
       service.hooks({
         after: {
-          create (hook, next) {
+          create (hook) {
             hook.result.some = 'thing';
-            next();
+
+            return hook;
           }
         }
       });
 
       service.hooks({
         after: {
-          create (hook, next) {
+          create (hook) {
             hook.result.other = 'stuff';
-
-            next();
           }
         }
       });
@@ -260,14 +259,15 @@ describe('`after` hooks', () => {
       service.hooks({
         after: {
           create: [
-            function (hook, next) {
+            function (hook) {
               hook.result.some = 'thing';
-              next();
+
+              return hook;
             },
-            function (hook, next) {
+            function (hook) {
               hook.result.other = 'stuff';
 
-              next();
+              return hook;
             }
           ]
         }
@@ -293,9 +293,10 @@ describe('`after` hooks', () => {
 
       service.hooks({
         after: {
-          get (hook, next) {
+          get (hook) {
             hook.result.items = ['first'];
-            next();
+
+            return hook;
           }
         }
       });
@@ -303,13 +304,15 @@ describe('`after` hooks', () => {
       service.hooks({
         after: {
           get: [
-            function (hook, next) {
+            function (hook) {
               hook.result.items.push('second');
-              next();
+
+              return hook;
             },
-            function (hook, next) {
+            function (hook) {
               hook.result.items.push('third');
-              next();
+
+              return hook;
             }
           ]
         }
@@ -338,18 +341,20 @@ describe('`after` hooks', () => {
 
       service.hooks({
         after: {
-          all (hook, next) {
+          all (hook) {
             hook.result.afterAllObject = true;
-            next();
+
+            return hook;
           }
         }
       });
 
       service.hooks({
         after: [
-          function (hook, next) {
+          function (hook) {
             hook.result.afterAllMethodArray = true;
-            next();
+
+            return hook;
           }
         ]
       });
@@ -380,9 +385,10 @@ describe('`after` hooks', () => {
 
       service.hooks({
         after: {
-          get (hook, next) {
+          get (hook) {
             hook.result.test = this.number + 1;
-            next();
+
+            return hook;
           }
         }
       });
@@ -394,33 +400,6 @@ describe('`after` hooks', () => {
           test: 43
         });
       });
-    });
-
-    it('can not call next() multiple times', () => {
-      const app = feathers().use('/dummy', {
-        get (id) {
-          return Promise.resolve({ id });
-        }
-      });
-
-      const service = app.service('dummy');
-
-      service.hooks({
-        after: {
-          get: [
-            function (hook, next) {
-              next();
-            },
-
-            function (hook, next) {
-              next();
-              next();
-            }
-          ]
-        }
-      });
-
-      return service.get(10);
     });
   });
 });

--- a/packages/feathers/test/hooks/before.test.js
+++ b/packages/feathers/test/hooks/before.test.js
@@ -182,7 +182,7 @@ describe('`before` hooks', () => {
 
       service.hooks({
         before: {
-          create (hook, next) {
+          create (hook) {
             assert.strictEqual(hook.type, 'before');
 
             hook.data.modified = 'data';
@@ -191,7 +191,7 @@ describe('`before` hooks', () => {
               modified: 'params'
             });
 
-            next(null, hook);
+            return hook;
           }
         }
       });
@@ -216,10 +216,11 @@ describe('`before` hooks', () => {
 
       someService.hooks({
         before: {
-          create (hook, next) {
+          create (hook) {
             hook.data.appPresent = typeof hook.app !== 'undefined';
             assert.strictEqual(hook.data.appPresent, true);
-            next(null, hook);
+
+            return hook;
           }
         }
       });
@@ -244,8 +245,8 @@ describe('`before` hooks', () => {
 
       service.hooks({
         before: {
-          update (hook, next) {
-            next(new Error('You are not allowed to update'));
+          update () {
+            throw new Error('You are not allowed to update');
           }
         }
       });
@@ -271,8 +272,8 @@ describe('`before` hooks', () => {
 
       service.hooks({
         before: {
-          remove (hook, next) {
-            next();
+          remove (hook) {
+            return hook;
           }
         }
       });
@@ -301,20 +302,20 @@ describe('`before` hooks', () => {
 
       service.hooks({
         before: {
-          create (hook, next) {
+          create (hook) {
             hook.params.modified = 'params';
 
-            next();
+            return hook;
           }
         }
       });
 
       service.hooks({
         before: {
-          create (hook, next) {
+          create (hook) {
             hook.data.modified = 'second data';
 
-            next();
+            return hook;
           }
         }
       });
@@ -344,15 +345,15 @@ describe('`before` hooks', () => {
       service.hooks({
         before: {
           create: [
-            function (hook, next) {
+            function (hook) {
               hook.params.modified = 'params';
 
-              next();
+              return hook;
             },
-            function (hook, next) {
+            function (hook) {
               hook.data.modified = 'second data';
 
-              next();
+              return hook;
             }
           ]
         }
@@ -377,9 +378,10 @@ describe('`before` hooks', () => {
 
       service.hooks({
         before: {
-          get (hook, next) {
+          get (hook) {
             hook.params.items = ['first'];
-            next();
+
+            return hook;
           }
         }
       });
@@ -387,13 +389,15 @@ describe('`before` hooks', () => {
       service.hooks({
         before: {
           get: [
-            function (hook, next) {
+            function (hook) {
               hook.params.items.push('second');
-              next();
+
+              return hook;
             },
-            function (hook, next) {
+            function (hook) {
               hook.params.items.push('third');
-              next();
+
+              return hook;
             }
           ]
         }
@@ -426,18 +430,20 @@ describe('`before` hooks', () => {
 
       service.hooks({
         before: {
-          all (hook, next) {
+          all (hook) {
             hook.params.beforeAllObject = true;
-            next();
+
+            return hook;
           }
         }
       });
 
       service.hooks({
         before: [
-          function (hook, next) {
+          function (hook) {
             hook.params.beforeAllMethodArray = true;
-            next();
+
+            return hook;
           }
         ]
       });
@@ -461,9 +467,10 @@ describe('`before` hooks', () => {
 
       service.hooks({
         before: {
-          get (hook, next) {
+          get (hook) {
             hook.params.test = this.number + 2;
-            next();
+
+            return hook;
           }
         }
       });
@@ -474,35 +481,6 @@ describe('`before` hooks', () => {
           number: 42,
           test: 44
         });
-      });
-    });
-
-    it('calling next() multiple times does not do anything', () => {
-      const app = feathers().use('/dummy', {
-        get (id) {
-          return Promise.resolve({ id });
-        }
-      });
-
-      const service = app.service('dummy');
-
-      service.hooks({
-        before: {
-          get: [
-            function (hook, next) {
-              next();
-            },
-
-            function (hook, next) {
-              next();
-              next();
-            }
-          ]
-        }
-      });
-
-      return service.get(10).then(data => {
-        assert.deepStrictEqual(data, { id: 10 });
       });
     });
   });

--- a/packages/feathers/test/hooks/error.test.js
+++ b/packages/feathers/test/hooks/error.test.js
@@ -76,8 +76,8 @@ describe('`error` hooks', () => {
     it('calling `next` with error', () => {
       service.hooks({
         error: {
-          get (hook, next) {
-            next(new Error(errorMessage));
+          get () {
+            throw new Error(errorMessage);
           }
         }
       });
@@ -102,10 +102,10 @@ describe('`error` hooks', () => {
               return Promise.resolve(hook);
             },
 
-            function (hook, next) {
+            function (hook) {
               hook.error.third = true;
 
-              next();
+              return hook;
             }
           ]
         }


### PR DESCRIPTION
In preparation to support Koa style hooks (see #932) this pull request

- Removes the `(context, next)` signature. This has not been documented or used since the Auk release.
- Removes `feathers.SKIP` to skip the following hooks. It turned out to cause issues because
  - It is not easily possible to see if a hook makes its following hooks skip. This made hook chains very hard to debug.
  - Returning SKIP also messes with Feathers internals like the event system

The use-cases for `feathers.SKIP` can now be explicitly handled by

- [Running hooks conditionally](https://feathers-plus.github.io/v1/feathers-hooks-common/#iff) through a flag
- [Calling the hook-less service methods](https://crow.docs.feathersjs.com/migrating.html#hook-less-service-methods) of the database adapters
- Setting `context.event = null` to skip event emitting (#1270)