### PR TITLE
fix: Service typings

### DIFF
--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -52,7 +52,7 @@ declare namespace createApplication {
          * A read only property that contains the Feathers application object. This can be used to
          * retrieve other services (via context.app.service('name')) or configuration values.
          */
-        readonly app: Application;
+        readonly app: Application<T>;
         /**
          * A writeable property containing the data of a create, update and patch service
          * method call.

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -204,7 +204,7 @@ export interface Application<ServiceTypes = any> extends EventEmitter {
 
     setup (server?: any): this;
 
-    service<L extends keyof ServiceTypes> (location: L): ServiceTypes[L];
+    service<L extends keyof ServiceTypes> (location: L): Service<ServiceTypes[L]>;
 
     service (location: string): Service<any>;
 

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -1,212 +1,213 @@
-// Type definitions for @feathersjs/feathers 3.1
-// Project: http://feathersjs.com/
-// Definitions by:  Jan Lohage <https://github.com/j2L4e>
-//                  Abraao Alves <https://github.com/AbraaoAlves>
-//                  Tim Mensch <https://github.com/TimMensch>
-// Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-
-// TypeScript Version: 2.3
-
 /// <reference types='node' />
 
 import { EventEmitter } from 'events';
 
-// tslint:disable-next-line no-unnecessary-generics
-declare const feathers: (<T = any>() => Application<T>);
-export default feathers;
+declare const createApplication: Feathers;
+export = createApplication;
 
-export const version: string;
-
-export type Id = number | string;
-export type NullableId = Id | null;
-
-export interface Query {
-    [key: string]: any;
-}
-
-export interface PaginationOptions {
-    default: number;
-    max: number;
-}
-
-export type ClientSideParams = Pick<Params, 'query' | 'paginate'>;
-export type ServerSideParams = Params;
-
-export interface Params {
-    query?: Query;
-    paginate?: false | Pick<PaginationOptions, 'max'>;
-
-    [key: string]: any; // (JL) not sure if we want this
-}
-
-export interface Paginated<T> {
-    total: number;
-    limit: number;
-    skip: number;
-    data: T[];
-}
-
-// tslint:disable-next-line void-return
-export type Hook = (hook: HookContext) => (Promise<HookContext | void> | HookContext | void);
-
-export interface HookContext<T = any> {
-    /**
-     * A read only property that contains the Feathers application object. This can be used to
-     * retrieve other services (via context.app.service('name')) or configuration values.
-     */
-    readonly app: Application;
-    /**
-     * A writeable property containing the data of a create, update and patch service
-     * method call.
-     */
-    data?: T;
-    /**
-     * A writeable property with the error object that was thrown in a failed method call.
-     * It is only available in error hooks.
-     */
-    error?: any;
-    /**
-     * A writeable property and the id for a get, remove, update and patch service
-     * method call. For remove, update and patch context.id can also be null when
-     * modifying multiple entries. In all other cases it will be undefined.
-     */
-    id?: string | number;
-    /**
-     * A read only property with the name of the service method (one of find, get,
-     * create, update, patch, remove).
-     */
-    readonly method: string;
-    /**
-     * A writeable property that contains the service method parameters (including
-     * params.query).
-     */
-    params: Params;
-    /**
-     * A read only property and contains the service name (or path) without leading or
-     * trailing slashes.
-     */
-    readonly path: string;
-    /**
-     * A writeable property containing the result of the successful service method call.
-     * It is only available in after hooks.
-     *
-     * `context.result` can also be set in
-     *
-     *  - A before hook to skip the actual service method (database) call
-     *  - An error hook to swallow the error and return a result instead
-     */
-    result?: T;
-    /**
-     * A read only property and contains the service this hook currently runs on.
-     */
-    readonly service: Service<T>;
-    /**
-     * A writeable, optional property and contains a 'safe' version of the data that
-     * should be sent to any client. If context.dispatch has not been set context.result
-     * will be sent to the client instead.
-     */
-    dispatch?: T;
-    /**
-     * A writeable, optional property that allows to override the standard HTTP status
-     * code that should be returned.
-     */
-    statusCode?: number;
-    /**
-     * A read only property with the hook type (one of before, after or error).
-     */
-    readonly type: 'before' | 'after' | 'error';
-    /**
-     * The real-time connection object
-     */
-    connection?: any;
-}
-
-export interface HookMap {
-    all: Hook | Hook[];
-    find: Hook | Hook[];
-    get: Hook | Hook[];
-    create: Hook | Hook[];
-    update: Hook | Hook[];
-    patch: Hook | Hook[];
-    remove: Hook | Hook[];
-}
-
-export interface HooksObject {
-    before: Partial<HookMap> | Hook | Hook[];
-    after: Partial<HookMap> | Hook | Hook[];
-    error: Partial<HookMap> | Hook | Hook[];
-    finally: Partial<HookMap> | Hook | Hook[];
-}
-
-// todo: figure out what to do: These methods don't actually need to be implemented, so they can be undefined at runtime. Yet making them optional gets cumbersome in strict mode.
-export interface ServiceMethods<T> {
-    [key: string]: any;
-
-    find? (params?: Params): Promise<T | T[] | Paginated<T>>;
-
-    get? (id: Id, params?: Params): Promise<T>;
-
-    create? (data: Partial<T> | Array<Partial<T>>, params?: Params): Promise<T | T[]>;
-
-    update? (id: NullableId, data: T, params?: Params): Promise<T>;
-
-    patch? (id: NullableId, data: Partial<T>, params?: Params): Promise<T>;
-
-    remove? (id: NullableId, params?: Params): Promise<T>;
-}
-
-export interface SetupMethod {
-    setup (app: Application, path: string): void;
-}
-
-export interface ServiceOverloads<T> {
-    create? (data: Array<Partial<T>>, params?: Params): Promise<T[]>;
-
-    create? (data: Partial<T>, params?: Params): Promise<T>;
-
-    patch? (id: NullableId, data: Pick<T, keyof T>, params?: Params): Promise<T>;
-}
-
-export interface ServiceAddons<T> extends EventEmitter {
-    id?: any;
-    _serviceEvents: string[];
-    hooks (hooks: Partial<HooksObject>): this;
-}
-
-export type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T>;
-
-export type ServiceMixin = (service: Service<any>, path: string) => void;
-
-export interface Application<ServiceTypes = never> extends EventEmitter {
+interface Feathers {
+    <T = any>(): createApplication.Application<T>;
+    readonly ACTIVATE_HOOKS: unique symbol;
     version: string;
+    default: Feathers;
+    // TODO: Write a definition for activateHooks.
+    // activateHooks(): void
+}
 
-    services: ServiceTypes;
+declare namespace createApplication {
+    type Id = number | string;
+    type NullableId = Id | null;
 
-    mixins: ServiceMixin[];
+    interface Query {
+        [key: string]: any;
+    }
 
-    methods: string[];
+    interface PaginationOptions {
+        default: number;
+        max: number;
+    }
 
-    get (name: string): any;
+    type ClientSideParams = Pick<Params, 'query' | 'paginate'>;
+    type ServerSideParams = Params;
 
-    set (name: string, value: any): this;
+    interface Params {
+        query?: Query;
+        paginate?: false | Pick<PaginationOptions, 'max'>;
 
-    disable (name: string): this;
+        [key: string]: any; // (JL) not sure if we want this
+    }
 
-    disabled (name: string): boolean;
+    interface Paginated<T> {
+        total: number;
+        limit: number;
+        skip: number;
+        data: T[];
+    }
 
-    enable (name: string): this;
+    // tslint:disable-next-line void-return
+    type Hook = (hook: HookContext) => (Promise<HookContext | void> | HookContext | void);
 
-    enabled (name: string): boolean;
+    interface HookContext<T = any> {
+        /**
+         * A read only property that contains the Feathers application object. This can be used to
+         * retrieve other services (via context.app.service('name')) or configuration values.
+         */
+        readonly app: Application;
+        /**
+         * A writeable property containing the data of a create, update and patch service
+         * method call.
+         */
+        data?: T;
+        /**
+         * A writeable property with the error object that was thrown in a failed method call.
+         * It is only available in error hooks.
+         */
+        error?: any;
+        /**
+         * A writeable property and the id for a get, remove, update and patch service
+         * method call. For remove, update and patch context.id can also be null when
+         * modifying multiple entries. In all other cases it will be undefined.
+         */
+        id?: string | number;
+        /**
+         * A read only property with the name of the service method (one of find, get,
+         * create, update, patch, remove).
+         */
+        readonly method: string;
+        /**
+         * A writeable property that contains the service method parameters (including
+         * params.query).
+         */
+        params: Params;
+        /**
+         * A read only property and contains the service name (or path) without leading or
+         * trailing slashes.
+         */
+        readonly path: string;
+        /**
+         * A writeable property containing the result of the successful service method call.
+         * It is only available in after hooks.
+         *
+         * `context.result` can also be set in
+         *
+         *  - A before hook to skip the actual service method (database) call
+         *  - An error hook to swallow the error and return a result instead
+         */
+        result?: T;
+        /**
+         * A read only property and contains the service this hook currently runs on.
+         */
+        readonly service: Service<T>;
+        /**
+         * A writeable, optional property and contains a 'safe' version of the data that
+         * should be sent to any client. If context.dispatch has not been set context.result
+         * will be sent to the client instead.
+         */
+        dispatch?: T;
+        /**
+         * A writeable, optional property that allows to override the standard HTTP status
+         * code that should be returned.
+         */
+        statusCode?: number;
+        /**
+         * A read only property with the hook type (one of before, after or error).
+         */
+        readonly type: 'before' | 'after' | 'error';
+        /**
+         * The real-time connection object
+         */
+        connection?: any;
+    }
 
-    configure (callback: (this: this, app: this) => void): this;
+    interface HookMap {
+        all: Hook | Hook[];
+        find: Hook | Hook[];
+        get: Hook | Hook[];
+        create: Hook | Hook[];
+        update: Hook | Hook[];
+        patch: Hook | Hook[];
+        remove: Hook | Hook[];
+    }
 
-    hooks (hooks: Partial<HooksObject>): this;
+    interface HooksObject {
+        before: Partial<HookMap> | Hook | Hook[];
+        after: Partial<HookMap> | Hook | Hook[];
+        error: Partial<HookMap> | Hook | Hook[];
+        finally?: Partial<HookMap> | Hook | Hook[];
+    }
 
-    setup (server?: any): this;
+    // todo: figure out what to do: These methods don't actually need to be
+    // implemented, so they can be undefined at runtime. Yet making them
+    // optional gets cumbersome in strict mode.
+    interface ServiceMethods<T> {
+        [key: string]: any;
 
-    service<L extends keyof ServiceTypes> (location: L): Service<ServiceTypes[L]>;
+        find? (params?: Params): Promise<T | T[] | Paginated<T>>;
 
-    service (location: string): ServiceTypes extends never ? Service<any> : never;
+        get? (id: Id, params?: Params): Promise<T>;
 
-    use (path: string, service: Partial<ServiceMethods<any> & SetupMethod> | Application, options?: any): this;
+        create? (data: Partial<T> | Array<Partial<T>>, params?: Params): Promise<T | T[]>;
+
+        update? (id: NullableId, data: T, params?: Params): Promise<T>;
+
+        patch? (id: NullableId, data: Partial<T>, params?: Params): Promise<T>;
+
+        remove? (id: NullableId, params?: Params): Promise<T>;
+    }
+
+    interface SetupMethod {
+        setup (app: Application, path: string): void;
+    }
+
+    interface ServiceOverloads<T> {
+        create? (data: Array<Partial<T>>, params?: Params): Promise<T[]>;
+
+        create? (data: Partial<T>, params?: Params): Promise<T>;
+
+        patch? (id: NullableId, data: Pick<T, keyof T>, params?: Params): Promise<T>;
+    }
+
+    interface ServiceAddons<T> extends EventEmitter {
+        id?: any;
+        _serviceEvents: string[];
+        hooks (hooks: Partial<HooksObject>): this;
+    }
+
+    type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T>;
+
+    type ServiceMixin = (service: Service<any>, path: string) => void;
+
+    interface Application<ServiceTypes = never> extends EventEmitter {
+        version: string;
+
+        services: ServiceTypes;
+
+        mixins: ServiceMixin[];
+
+        methods: string[];
+
+        get (name: string): any;
+
+        set (name: string, value: any): this;
+
+        disable (name: string): this;
+
+        disabled (name: string): boolean;
+
+        enable (name: string): this;
+
+        enabled (name: string): boolean;
+
+        configure (callback: (this: this, app: this) => void): this;
+
+        hooks (hooks: Partial<HooksObject>): this;
+
+        setup (server?: any): this;
+
+        service<L extends keyof ServiceTypes> (location: L): Service<ServiceTypes[L]>;
+
+        service (location: string): ServiceTypes extends never ? Service<any> : never;
+
+        use (path: string, service: Partial<ServiceMethods<any> & SetupMethod> | Application, options?: any): this;
+    }
 }

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -177,7 +177,7 @@ export type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods
 
 export type ServiceMixin = (service: Service<any>, path: string) => void;
 
-export interface Application<ServiceTypes = any> extends EventEmitter {
+export interface Application<ServiceTypes = never> extends EventEmitter {
     version: string;
 
     services: ServiceTypes;
@@ -206,7 +206,7 @@ export interface Application<ServiceTypes = any> extends EventEmitter {
 
     service<L extends keyof ServiceTypes> (location: L): Service<ServiceTypes[L]>;
 
-    service (location: string): Service<any>;
+    service (location: string): ServiceTypes extends never ? Service<any> : never;
 
     use (path: string, service: Partial<ServiceMethods<any> & SetupMethod> | Application, options?: any): this;
 }


### PR DESCRIPTION
1. Fixed typings for Service.

2. Improvement in service typings is described as follows.

Current typings consists of a catch-all for any service name:

```TypeScript
export interface Application<ServiceTypes = any> extends EventEmitter {

    service<L extends keyof ServiceTypes> (location: L): Service<ServiceTypes[L]>;

    // vvv: Catch-all for any service name
    service (location: string): Service<any>;
}

```

This allows service type to resolve if no `ServiceType` is specified.

```TypeScript
const app = feathersExpress(feathers());
let service1 = app.service('messages'); // service1: Service<any>
```

However, if `ServiceType` is specified, invalid service name should not be resolved:

```TypeScript
type Message = { text: string };
type App = Application<{ messages: Message }>;

const app2 = feathersExpress(feathers()) as App;
let service3 = app2.service('messages'); // service3: Service<Message>
let service4 = app2.service('message');  // service4: never <- Will resolve to Service<any> for current typings
```

Defaulting the `ServiceType` to `never` and modifying the 'catch-all' typings can fulfill the above:

```TypeScript
export interface Application<ServiceTypes = never> extends EventEmitter {

    service<L extends keyof ServiceTypes> (location: L): Service<ServiceTypes[L]>;

    // vvv: Modified catch-all for service name if `ServiceType` is not provided,
    service (location: string): ServiceTypes extends never ? Service<any> : never;
}
```
