### PR TITLE
fix: Always require strategy parameter in authentication

### DIFF
--- a/packages/authentication-local/src/strategy.ts
+++ b/packages/authentication-local/src/strategy.ts
@@ -94,14 +94,9 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
   }
 
   async authenticate (data: AuthenticationRequest, params: Params) {
-    const { passwordField, usernameField, entity, errorMessage } = this.configuration;
+    const { passwordField, usernameField, entity } = this.configuration;
     const username = data[usernameField];
     const password = data[passwordField];
-
-    if (data.strategy && data.strategy !== this.name) {
-      throw new NotAuthenticated(errorMessage);
-    }
-
     const result = await this.findEntity(username, omit(params, 'provider'));
 
     await this.comparePassword(result, password);

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -5,7 +5,6 @@ import {
   AuthenticationRequest, AuthenticationBaseStrategy
 } from '@feathersjs/authentication';
 import { Params } from '@feathersjs/feathers';
-import { NotAuthenticated } from '@feathersjs/errors';
 
 const debug = Debug('@feathersjs/authentication-oauth/strategy');
 
@@ -97,10 +96,6 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
   }
 
   async authenticate (authentication: AuthenticationRequest, params: Params) {
-    if (authentication.strategy !== this.name) {
-      throw new NotAuthenticated('Not authenticated');
-    }
-
     const entity: string = this.configuration.entity;
     const profile = await this.getProfile(authentication, params);
     const existingEntity = await this.findEntity(profile, params)

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -20,18 +20,6 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
   });
 
   describe('authenticate', () => {
-    it('errors when strategy is not set', async () => {
-      try {
-        await strategy.authenticate({
-          id: 'newEntity'
-        }, {});
-        assert.fail('Should never get here');
-      } catch (error) {
-        assert.equal(error.name, 'NotAuthenticated');
-        assert.equal(error.message, 'Not authenticated');
-      }
-    });
-
     it('with new user', async () => {
       const authResult = await strategy.authenticate({
         strategy: 'test',

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -47,10 +47,10 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
   }
 
   async authenticate (authentication: AuthenticationRequest, params: Params) {
-    const { accessToken, strategy } = authentication;
+    const { accessToken } = authentication;
     const { entity } = this.configuration;
 
-    if (!accessToken || (strategy && strategy !== this.name)) {
+    if (!accessToken) {
       throw new NotAuthenticated('Not authenticated');
     }
 

--- a/packages/authentication/test/hooks/authenticate.test.ts
+++ b/packages/authentication/test/hooks/authenticate.test.ts
@@ -161,6 +161,7 @@ describe('authentication/hooks/authenticate', () => {
     try {
       await app.service('users').get(1, {
         authentication: {
+          strategy: 'first',
           some: 'thing'
         }
       });

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -85,7 +85,7 @@ describe('authentication/jwt', () => {
         assert.fail('Should never get here');
       } catch (error) {
         assert.strictEqual(error.name, 'NotAuthenticated');
-        assert.strictEqual(error.message, 'Not authenticated');
+        assert.strictEqual(error.message, 'Invalid authentication information (no `strategy` set)');
       }
     });
 

--- a/packages/authentication/test/service.test.ts
+++ b/packages/authentication/test/service.test.ts
@@ -211,7 +211,7 @@ describe('authentication/service', () => {
         await app.service('authentication').remove(null);
         assert.fail('Should never get here');
       } catch (error) {
-        assert.strictEqual(error.message, 'No valid authentication strategy available');
+        assert.strictEqual(error.message, 'Invalid authentication information (no `strategy` set)');
       }
     });
   });

--- a/packages/express/test/authentication.test.js
+++ b/packages/express/test/authentication.test.js
@@ -165,7 +165,7 @@ describe('@feathersjs/express/authentication', () => {
         const { data } = error.response;
 
         assert.strictEqual(data.name, 'NotAuthenticated');
-        assert.strictEqual(data.message, 'No valid authentication strategy available');
+        assert.strictEqual(data.message, 'Invalid authentication information (no `strategy` set)');
       });
     });
 


### PR DESCRIPTION
Running through all strategies is inefficient and confusing. This PR always requires `strategy` property for authentication and will only run that strategy and return its error or success.

Closes #1323 