### PR TITLE
fix: Clean up hooks code

### DIFF
--- a/packages/express/test/rest.test.js
+++ b/packages/express/test/rest.test.js
@@ -249,7 +249,8 @@ describe('@feathersjs/express/rest provider', () => {
                 arguments: ['dishes', paramsWithHeaders ],
                 type: 'error',
                 method: 'get',
-                path: 'hook-error'
+                path: 'hook-error',
+                original: data.hook.original
               },
               error: { message: 'I blew up' }
             });

--- a/packages/feathers/lib/hooks/base.js
+++ b/packages/feathers/lib/hooks/base.js
@@ -3,16 +3,14 @@ const { _ } = require('@feathersjs/commons');
 const assignArguments = context => {
   const { service, method } = context;
   const parameters = service.methods[method];
-  const argsObject = context.arguments.reduce((result, value, index) => {
-    result[parameters[index]] = value;
-    return result;
-  }, {});
 
-  if (!argsObject.params) {
-    argsObject.params = {};
+  context.arguments.forEach((value, index) => {
+    context[parameters[index]] = value;
+  });
+
+  if (!context.params) {
+    context.params = {};
   }
-
-  Object.assign(context, argsObject);
 
   return context;
 };

--- a/packages/transport-commons/src/channels/mixins.ts
+++ b/packages/transport-commons/src/channels/mixins.ts
@@ -11,7 +11,7 @@ const ALL_EVENTS = Symbol('@feathersjs/transport-commons/all-events');
 export const keys = {
   PUBLISHERS: PUBLISHERS as typeof PUBLISHERS,
   CHANNELS: CHANNELS as typeof CHANNELS,
-  ALL_EVENTS: ALL_EVENTS as typeof ALL_EVENTS,
+  ALL_EVENTS: ALL_EVENTS as typeof ALL_EVENTS
 };
 
 export interface ChannelMixin {


### PR DESCRIPTION
Fixes two errors:

1) `finally` hooks can possibly run twice for same method call if one of them throws. Also a `finally` hook if throws activates `error` hooks, this is in conflict with this [comment](https://github.com/feathersjs/feathers/blob/f9d8536c400caba355ccc8a2cdf171dcd9cff555/packages/feathers/lib/events.js#L77) and also `Promise.finally` and `try/catch/finally` convention. Because currently it is like this ([1](https://github.com/feathersjs/feathers/blob/f9d8536c400caba355ccc8a2cdf171dcd9cff555/packages/feathers/lib/hooks/index.js#L73), [2](https://github.com/feathersjs/feathers/blob/f9d8536c400caba355ccc8a2cdf171dcd9cff555/packages/feathers/lib/hooks/index.js#L85)):
```js
try {
  run([...before])();
  method();
  run([...after, ...finally])();
} catch {
  run([...error, ...finally])();
}
```

2) An `error` hook can get a context which is not up to date, if any `before` hook returns new context object and a service method throws, because errors ([1](https://github.com/feathersjs/feathers/blob/f9d8536c400caba355ccc8a2cdf171dcd9cff555/packages/feathers/lib/hooks/index.js#L59), [2](https://github.com/feathersjs/feathers/blob/f9d8536c400caba355ccc8a2cdf171dcd9cff555/packages/feathers/lib/hooks/index.js#L62)) thrown in a method invocation do no have `hook` property set (which should contain a last valid hook context), that's why `error` hooks end up using an initial hook object.

Added fixes and tests for such cases. Also small clean up changes for readability and performance.

A question for future: What are use cases for allowing returning new context object from hook functions where modifying context in place is not as convenient?