### PR TITLE
feat: Add authentication through oAuth redirect to authentication client

### DIFF
--- a/packages/authentication-client/src/index.ts
+++ b/packages/authentication-client/src/index.ts
@@ -1,7 +1,8 @@
-import { AuthenticationClient, Storage, AuthenticationClientOptions } from './core';
+import { AuthenticationClient, AuthenticationClientOptions } from './core';
 import * as hooks from './hooks';
 import { Application } from '@feathersjs/feathers';
 import { AuthenticationResult, AuthenticationRequest } from '@feathersjs/authentication';
+import { Storage, MemoryStorage, StorageWrapper } from './storage';
 
 declare module '@feathersjs/feathers' {
   interface Application<ServiceTypes = any> {
@@ -10,26 +11,31 @@ declare module '@feathersjs/feathers' {
     primus?: any;
     authentication: AuthenticationClient;
     authenticate (authentication?: AuthenticationRequest): Promise<AuthenticationResult>;
-    reauthenticate (force: boolean): Promise<AuthenticationResult>;
+    reAuthenticate (force: boolean): Promise<AuthenticationResult>;
     logout (): Promise<AuthenticationResult>;
   }
 }
 
+export { AuthenticationClient, AuthenticationClientOptions, Storage, MemoryStorage, hooks };
+
 export type ClientConstructor = new (app: Application, options: AuthenticationClientOptions) => AuthenticationClient;
+
+export const defaultStorage: Storage = typeof window !== 'undefined' && window.localStorage ?
+  new StorageWrapper(window.localStorage) : new MemoryStorage();
 
 export const defaults: AuthenticationClientOptions = {
   header: 'Authorization',
   scheme: 'Bearer',
   storageKey: 'feathers-jwt',
+  locationKey: 'access_token',
   jwtStrategy: 'jwt',
   path: '/authentication',
-  Authentication: AuthenticationClient
+  Authentication: AuthenticationClient,
+  storage: defaultStorage
 };
 
-const init = (_options: AuthenticationClientOptions = {}) => {
-  const options: AuthenticationClientOptions = Object.assign({}, {
-    storage: new Storage()
-  }, defaults, _options);
+const init = (_options: Partial<AuthenticationClientOptions> = {}) => {
+  const options: AuthenticationClientOptions = Object.assign({}, defaults, _options);
   const { Authentication } = options;
 
   return (app: Application) => {
@@ -37,7 +43,7 @@ const init = (_options: AuthenticationClientOptions = {}) => {
 
     app.authentication = authentication;
     app.authenticate = authentication.authenticate.bind(authentication);
-    app.reauthenticate = authentication.reauthenticate.bind(authentication);
+    app.reAuthenticate = authentication.reAuthenticate.bind(authentication);
     app.logout = authentication.logout.bind(authentication);
 
     app.hooks({
@@ -51,7 +57,6 @@ const init = (_options: AuthenticationClientOptions = {}) => {
   };
 };
 
-export { AuthenticationClient, AuthenticationClientOptions, Storage, hooks };
 export default init;
 
 if (typeof module !== 'undefined') {

--- a/packages/authentication-client/src/storage.ts
+++ b/packages/authentication-client/src/storage.ts
@@ -1,0 +1,49 @@
+export interface Storage {
+  getItem (key: string): Promise<any>;
+  setItem? (key: string, value: any): Promise<any>;
+  removeItem? (key: string): Promise<any>;
+}
+
+export class MemoryStorage implements Storage {
+  store: { [key: string]: any };
+
+  constructor () {
+    this.store = {};
+  }
+
+  getItem (key: string) {
+    return Promise.resolve(this.store[key]);
+  }
+
+  setItem (key: string, value: any) {
+    return Promise.resolve(this.store[key] = value);
+  }
+
+  removeItem (key: string) {
+    const value = this.store[key];
+
+    delete this.store[key];
+
+    return Promise.resolve(value);
+  }
+}
+
+export class StorageWrapper implements Storage {
+  storage: any;
+
+  constructor (storage: any) {
+    this.storage = storage;
+  }
+
+  getItem (key: string) {
+    return Promise.resolve(this.storage.getItem(key));
+  }
+
+  setItem (key: string, value: any) {
+    return Promise.resolve(this.storage.setItem(key, value));
+  }
+
+  removeItem (key: string) {
+    return Promise.resolve(this.storage.removeItem(key));
+  }
+}

--- a/packages/authentication-client/test/index.test.ts
+++ b/packages/authentication-client/test/index.test.ts
@@ -41,16 +41,41 @@ describe('@feathersjs/authentication-client', () => {
     assert.strictEqual(typeof app.logout, 'function');
   });
 
-  it('setJwt, getJwt, removeJwt', () => {
+  it('setJwt, getJwt, removeJwt', async () => {
     const auth = app.authentication;
     const token = 'hi';
 
-    return auth.setJwt(token)
-      .then(() => auth.getJwt())
-      .then(res => assert.strictEqual(res, token))
-      .then(() => auth.removeJwt())
-      .then(() => auth.getJwt())
-      .then(res => assert.strictEqual(res, undefined));
+    await auth.setJwt(token);
+      
+    const res = await auth.getJwt();
+
+    assert.strictEqual(res, token);
+
+    await auth.removeJwt();
+    assert.strictEqual(await auth.getJwt(), null);
+  });
+
+  it('getFromLocation', async () => {
+    const auth = app.authentication;
+    let dummyLocation = { hash: 'access_token=testing' } as Location;
+    
+    let token = await auth.getFromLocation(dummyLocation);
+
+    assert.strictEqual(token, 'testing');
+    assert.strictEqual(dummyLocation.hash, '');
+
+    dummyLocation.hash = 'a=b&access_token=otherTest&c=d';
+    token = await auth.getFromLocation(dummyLocation);
+
+    assert.strictEqual(token, 'otherTest');
+    assert.strictEqual(dummyLocation.hash, 'a=b&c=d');
+
+    dummyLocation = { search: 'access_token=testing' } as Location;
+    token = await auth.getFromLocation(dummyLocation);
+
+    assert.strictEqual(token, 'testing');
+    assert.strictEqual(dummyLocation.search, '');
+    assert.strictEqual(await auth.getFromLocation({} as Location), null);
   });
 
   it('authenticate, authentication hook, login event', () => {
@@ -100,7 +125,7 @@ describe('@feathersjs/authentication-client', () => {
 
   describe('reauthenticate', () => {
     it('fails when no token in storage', () => {
-      return app.authentication.reauthenticate().then(() => {
+      return app.authentication.reAuthenticate().then(() => {
         assert.fail('Should never get here');
       }).catch(error => {
         assert.strictEqual(error.message, 'No accessToken found in storage');
@@ -120,7 +145,7 @@ describe('@feathersjs/authentication-client', () => {
         });
 
         return result;
-      }).then(() => app.authentication.reauthenticate())
+      }).then(() => app.authentication.reAuthenticate())
         .then(() =>
           app.authentication.reset()
         ).then(() => {
@@ -128,7 +153,7 @@ describe('@feathersjs/authentication-client', () => {
         }).then(at => {
           assert.strictEqual(at, accessToken, 'Set accessToken in storage');
 
-          return app.authentication.reauthenticate();
+          return app.authentication.reAuthenticate();
         }).then(at => {
           assert.deepStrictEqual(at, {
             accessToken,


### PR DESCRIPTION
This allows the client to pick up the cross-domain `access_token` redirect from an oAuth authentication flow (but only if there is no local token) and sets `localStorage` as the default if it is a browser environment.