### PR TITLE
feat: Support params symbol to skip authenticate hook

### DIFF
--- a/packages/authentication/src/core.ts
+++ b/packages/authentication/src/core.ts
@@ -12,6 +12,9 @@ const debug = Debug('@feathersjs/authentication/base');
 const verifyJWT = promisify(jsonwebtoken.verify);
 const createJWT = promisify(jsonwebtoken.sign);
 
+// TypeScript hack because it does not allow symbols as indexes!?
+export const AUTHENTICATE: string = Symbol('@feathersjs/authentication/internal') as any;
+
 export interface AuthenticationResult {
   [key: string]: any;
 }
@@ -205,7 +208,10 @@ export class AuthenticationBase {
     }
 
     const { strategy } = authentication;
-    const authParams = Object.assign(params, { authentication: true });
+    const authParams = {
+      ...params,
+      [AUTHENTICATE]: false
+    };
 
     // Throw an error is a `strategy` is indicated but not in the allowed strategies
     if (strategy && !allowed.includes(strategy)) {

--- a/packages/authentication/src/hooks/authenticate.ts
+++ b/packages/authentication/src/hooks/authenticate.ts
@@ -3,6 +3,7 @@ import { HookContext } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
 import Debug from 'debug';
 import { AuthenticationService } from '../service';
+import { AUTHENTICATE } from '../core';
 
 const debug = Debug('@feathersjs/authentication/hooks/authenticate');
 
@@ -44,7 +45,11 @@ export default (originalSettings: string|AuthenticateHookSettings, ...originalSt
       throw new NotAuthenticated('The authenticate hook does not need to be used on the authentication service');
     }
 
-    if (authentication && authentication !== true) {
+    if (params[AUTHENTICATE] === false) {
+      return context;
+    }
+
+    if (authentication) {
       const authParams = omit(params, 'provider', 'authentication');
 
       debug('Authenticating with', authentication, strategies);

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -8,7 +8,8 @@ export {
   AuthenticationBase,
   AuthenticationRequest,
   AuthenticationResult,
-  AuthenticationStrategy
+  AuthenticationStrategy,
+  AUTHENTICATE
 } from './core';
 export { AuthenticationBaseStrategy } from './strategy';
 export { AuthenticationService } from './service';

--- a/packages/authentication/test/core.test.ts
+++ b/packages/authentication/test/core.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import feathers, { Application } from '@feathersjs/feathers';
 import jwt from 'jsonwebtoken';
 
-import { AuthenticationBase } from '../src/core';
+import { AuthenticationBase, AUTHENTICATE } from '../src/core';
 import { Strategy1, Strategy2, MockRequest } from './fixtures';
 import { ServerResponse } from 'http';
 
@@ -141,7 +141,7 @@ describe('authentication/core', () => {
 
         assert.deepStrictEqual(result, Object.assign({}, Strategy2.result, {
           authentication,
-          params: { authentication: true }
+          params: { [AUTHENTICATE]: false }
         }));
       });
 
@@ -159,7 +159,7 @@ describe('authentication/core', () => {
 
         assert.deepStrictEqual(result, Object.assign({
           params: Object.assign(params, {
-            authentication: true
+            [AUTHENTICATE]: false
           }),
           authentication
         }, Strategy2.result));
@@ -198,7 +198,7 @@ describe('authentication/core', () => {
 
         assert.deepStrictEqual(result, Object.assign({
           authentication,
-          params: { authentication: true }
+          params: { [AUTHENTICATE]: false }
         }, Strategy2.result));
       });
 

--- a/packages/authentication/test/hooks/authenticate.test.ts
+++ b/packages/authentication/test/hooks/authenticate.test.ts
@@ -3,7 +3,7 @@ import feathers, { Application, Params, Service } from '@feathersjs/feathers';
 
 import { Strategy1, Strategy2 } from '../fixtures';
 import { AuthenticationService, hooks } from '../../src';
-import { AuthenticationResult } from '../../src/core';
+import { AuthenticationResult, AUTHENTICATE } from '../../src/core';
 
 const { authenticate } = hooks;
 
@@ -147,7 +147,7 @@ describe('authentication/hooks/authenticate', () => {
 
     assert.deepStrictEqual(result, Object.assign({
       authentication: params.authentication,
-      params: { authentication: true }
+      params: {}
     }, Strategy2.result));
   });
 
@@ -183,16 +183,14 @@ describe('authentication/hooks/authenticate', () => {
     }
   });
 
-  it('passes with authentication true but external call', async () => {
-    const result = await app.service('users').get(1, {
+  it('passes with [AUTHENTICATE]: false but external call', async () => {
+    const params = {
       provider: 'rest',
-      authentication: true
-    });
+      [AUTHENTICATE]: false
+    };
+    const result = await app.service('users').get(1, params);
 
-    assert.deepStrictEqual(result, {
-      provider: 'rest',
-      authentication: true
-    });
+    assert.deepStrictEqual(result, params);
   });
 
   it('errors when used on the authentication service', async () => {


### PR DESCRIPTION
When running authentication strategies the `params` are being passed on but there needs to be an indicator for the `authenticate` hook to not run to avoid infinite loops (e.g. if a service called by an authentication strategy also has the `authenticate` hook). This PR adds an `AUTHENTICATE` symbol that the authentication core uses as a flag to skip the `authenticate` hook.