### PR TITLE
feat: Add params.headers to all transports when available

### DIFF
--- a/packages/express/lib/rest/index.js
+++ b/packages/express/lib/rest/index.js
@@ -108,7 +108,10 @@ function rest (handler = formatter) {
     };
 
     app.use(function (req, res, next) {
-      req.feathers = Object.assign({ provider: 'rest' }, req.feathers);
+      req.feathers = Object.assign({
+        provider: 'rest',
+        headers: req.headers
+      }, req.feathers);
       next();
     });
 

--- a/packages/express/test/authentication.test.js
+++ b/packages/express/test/authentication.test.js
@@ -116,6 +116,21 @@ describe('@feathersjs/express/authentication', () => {
       });
     });
 
+    it('errors when there are no httpStrategies', () => {
+      const { accessToken } = authResult;
+      app.get('authentication').httpStrategies = [];
+
+      return axios.get('/dummy/dave', {
+        headers: {
+          Authorization: accessToken
+        }
+      }).then(() => assert.fail('Should never get here'))
+      .catch(error => {
+        assert.strictEqual(error.response.data.name, 'NotAuthenticated');
+        app.get('authentication').httpStrategies = [ 'jwt' ];
+      });
+    });
+
     it('can make a protected request with Authorization header and bearer scheme', () => {
       const { accessToken } = authResult;
 
@@ -134,6 +149,15 @@ describe('@feathersjs/express/authentication', () => {
   });
 
   describe('authenticate middleware', () => {
+    it('errors without valid strategies', () => {
+      try {
+        authenticate();
+        assert.fail('Should never get here');
+      } catch (error) {
+        assert.strictEqual(error.message, 'The authenticate hook needs at least one allowed strategy');
+      }
+    });
+
     it('protected endpoint fails when JWT is not present', () => {
       return axios.get('/protected').then(() => {
         assert.fail('Should never get here');

--- a/packages/primus/lib/index.js
+++ b/packages/primus/lib/index.js
@@ -42,7 +42,17 @@ function configurePrimus (config, configurer) {
             primus.plugin('emitter', Emitter);
 
             primus.use('feathers', function (req, res, next) {
-              req.feathers = { provider: 'primus' };
+              req.feathers = {
+                headers: Object.keys(req.headers).reduce((key, result) => {
+                  const value = req.headers[key];
+
+                  return typeof value === 'object' ? result : {
+                    ...result,
+                    [key]: value
+                  };
+                }, {}),
+                provider: 'primus'
+              };
 
               next();
             }, 0);

--- a/packages/primus/test/index.test.js
+++ b/packages/primus/test/index.test.js
@@ -29,6 +29,7 @@ describe('@feathersjs/primus', () => {
       }, function (primus) {
         primus.authorize(function (req, done) {
           req.feathers.user = { name: 'David' };
+          options.socketParams.headers = req.feathers.headers;
 
           const { channel } = req.query;
 

--- a/packages/socketio/lib/index.js
+++ b/packages/socketio/lib/index.js
@@ -51,7 +51,8 @@ function configureSocketio (port, options, config) {
 
             io.use((socket, next) => {
               const connection = {
-                provider: 'socketio'
+                provider: 'socketio',
+                headers: socket.handshake.headers
               };
 
               Object.defineProperty(connection, socketKey, {

--- a/packages/socketio/test/index.test.js
+++ b/packages/socketio/test/index.test.js
@@ -10,7 +10,7 @@ const methodTests = require('./methods.js');
 const eventTests = require('./events');
 const socketio = require('../lib');
 
-describe('@feathersjs/socketio', () => {
+describe.only('@feathersjs/socketio', () => {
   let app;
   let server;
   let socket;
@@ -40,6 +40,7 @@ describe('@feathersjs/socketio', () => {
       .configure(socketio(function (io) {
         io.use(function (socket, next) {
           socket.feathers.user = { name: 'David' };
+          socketParams.headers = socket.feathers.headers;
 
           const { channel } = socket.handshake.query;
 


### PR DESCRIPTION
`params.headers` was never supposed to be available in service calls (to stay more transport independent) but the old Feathers authentication added it and it seems to be relied on a lot so this PR adds it to the transport providers themselves.