### PR TITLE
fix: Add registerPublisher alias for .publish

### DIFF
--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -11,9 +11,9 @@ const { CHANNELS, PUBLISHERS, ALL_EVENTS } = keys;
 declare module '@feathersjs/feathers' {
   interface ServiceAddons<T> {
     publish (callback: (data: T, hook: HookContext<T>) => Channel): this;
-    registerPublisher (callback: (data: T, hook: HookContext<T>) => Channel): this;
-
     publish (event: string, callback: (data: T, hook: HookContext<T>) => Channel): this;
+
+    registerPublisher (callback: (data: T, hook: HookContext<T>) => Channel): this;
     registerPublisher (event: string, callback: (data: T, hook: HookContext<T>) => Channel): this;
   }
 
@@ -23,14 +23,10 @@ declare module '@feathersjs/feathers' {
     channel (name: string[]): Channel;
     channel (...names: string[]): Channel;
 
-    // tslint:disable-next-line void-return
     publish<T> (callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
-    // tslint:disable-next-line void-return
-    registerPublisher<T> (callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
-
-    // tslint:disable-next-line void-return
     publish<T> (event: string, callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
-    // tslint:disable-next-line void-return
+
+    registerPublisher<T> (callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
     registerPublisher<T> (event: string, callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
   }
 }

--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -11,8 +11,10 @@ const { CHANNELS, PUBLISHERS, ALL_EVENTS } = keys;
 declare module '@feathersjs/feathers' {
   interface ServiceAddons<T> {
     publish (callback: (data: T, hook: HookContext<T>) => Channel): this;
+    registerPublisher (callback: (data: T, hook: HookContext<T>) => Channel): this;
 
     publish (event: string, callback: (data: T, hook: HookContext<T>) => Channel): this;
+    registerPublisher (event: string, callback: (data: T, hook: HookContext<T>) => Channel): this;
   }
 
   interface Application<ServiceTypes> {
@@ -23,9 +25,13 @@ declare module '@feathersjs/feathers' {
 
     // tslint:disable-next-line void-return
     publish<T> (callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
+    // tslint:disable-next-line void-return
+    registerPublisher<T> (callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
 
     // tslint:disable-next-line void-return
     publish<T> (event: string, callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
+    // tslint:disable-next-line void-return
+    registerPublisher<T> (event: string, callback: (data: T, hook: HookContext<T>) => Channel | Channel[] | void): Application<ServiceTypes>;
   }
 }
 

--- a/packages/transport-commons/src/channels/mixins.ts
+++ b/packages/transport-commons/src/channels/mixins.ts
@@ -63,13 +63,18 @@ export function channelMixin () {
 export interface PublishMixin {
   [PUBLISHERS]: { [key: string]: Channel };
   publish (event: string|symbol, callback: (data: any, hook: HookContext) => Channel): any;
+  registerPublisher (event: string|symbol, callback: (data: any, hook: HookContext) => Channel): any;
 }
 
 export function publishMixin () {
   const result: PublishMixin = {
     [PUBLISHERS]: {},
 
-    publish (event, callback) {
+    publish (...args) {
+      return this.registerPublisher(...args);
+    },
+
+    registerPublisher (event, callback) {
       debug('Registering publisher', event);
 
       if (!callback && typeof event === 'function') {

--- a/packages/transport-commons/test/channels/dispatch.test.ts
+++ b/packages/transport-commons/test/channels/dispatch.test.ts
@@ -19,8 +19,8 @@ describe('app.publish', () => {
         }
       });
 
-      app.service('test').publish('created', function () {});
-      app.service('test').publish('bla', function () {});
+      app.service('test').registerPublisher('created', function () {});
+      app.service('test').registerPublisher('bla', function () {});
       assert.ok(false, 'Should never get here');
     } catch (e) {
       assert.strictEqual(e.message, `'bla' is not a valid service event`);
@@ -45,7 +45,7 @@ describe('app.publish', () => {
     it('simple event registration and dispatching', done => {
       app.channel('testing').join(c1);
 
-      app.service('test').publish('created', () => app.channel('testing'));
+      app.service('test').registerPublisher('created', () => app.channel('testing'));
 
       app.once('publish', (event: string, channel: Channel, hook: HookContext) => {
         assert.strictEqual(event, 'created');
@@ -65,8 +65,8 @@ describe('app.publish', () => {
       app.channel('testing').join(c1);
       app.channel('other').join(c2);
 
-      app.publish('created', () => app.channel('testing'));
-      app.publish(() => app.channel('other'));
+      app.registerPublisher('created', () => app.channel('testing'));
+      app.registerPublisher(() => app.channel('other'));
 
       app.once('publish', (_event: string, channel: Channel) => {
         assert.ok(channel.connections.indexOf(c1) !== -1);
@@ -82,12 +82,12 @@ describe('app.publish', () => {
       app.channel('testing').join(c1);
       app.channel('othertest').join(c2);
 
-      app.service('test').publish('created', () =>
+      app.service('test').registerPublisher('created', () =>
         new Promise(resolve =>
           setTimeout(() => resolve(app.channel('testing')), 50)
         )
       );
-      app.service('test').publish('created', () =>
+      app.service('test').registerPublisher('created', () =>
         new Promise(resolve =>
           setTimeout(() => resolve(app.channel('testing', 'othertest')), 100)
         )
@@ -110,7 +110,7 @@ describe('app.publish', () => {
       app.channel('testing').join(c1);
       app.channel('othertest').join(c2);
 
-      app.service('test').publish('foo', () => app.channel('testing'));
+      app.service('test').registerPublisher('foo', () => app.channel('testing'));
 
       app.once('publish', (event: string, channel: Channel, hook: HookContext) => {
         assert.strictEqual(event, 'foo');
@@ -141,7 +141,7 @@ describe('app.publish', () => {
     });
 
     it('does not send `dispatch` event if there are no connections', done => {
-      app.service('test').publish('created', () =>
+      app.service('test').registerPublisher('created', () =>
         app.channel('dummy')
       );
       app.once('publish', () =>
@@ -158,7 +158,7 @@ describe('app.publish', () => {
       app.channel('testing').join(c1);
       app.channel('othertest').join(c2);
 
-      app.service('test').publish('created', () => [
+      app.service('test').registerPublisher('created', () => [
         app.channel('testing'),
         app.channel('othertest')
       ]);
@@ -180,7 +180,7 @@ describe('app.publish', () => {
       app.channel('testing').join(c1);
       app.channel('othertest').join(c2);
 
-      app.service('test').publish('created', () => [
+      app.service('test').registerPublisher('created', () => [
         app.channel('testing').send(c1data),
         app.channel('othertest')
       ]);
@@ -199,8 +199,8 @@ describe('app.publish', () => {
     it('publisher precedence and preventing publishing', done => {
       app.channel('test').join(c1);
 
-      app.publish(() => app.channel('test'));
-      app.service('test').publish('created', (): null => null);
+      app.registerPublisher(() => app.channel('test'));
+      app.service('test').registerPublisher('created', (): null => null);
 
       app.once('publish', () => done(new Error('Should never get here')));
 
@@ -213,7 +213,7 @@ describe('app.publish', () => {
       app.channel('testing').join(c1);
       app.channel('othertest').join(c1);
 
-      app.service('test').publish('created', () => {
+      app.service('test').registerPublisher('created', () => {
         return [
           app.channel('testing'),
           app.channel('othertest').send(sendData)

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ app.use(express.errorHandler());
 // Add any new real-time connection to the `everybody` channel
 app.on('connection', connection => app.channel('everybody').join(connection));
 // Publish all events to the `everybody` channel
-app.publish(data => app.channel('everybody'));
+app.registerPublisher(data => app.channel('everybody'));
 
 // Start the server
 app.listen(3030).on('listening', () =>


### PR DESCRIPTION
`app.publish` or `service.publish` should only be called once to register a publisher. It seems the name `publish` caused some confusion and I have seen it repeatedly being called in hooks and other places where it probably shouldn't. Changing the name to `registerPublisher` to be a little more concise.