### PR TITLE
fix: Bring back params.authenticated

### DIFF
--- a/packages/authentication/src/core.ts
+++ b/packages/authentication/src/core.ts
@@ -12,9 +12,6 @@ const debug = Debug('@feathersjs/authentication/base');
 const verifyJWT = promisify(jsonwebtoken.verify);
 const createJWT = promisify(jsonwebtoken.sign);
 
-// TypeScript hack because it does not allow symbols as indexes!?
-export const AUTHENTICATE: string = Symbol('@feathersjs/authentication/internal') as any;
-
 export interface AuthenticationResult {
   [key: string]: any;
 }
@@ -210,7 +207,7 @@ export class AuthenticationBase {
     const { strategy } = authentication;
     const authParams = {
       ...params,
-      [AUTHENTICATE]: false
+      authenticated: true
     };
 
     // Throw an error is a `strategy` is indicated but not in the allowed strategies

--- a/packages/authentication/src/hooks/authenticate.ts
+++ b/packages/authentication/src/hooks/authenticate.ts
@@ -3,7 +3,6 @@ import { HookContext } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
 import Debug from 'debug';
 import { AuthenticationService } from '../service';
-import { AUTHENTICATE } from '../core';
 
 const debug = Debug('@feathersjs/authentication/hooks/authenticate');
 
@@ -45,7 +44,7 @@ export default (originalSettings: string|AuthenticateHookSettings, ...originalSt
       throw new NotAuthenticated('The authenticate hook does not need to be used on the authentication service');
     }
 
-    if (params[AUTHENTICATE] === false) {
+    if (params.authenticated === true) {
       return context;
     }
 

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -8,8 +8,7 @@ export {
   AuthenticationBase,
   AuthenticationRequest,
   AuthenticationResult,
-  AuthenticationStrategy,
-  AUTHENTICATE
+  AuthenticationStrategy
 } from './core';
 export { AuthenticationBaseStrategy } from './strategy';
 export { AuthenticationService } from './service';

--- a/packages/authentication/test/core.test.ts
+++ b/packages/authentication/test/core.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import feathers, { Application } from '@feathersjs/feathers';
 import jwt from 'jsonwebtoken';
 
-import { AuthenticationBase, AUTHENTICATE } from '../src/core';
+import { AuthenticationBase } from '../src/core';
 import { Strategy1, Strategy2, MockRequest } from './fixtures';
 import { ServerResponse } from 'http';
 
@@ -152,7 +152,7 @@ describe('authentication/core', () => {
 
         assert.deepStrictEqual(result, Object.assign({}, Strategy2.result, {
           authentication,
-          params: { [AUTHENTICATE]: false }
+          params: { authenticated: true }
         }));
       });
 
@@ -170,7 +170,7 @@ describe('authentication/core', () => {
 
         assert.deepStrictEqual(result, Object.assign({
           params: Object.assign(params, {
-            [AUTHENTICATE]: false
+            authenticated: true
           }),
           authentication
         }, Strategy2.result));
@@ -209,7 +209,7 @@ describe('authentication/core', () => {
 
         assert.deepStrictEqual(result, Object.assign({
           authentication,
-          params: { [AUTHENTICATE]: false }
+          params: { authenticated: true }
         }, Strategy2.result));
       });
 

--- a/packages/authentication/test/hooks/authenticate.test.ts
+++ b/packages/authentication/test/hooks/authenticate.test.ts
@@ -3,7 +3,7 @@ import feathers, { Application, Params, Service } from '@feathersjs/feathers';
 
 import { Strategy1, Strategy2 } from '../fixtures';
 import { AuthenticationService, hooks } from '../../src';
-import { AuthenticationResult, AUTHENTICATE } from '../../src/core';
+import { AuthenticationResult } from '../../src/core';
 
 const { authenticate } = hooks;
 
@@ -147,7 +147,7 @@ describe('authentication/hooks/authenticate', () => {
 
     assert.deepStrictEqual(result, Object.assign({
       authentication: params.authentication,
-      params: {}
+      params: { authenticated: true }
     }, Strategy2.result));
   });
 
@@ -183,10 +183,10 @@ describe('authentication/hooks/authenticate', () => {
     }
   });
 
-  it('passes with [AUTHENTICATE]: false but external call', async () => {
+  it('passes with authenticated: true but external call', async () => {
     const params = {
       provider: 'rest',
-      [AUTHENTICATE]: false
+      authenticated: true
     };
     const result = await app.service('users').get(1, params);
 


### PR DESCRIPTION
The `AUTHENTICATE` symbol was not backwards compatible but effectively doing the same thing as the previously used `params.authenticated` boolean flag so we might as well keep it that way.