### PR TITLE
fix: Rename jwtStrategies option to authStrategies

### DIFF
--- a/packages/authentication-client/src/index.ts
+++ b/packages/authentication-client/src/index.ts
@@ -20,7 +20,7 @@ export { AuthenticationClient, AuthenticationClientOptions, Storage, MemoryStora
 
 export type ClientConstructor = new (app: Application, options: AuthenticationClientOptions) => AuthenticationClient;
 
-export const defaultStorage: Storage = typeof window !== 'undefined' && window.localStorage ?
+export const defaultStorage: Storage = typeof window !== 'undefined' ?
   new StorageWrapper(window.localStorage) : new MemoryStorage();
 
 export const defaults: AuthenticationClientOptions = {

--- a/packages/authentication-client/test/integration/fixture.ts
+++ b/packages/authentication-client/test/integration/fixture.ts
@@ -15,7 +15,7 @@ export default (app: Application) => {
     service: 'users',
     secret: 'supersecret',
     httpStrategies: [ 'jwt' ],
-    jwtStrategies: [ 'local', 'jwt' ],
+    authStrategies: [ 'local', 'jwt' ],
     local: {
       usernameField: 'email',
       passwordField: 'password'

--- a/packages/authentication-local/src/strategy.ts
+++ b/packages/authentication-local/src/strategy.ts
@@ -35,10 +35,11 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
     };
   }
 
-  getEntityQuery (query: Query, _params: Params) {
-    return Promise.resolve(Object.assign({
-      $limit: 1
-    }, query));
+  async getEntityQuery (query: Query, _params: Params) {
+    return {
+      $limit: 1,
+      ...query
+    };
   }
 
   async findEntity (username: string, params: Params) {

--- a/packages/authentication-local/test/fixture.js
+++ b/packages/authentication-local/test/fixture.js
@@ -12,7 +12,7 @@ module.exports = (app = feathers()) => {
     entity: 'user',
     service: 'users',
     secret: 'supersecret',
-    jwtStrategies: [ 'local', 'jwt' ],
+    authStrategies: [ 'local', 'jwt' ],
     httpStrategies: [ 'jwt' ],
     local: {
       usernameField: 'email',

--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -74,7 +74,7 @@ export default (options: OauthSetupSettings) => {
 
         const params = {
           provider: 'rest',
-          jwtStrategies: [ name ],
+          authStrategies: [ name ],
           authentication: accessToken ? {
             strategy: linkStrategy,
             accessToken

--- a/packages/authentication/src/options.ts
+++ b/packages/authentication/src/options.ts
@@ -1,6 +1,6 @@
 export default {
   httpStrategies: [],
-  jwtStrategies: [],
+  authStrategies: [],
   jwtOptions: {
     header: { typ: 'access' }, // by default is an access token but can be any type
     audience: 'https://yourdomain.com', // The resource server where the token is processed

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -54,13 +54,13 @@ export class AuthenticationService extends AuthenticationBase implements Service
    * @param params Service call parameters
    */
   async create (data: AuthenticationRequest, params: Params) {
-    const jwtStrategies = params.jwtStrategies || this.configuration.jwtStrategies;
+    const authStrategies = params.authStrategies || this.configuration.authStrategies;
 
-    if (!jwtStrategies.length) {
-      throw new NotAuthenticated('No authentication strategies allowed for creating a JWT (`jwtStrategies`)');
+    if (!authStrategies.length) {
+      throw new NotAuthenticated('No authentication strategies allowed for creating a JWT (`authStrategies`)');
     }
 
-    const authResult = await this.authenticate(data, params, ...jwtStrategies);
+    const authResult = await this.authenticate(data, params, ...authStrategies);
 
     debug('Got authentication result', authResult);
 
@@ -88,7 +88,7 @@ export class AuthenticationService extends AuthenticationBase implements Service
    */
   async remove (id: null|string, params: Params) {
     const { authentication } = params;
-    const { jwtStrategies } = this.configuration;
+    const { authStrategies } = this.configuration;
 
     // When an id is passed it is expected to be the authentication `accessToken`
     if (id !== null && id !== authentication.accessToken) {
@@ -97,7 +97,7 @@ export class AuthenticationService extends AuthenticationBase implements Service
 
     debug('Verifying authentication strategy in remove');
 
-    return this.authenticate(authentication, params, ...jwtStrategies);
+    return this.authenticate(authentication, params, ...authStrategies);
   }
 
   /**

--- a/packages/authentication/test/hooks/authenticate.test.ts
+++ b/packages/authentication/test/hooks/authenticate.test.ts
@@ -20,13 +20,13 @@ describe('authentication/hooks/authenticate', () => {
       entity: 'user',
       service: 'users',
       secret: 'supersecret',
-      jwtStrategies: [ 'first' ]
+      authStrategies: [ 'first' ]
     }));
     app.use('/auth-v2', new AuthenticationService(app, 'auth-v2', {
       entity: 'user',
       service: 'users',
       secret: 'supersecret',
-      jwtStrategies: [ 'test' ]
+      authStrategies: [ 'test' ]
     }));
     app.use('/users', {
       async find () {

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -27,7 +27,7 @@ describe('authentication/jwt', () => {
       entity: 'user',
       service: 'users',
       secret: 'supersecret',
-      jwtStrategies: [ 'jwt' ]
+      authStrategies: [ 'jwt' ]
     });
 
     authService.register('jwt', new JWTStrategy());

--- a/packages/authentication/test/service.test.ts
+++ b/packages/authentication/test/service.test.ts
@@ -27,7 +27,7 @@ describe('authentication/service', () => {
       entity: 'user',
       service: 'users',
       secret: 'supersecret',
-      jwtStrategies: [ 'first' ]
+      authStrategies: [ 'first' ]
     }));
     app.use('/users', memory());
 
@@ -149,7 +149,7 @@ describe('authentication/service', () => {
       const service = app.service('authentication');
       const configuration = service.configuration;
 
-      delete configuration.jwtStrategies;
+      delete configuration.authStrategies;
 
       app.set('authentication', configuration);
 
@@ -161,7 +161,7 @@ describe('authentication/service', () => {
         assert.fail('Should never get here');
       } catch (error) {
         assert.strictEqual(error.name, 'NotAuthenticated');
-        assert.strictEqual(error.message, 'No authentication strategies allowed for creating a JWT (`jwtStrategies`)');
+        assert.strictEqual(error.message, 'No authentication strategies allowed for creating a JWT (`authStrategies`)');
       }
     });
   });
@@ -233,7 +233,7 @@ describe('authentication/service', () => {
 
       otherApp.use('/authentication', new AuthenticationService(otherApp, 'authentication', {
         secret: 'supersecret',
-        jwtStrategies: [ 'first' ]
+        authStrategies: [ 'first' ]
       }));
 
       try {
@@ -251,7 +251,7 @@ describe('authentication/service', () => {
         entity: 'user',
         service: 'users',
         secret: 'supersecret',
-        jwtStrategies: [ 'first' ]
+        authStrategies: [ 'first' ]
       }));
 
       try {


### PR DESCRIPTION
Because it is more accurate. It is a list of strategies that are allowed to create an `accessToken`.