### PR TITLE
feat: Allow to skip sending service events

### DIFF
--- a/packages/feathers/lib/events.js
+++ b/packages/feathers/lib/events.js
@@ -6,7 +6,7 @@ const Proto = require('uberproto');
 const eventHook = exports.eventHook = function eventHook () {
   return function (hook) {
     const { app, service } = hook;
-    const eventName = app.eventMappings[hook.method];
+    const eventName = hook.event === null ? hook.event : app.eventMappings[hook.method];
     const isHookEvent = service._hookEvents && service._hookEvents.indexOf(eventName) !== -1;
 
     // If this event is not being sent yet and we are not in an error hook

--- a/packages/feathers/test/events.test.js
+++ b/packages/feathers/test/events.test.js
@@ -56,6 +56,32 @@ describe('Service events', () => {
       service.create({ message: 'Hello' });
     });
 
+    it('allows to skip event emitting', done => {
+      const app = feathers().use('/creator', {
+        create (data) {
+          return Promise.resolve(data);
+        }
+      });
+
+      const service = app.service('creator');
+
+      service.hooks({
+        before: {
+          create (context) {
+            context.event = null;
+
+            return context;
+          }
+        }
+      });
+
+      service.on('created', data => {
+        done(new Error('Should never get here'));
+      });
+
+      service.create({ message: 'Hello' }).then(() => done());
+    });
+
     it('.update and updated', done => {
       const app = feathers().use('/creator', {
         update (id, data) {


### PR DESCRIPTION
Allow to skip the service event by setting `context.event = null;` in a hook.

Closes #862