### PR TITLE
fix: Add fallback for legacy socket authentication

### DIFF
--- a/packages/transport-commons/src/socket/index.ts
+++ b/packages/transport-commons/src/socket/index.ts
@@ -36,6 +36,13 @@ export function socket ({ done, emit, socketKey, getParams }: SocketOptions) {
           runMethod(app, getParams(connection), path, method, args);
         });
       }
+
+      connection.on('authenticate', (...args: any[]) => {
+        if (app.get('defaultAuthentication')) {
+          debug('Got legacy authenticate event');
+          runMethod(app, getParams(connection), app.get('defaultAuthentication'), 'create', args);
+        }
+      });
     }));
 
     // Legacy `socket.emit('serviceName::methodName', ...args)` handlers

--- a/packages/transport-commons/test/socket/index.test.ts
+++ b/packages/transport-commons/test/socket/index.test.ts
@@ -113,6 +113,32 @@ describe('@feathersjs/transport-commons', () => {
   });
 
   describe('legacy method socket event format', () => {
+    it('legacy `authenticate`', done => {
+      const socket = new EventEmitter();
+      const data = {
+        test: 'data'
+      };
+
+      app.set('defaultAuthentication', 'myservice');
+      provider.emit('connection', socket);
+
+      socket.emit('authenticate', data, (error: any, result: any) => {
+        try {
+          const params = Object.assign({
+            query: {},
+            route: {},
+            connection
+          }, connection);
+
+          assert.ok(!error);
+          assert.deepStrictEqual(result, Object.assign({ params }, data));
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+    
     it('.get without params', done => {
       const socket = new EventEmitter();
 


### PR DESCRIPTION
Adds the `authenticate` event from the old authentication so that socket clients using that format will still continue to work.