### PR TITLE
fix: Improve oAuth option handling

### DIFF
--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -16,15 +16,16 @@ const debug = Debug('@feathersjs/authentication-oauth/express');
 
 export default (options: OauthSetupSettings) => {
   return (feathersApp: Application) => {
-    const { path, authService, linkStrategy } = options;
+    const { authService, linkStrategy } = options;
     const app = feathersApp as ExpressApplication;
     const config = app.get('grant');
-
+    
     if (!config) {
       debug('No grant configuration found, skipping Express oAuth setup');
       return;
     }
-
+    
+    const { path } = config.defaults;
     const grantApp = grant(config);
     const authApp = express();
 
@@ -74,7 +75,6 @@ export default (options: OauthSetupSettings) => {
           grant.response : req.query;
 
         const params = {
-          provider: 'rest',
           authStrategies: [ name ],
           authentication: accessToken ? {
             strategy: linkStrategy,

--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -1,7 +1,6 @@
 // @ts-ignore
 import { express as grantExpress } from 'grant';
 import Debug from 'debug';
-import session from 'express-session';
 import querystring from 'querystring';
 import { Application } from '@feathersjs/feathers';
 import { AuthenticationService, AuthenticationResult } from '@feathersjs/authentication';
@@ -10,6 +9,7 @@ import {
   original as express
 } from '@feathersjs/express';
 import { OauthSetupSettings } from './utils';
+import { OAuthStrategy } from '.';
 
 const grant = grantExpress();
 const debug = Debug('@feathersjs/authentication-oauth/express');
@@ -19,7 +19,6 @@ export default (options: OauthSetupSettings) => {
     const { path, authService, linkStrategy } = options;
     const app = feathersApp as ExpressApplication;
     const config = app.get('grant');
-    const secret = Math.random().toString(36).substring(7);
 
     if (!config) {
       debug('No grant configuration found, skipping Express oAuth setup');
@@ -29,11 +28,7 @@ export default (options: OauthSetupSettings) => {
     const grantApp = grant(config);
     const authApp = express();
 
-    authApp.use(session({
-      secret,
-      resave: true,
-      saveUninitialized: true
-    }));
+    authApp.use(options.expressSession);
 
     authApp.get('/:name', (req, res) => {
       const { name } = req.params;
@@ -56,15 +51,21 @@ export default (options: OauthSetupSettings) => {
       const { name } = req.params;
       const { accessToken, grant } = req.session;
       const service: AuthenticationService = app.service(authService);
+      const [ strategy ] = service.getStrategies(name) as OAuthStrategy[];
       const sendResponse = async (data: AuthenticationResult|Error) => {
-        const redirect = await options.getRedirect(service, data);
+        try {
+          const redirect = await strategy.getRedirect(data);
 
-        if (redirect !== null) {
-          res.redirect(redirect);
-        } else if (data instanceof Error) {
-          next(data);
-        } else {
-          res.json(data);
+          if (redirect !== null) {
+            res.redirect(redirect);
+          } else if (data instanceof Error) {
+            throw data;
+          } else {
+            res.json(data);
+          }
+        } catch (error) {
+          debug('oAuth error', error);
+          next(error);
         }
       };
 
@@ -95,7 +96,7 @@ export default (options: OauthSetupSettings) => {
         await sendResponse(authResult);
       } catch (error) {
         debug('Received oAuth authentication error', error);
-        sendResponse(error);
+        await sendResponse(error);
       }
     });
 

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -49,7 +49,7 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   app.set('grant', grant);
 };
 
-export const express = (settings: OauthSetupSettings = {}) => (app: Application) => {
+export const express = (settings: Partial<OauthSetupSettings> = {}) => (app: Application) => {
   const options = getDefaultSettings(app, settings);
 
   app.configure(setup(options));

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -38,7 +38,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
   async getEntityData (profile: OAuthProfile, _existingEntity: any, _params: Params) {
     return {
-      [`${this.name}Id`]: profile.id
+      [`${this.name}Id`]: profile.sub || profile.id
     };
   }
 

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -1,8 +1,9 @@
 // @ts-ignore
 import getProfile from 'grant-profile/lib/client';
+import querystring from 'querystring';
 import Debug from 'debug';
 import {
-  AuthenticationRequest, AuthenticationBaseStrategy
+  AuthenticationRequest, AuthenticationBaseStrategy, AuthenticationResult
 } from '@feathersjs/authentication';
 import { Params } from '@feathersjs/feathers';
 
@@ -29,6 +30,18 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     return this.configuration.entityId || this.entityService.id;
   }
 
+  async getEntityQuery (profile: OAuthProfile, _params: Params) {
+    return {
+      [`${this.name}Id`]: profile.sub || profile.id
+    };
+  }
+
+  async getEntityData (profile: OAuthProfile, _existingEntity: any, _params: Params) {
+    return {
+      [`${this.name}Id`]: profile.id
+    };
+  }
+
   /* istanbul ignore next */
   async getProfile (data: AuthenticationRequest, _params: Params) {
     const config = this.app.get('grant');
@@ -50,16 +63,32 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
       const authResult = await this.authentication
         .authenticate(authentication, params, strategy);
 
-      return authResult[entity] || null;
+      return authResult[entity];
     }
 
     return null;
   }
 
-  async findEntity (profile: OAuthProfile, params: Params) {
-    const query = {
-      [`${this.name}Id`]: profile.id
+  async getRedirect (data: AuthenticationResult|Error) {
+    const { redirect } = this.authentication.configuration.oauth;
+
+    if (!redirect) {
+      return null;
+    }
+
+    const separator = redirect.endsWith('?') ? '' : '#';
+    const authResult: AuthenticationResult = data;
+    const query = authResult.accessToken ? {
+      access_token: authResult.accessToken
+    } : {
+      error: data.message || 'OAuth Authentication not successful'
     };
+
+    return redirect + separator + querystring.stringify(query);
+  }
+
+  async findEntity (profile: OAuthProfile, params: Params) {
+    const query = await this.getEntityQuery(profile, params);
 
     debug('findEntity with query', query);
 
@@ -75,9 +104,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
   }
 
   async createEntity (profile: OAuthProfile, params: Params) {
-    const data = {
-      [`${this.name}Id`]: profile.id
-    };
+    const data = await this.getEntityData(profile, null, params);
 
     debug('createEntity with data', data);
 
@@ -86,9 +113,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
   async updateEntity (entity: any, profile: OAuthProfile, params: Params) {
     const id = entity[this.entityId];
-    const data = {
-      [`${this.name}Id`]: profile.id
-    };
+    const data = await this.getEntityData(profile, entity, params);
 
     debug(`updateEntity with id ${id} and data`, data);
 
@@ -103,8 +128,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
     debug(`authenticate with (existing) entity`, existingEntity);
 
-    const authEntity = existingEntity === null
-      ? await this.createEntity(profile, params)
+    const authEntity = !existingEntity ? await this.createEntity(profile, params)
       : await this.updateEntity(existingEntity, profile, params);
 
     return {

--- a/packages/authentication-oauth/src/utils.ts
+++ b/packages/authentication-oauth/src/utils.ts
@@ -3,7 +3,6 @@ import session from 'express-session';
 import { Application } from '@feathersjs/feathers';
 
 export interface OauthSetupSettings {
-  path: string;
   authService: string;
   linkStrategy: string;
   expressSession: RequestHandler;
@@ -11,7 +10,6 @@ export interface OauthSetupSettings {
 
 export const getDefaultSettings = (app: Application, other?: Partial<OauthSetupSettings>) => {
   const defaults: OauthSetupSettings = {
-    path: '/auth',
     authService: app.get('defaultAuthentication'),
     linkStrategy: 'jwt',
     expressSession: session({

--- a/packages/authentication-oauth/src/utils.ts
+++ b/packages/authentication-oauth/src/utils.ts
@@ -1,38 +1,24 @@
-import querystring from 'querystring';
+import { RequestHandler } from 'express';
+import session from 'express-session';
 import { Application } from '@feathersjs/feathers';
-import { AuthenticationService, AuthenticationResult } from '@feathersjs/authentication';
 
 export interface OauthSetupSettings {
-  path?: string;
-  authService?: string;
-  linkStrategy?: string;
-  getRedirect? (service: AuthenticationService, data: AuthenticationResult|Error): Promise<string>;
+  path: string;
+  authService: string;
+  linkStrategy: string;
+  expressSession: RequestHandler;
 }
 
-export const getRedirect = async (service: AuthenticationService, data: AuthenticationResult|Error) => {
-  const { redirect } = service.configuration.oauth;
-
-  if (!redirect) {
-    return null;
-  }
-
-  const separator = redirect.endsWith('?') ? '' : '#';
-  const authResult: AuthenticationResult = data;
-  const query = authResult.accessToken ? {
-    access_token: authResult.accessToken
-  } : {
-    error: data.message || 'OAuth Authentication not successful'
-  };
-
-  return redirect + separator + querystring.stringify(query);
-};
-
-export const getDefaultSettings = (app: Application, other?: OauthSetupSettings) => {
+export const getDefaultSettings = (app: Application, other?: Partial<OauthSetupSettings>) => {
   const defaults: OauthSetupSettings = {
     path: '/auth',
     authService: app.get('defaultAuthentication'),
     linkStrategy: 'jwt',
-    getRedirect,
+    expressSession: session({
+      secret: Math.random().toString(36).substring(7),
+      saveUninitialized: true,
+      resave: true
+    }),
     ...other
   };
 

--- a/packages/authentication-oauth/test/index.test.ts
+++ b/packages/authentication-oauth/test/index.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import feathers from '@feathersjs/feathers';
-import { setup, express } from '../src';
+import { setup, express, OauthSetupSettings } from '../src';
 import { AuthenticationService } from '@feathersjs/authentication/lib';
 
 describe('@feathersjs/authentication-oauth', () => {
@@ -9,7 +9,7 @@ describe('@feathersjs/authentication-oauth', () => {
       const app = feathers();
 
       try {
-        app.configure(setup({ authService: 'something' }));
+        app.configure(setup({ authService: 'something' } as OauthSetupSettings));
         assert.fail('Should never get here');
       } catch (error) {
         assert.equal(error.message,

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -4,12 +4,35 @@ import { AuthenticationService } from '@feathersjs/authentication/lib';
 
 describe('@feathersjs/authentication-oauth/strategy', () => {
   const authService: AuthenticationService = app.service('authentication');
-  const [strategy] = authService.getStrategies('test') as TestOAuthStrategy[];
+  const [ strategy ] = authService.getStrategies('test') as TestOAuthStrategy[];
 
   it('initializes, has .entityId and configuration', () => {
     assert.ok(strategy);
     assert.strictEqual(strategy.entityId, 'id');
     assert.ok(strategy.configuration.entity);
+  });
+
+  it('getRedirect', async () => {
+    app.get('authentication').oauth.redirect = '/home';
+
+    let redirect = await strategy.getRedirect({ accessToken: 'testing' });
+    assert.equal(redirect, '/home#access_token=testing');
+
+    redirect = await strategy.getRedirect(new Error('something went wrong'));
+    assert.equal(redirect, '/home#error=something%20went%20wrong');
+
+    redirect = await strategy.getRedirect(new Error());
+    assert.equal(redirect, '/home#error=OAuth%20Authentication%20not%20successful');
+
+    app.get('authentication').oauth.redirect = '/home?';
+
+    redirect = await strategy.getRedirect({ accessToken: 'testing' });
+    assert.equal(redirect, '/home?access_token=testing');
+
+    delete app.get('authentication').oauth.redirect;
+
+    redirect = await strategy.getRedirect({ accessToken: 'testing' });
+    assert.equal(redirect, null);
   });
 
   it('getProfile', async () => {

--- a/packages/authentication-oauth/test/utils.test.ts
+++ b/packages/authentication-oauth/test/utils.test.ts
@@ -1,34 +1,8 @@
 import { strict as assert } from 'assert';
-import { getRedirect, getDefaultSettings } from '../src/utils';
+import { getDefaultSettings } from '../src/utils';
 import { app } from './fixture';
-import { AuthenticationService } from '@feathersjs/authentication/lib';
 
 describe('@feathersjs/authentication-oauth/utils', () => {
-  it('getRedirect', async () => {
-    const service: AuthenticationService = app.service('authentication');
-
-    app.get('authentication').oauth.redirect = '/home';
-
-    let redirect = await getRedirect(service, { accessToken: 'testing' });
-    assert.equal(redirect, '/home#access_token=testing');
-
-    redirect = await getRedirect(service, { message: 'something went wrong' });
-    assert.equal(redirect, '/home#error=something%20went%20wrong');
-
-    redirect = await getRedirect(service, {});
-    assert.equal(redirect, '/home#error=OAuth%20Authentication%20not%20successful');
-
-    app.get('authentication').oauth.redirect = '/home?';
-
-    redirect = await getRedirect(service, { accessToken: 'testing' });
-    assert.equal(redirect, '/home?access_token=testing');
-
-    delete app.get('authentication').oauth.redirect;
-
-    redirect = await getRedirect(service, { accessToken: 'testing' });
-    assert.equal(redirect, null);
-  });
-
   it('getDefaultSettings', () => {
     const settings = getDefaultSettings(app);
 

--- a/packages/authentication-oauth/test/utils.test.ts
+++ b/packages/authentication-oauth/test/utils.test.ts
@@ -6,7 +6,6 @@ describe('@feathersjs/authentication-oauth/utils', () => {
   it('getDefaultSettings', () => {
     const settings = getDefaultSettings(app);
 
-    assert.equal(settings.path, '/auth');
     assert.equal(settings.authService, 'authentication');
     assert.equal(settings.linkStrategy, 'jwt');
   });


### PR DESCRIPTION
Pull request that should close https://github.com/feathersjs/feathers/issues/1324 specifically

- `9)` by adding an `expressSession` option to provide a custom session store
- `10)` by using both `profile.sub` and `profile.id`
- `11)` by adding `getRedirect` to the strategy (so it is also customizable on a per-strategy basis)
- `12)` by supporting the `getEntityQuery` and `getEntityData` methods that should make customization easier

@KidkArolis let me know if you see anything that's missing