### PR TITLE
feat: Change and *JWT methods to *accessToken

### DIFF
--- a/packages/authentication-local/test/strategy.test.ts
+++ b/packages/authentication-local/test/strategy.test.ts
@@ -108,7 +108,7 @@ describe('@feathersjs/authentication-local/strategy', () => {
     assert.ok(accessToken);
     assert.strictEqual(authResult.user.email, email);
 
-    const decoded = await authService.verifyJWT(accessToken);
+    const decoded = await authService.verifyAccessToken(accessToken);
 
     assert.strictEqual(decoded.sub, `${user.id}`);
   });
@@ -129,7 +129,7 @@ describe('@feathersjs/authentication-local/strategy', () => {
     assert.strictEqual(authResult.user.email, email);
     assert.strictEqual(authResult.user.passsword, undefined);
 
-    const decoded = await authService.verifyJWT(accessToken);
+    const decoded = await authService.verifyAccessToken(accessToken);
 
     assert.strictEqual(decoded.sub, `${user.id}`);
   });

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -64,7 +64,7 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
       const user = await app.service('users').create({
         name: 'David'
       });
-      const jwt = await authService.createJWT({}, {
+      const jwt = await authService.createAccessToken({}, {
         subject: `${user.id}`
       });
 

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "mocha --opts ../../mocha.ts.opts --recursive test/**.test.ts test/**/*.test.ts"
+    "test": "npm run compile && npm run mocha",
+    "mocha": "mocha --opts ../../mocha.ts.opts --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {
     "lib": "lib"

--- a/packages/authentication/src/core.ts
+++ b/packages/authentication/src/core.ts
@@ -147,12 +147,12 @@ export class AuthenticationBase {
   }
 
   /**
-   * Create a new JWT with payload and options.
+   * Create a new access token with payload and options.
    * @param payload The JWT payload
    * @param optsOverride The options to extend the defaults (`configuration.jwtOptions`) with
    * @param secretOverride Use a different secret instead
    */
-  createJWT (payload: string | Buffer | object, optsOverride?: SignOptions, secretOverride?: Secret) {
+  createAccessToken (payload: string | Buffer | object, optsOverride?: SignOptions, secretOverride?: Secret) {
     const { secret, jwtOptions } = this.configuration;
     // Use configuration by default but allow overriding the secret
     const jwtSecret = secretOverride || secret;
@@ -169,12 +169,12 @@ export class AuthenticationBase {
   }
 
   /**
-   * Verifies a JWT.
+   * Verifies an access token.
    * @param accessToken The token to verify
    * @param optsOverride The options to extend the defaults (`configuration.jwtOptions`) with
    * @param secretOverride Use a different secret instead
    */
-  verifyJWT (accessToken: string, optsOverride?: JwtVerifyOptions, secretOverride?: Secret) {
+  verifyAccessToken (accessToken: string, optsOverride?: JwtVerifyOptions, secretOverride?: Secret) {
     const { secret, jwtOptions } = this.configuration;
     const jwtSecret = secretOverride || secret;
     const options = merge({}, jwtOptions, optsOverride);

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -54,7 +54,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
       throw new NotAuthenticated('Not authenticated');
     }
 
-    const payload = await this.authentication.verifyJWT(accessToken, params.jwt);
+    const payload = await this.authentication.verifyAccessToken(accessToken, params.jwt);
     const entityId = payload.sub;
     const result = {
       accessToken,

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -27,7 +27,7 @@ export class AuthenticationService extends AuthenticationBase implements Service
    * @param authResult The authentication result
    * @param params Service call parameters
    */
-  async getJwtOptions (authResult: AuthenticationResult, params: Params) {
+  async getTokenOptions (authResult: AuthenticationResult, params: Params) {
     const { service, entity, entityId } = this.configuration;
     const jwtOptions = merge({}, params.jwtOptions, params.jwt);
     const hasEntity = service && entity && authResult[entity];
@@ -66,7 +66,7 @@ export class AuthenticationService extends AuthenticationBase implements Service
 
     const [ payload, jwtOptions ] = await Promise.all([
       this.getPayload(authResult, params),
-      this.getJwtOptions(authResult, params)
+      this.getTokenOptions(authResult, params)
     ]);
 
     if (authResult.accessToken) {

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -75,7 +75,7 @@ export class AuthenticationService extends AuthenticationBase implements Service
 
     debug('Creating JWT with', payload, jwtOptions);
 
-    const accessToken = await this.createJWT(payload, jwtOptions, params.secret);
+    const accessToken = await this.createAccessToken(payload, jwtOptions, params.secret);
 
     return Object.assign({}, { accessToken }, authResult);
   }

--- a/packages/authentication/test/core.test.ts
+++ b/packages/authentication/test/core.test.ts
@@ -272,11 +272,11 @@ describe('authentication/core', () => {
   describe('jwt', () => {
     const message = 'Some payload';
 
-    describe('createJWT', () => {
+    describe('createAccessToken', () => {
       // it('errors with no payload', () => {
       //   try {
       //     // @ts-ignore
-      //     await auth.createJWT();
+      //     await auth.createAccessToken();
       //     assert.fail('Should never get here');
       //   } catch (error) {
       //     assert.strictEqual(error.message, 'payload is required');
@@ -286,7 +286,7 @@ describe('authentication/core', () => {
       it('with default options', async () => {
         const msg = 'Some payload';
 
-        const accessToken = await auth.createJWT({ message: msg });
+        const accessToken = await auth.createAccessToken({ message: msg });
         const decoded = jwt.decode(accessToken);
         const settings = auth.configuration.jwtOptions;
 
@@ -308,7 +308,7 @@ describe('authentication/core', () => {
           jwtid: 'something'
         };
 
-        const accessToken = await auth.createJWT({ message }, overrides);
+        const accessToken = await auth.createAccessToken({ message }, overrides);
 
         assert.ok(typeof accessToken === 'string');
 
@@ -330,7 +330,7 @@ describe('authentication/core', () => {
         };
 
         try {
-          await auth.createJWT({}, overrides);
+          await auth.createAccessToken({}, overrides);
           assert.fail('Should never get here');
         } catch (error) {
           assert.strictEqual(error.message, '"algorithm" must be a valid string enum value');
@@ -338,26 +338,26 @@ describe('authentication/core', () => {
       });
     });
 
-    describe('verifyJWT', () => {
+    describe('verifyAccessToken', () => {
       let validToken: string;
       let expiredToken: string;
 
       beforeEach(async () => {
-        validToken = await auth.createJWT({ message });
-        expiredToken = await auth.createJWT({}, {
+        validToken = await auth.createAccessToken({ message });
+        expiredToken = await auth.createAccessToken({}, {
           expiresIn: '1ms'
         });
       });
 
       it('returns payload when token is valid', async () => {
-        const payload = await auth.verifyJWT(validToken);
+        const payload = await auth.verifyAccessToken(validToken);
 
         assert.strictEqual(payload.message, message);
       });
 
       it('errors when custom algorithm property does not match', async () => {
         try {
-          await auth.verifyJWT(validToken, {
+          await auth.verifyAccessToken(validToken, {
             algorithm: [ 'HS512' ]
           });
           assert.fail('Should never get here');
@@ -368,7 +368,7 @@ describe('authentication/core', () => {
 
       it('errors when algorithms property does not match', async () => {
         try {
-          await auth.verifyJWT(validToken, {
+          await auth.verifyAccessToken(validToken, {
             algorithms: [ 'HS512' ]
           });
           assert.fail('Should never get here');
@@ -379,7 +379,7 @@ describe('authentication/core', () => {
 
       it('errors when secret is different', async () => {
         try {
-          await auth.verifyJWT(validToken, {}, 'fdjskl');
+          await auth.verifyAccessToken(validToken, {}, 'fdjskl');
 
           assert.fail('Should never get here');
         } catch (error) {
@@ -389,7 +389,7 @@ describe('authentication/core', () => {
 
       it('errors when other custom options do not match', async () => {
         try {
-          await auth.verifyJWT(validToken, { issuer: 'someonelse' });
+          await auth.verifyAccessToken(validToken, { issuer: 'someonelse' });
 
           assert.fail('Should never get here');
         } catch (error) {
@@ -399,7 +399,7 @@ describe('authentication/core', () => {
 
       it('errors when token is expired', async () => {
         try {
-          await auth.verifyJWT(expiredToken);
+          await auth.verifyAccessToken(expiredToken);
           assert.fail('Should never get here');
         } catch (error) {
           assert.strictEqual(error.message, 'jwt expired');

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -54,11 +54,11 @@ describe('authentication/jwt', () => {
       name: 'David'
     });
 
-    accessToken = await service.createJWT({}, {
+    accessToken = await service.createAccessToken({}, {
       subject: `${user.id}`
     });
 
-    payload = await service.verifyJWT(accessToken);
+    payload = await service.verifyAccessToken(accessToken);
   });
 
   describe('with authenticate hook', () => {


### PR DESCRIPTION
Feathers authentication does not have to use JWT, it can generate any kind of accessToken. This change reflects it in the method names.