### PR TITLE
chore: Remove src folder from .npmignore for ts packages

### DIFF
--- a/packages/authentication-client/.npmignore
+++ b/packages/authentication-client/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json

--- a/packages/authentication-local/.npmignore
+++ b/packages/authentication-local/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json

--- a/packages/authentication-oauth/.npmignore
+++ b/packages/authentication-oauth/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json

--- a/packages/authentication/.npmignore
+++ b/packages/authentication/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json

--- a/packages/commons/.npmignore
+++ b/packages/commons/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json

--- a/packages/configuration/.npmignore
+++ b/packages/configuration/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json

--- a/packages/tests/.npmignore
+++ b/packages/tests/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json

--- a/packages/transport-commons/.npmignore
+++ b/packages/transport-commons/.npmignore
@@ -1,3 +1,2 @@
 test/
-src/
 tsconfig.json


### PR DESCRIPTION
Any drawbacks to this? 

As i understand should not affect local development as `link` command ignores `.npmignore`.