### PR TITLE
fix: @feathersjs/express: allow middleware arrays

### DIFF
--- a/packages/express/lib/index.js
+++ b/packages/express/lib/index.js
@@ -28,7 +28,7 @@ function feathersExpress (feathersApp) {
       let middleware = Array.from(arguments)
         .slice(1)
         .reduce(function (middleware, arg) {
-          if (typeof arg === 'function') {
+          if (typeof arg === 'function' || Array.isArray(arg)) {
             middleware[service ? 'after' : 'before'].push(arg);
           } else if (!service) {
             service = arg;
@@ -42,7 +42,7 @@ function feathersExpress (feathersApp) {
         });
 
       const hasMethod = methods => methods.some(name =>
-        (service && !Array.isArray(service) && typeof service[name] === 'function')
+        (service && typeof service[name] === 'function')
       );
 
       // Check for service (any object with at least one service method)

--- a/packages/express/test/rest.test.js
+++ b/packages/express/test/rest.test.js
@@ -367,6 +367,42 @@ describe('@feathersjs/express/rest provider', () => {
         .then(() => server.close());
     });
 
+    it('allows middleware arrays before and after a service', () => {
+      const app = expressify(feathers());
+
+      app.configure(rest())
+        .use(expressify.json())
+        .use('/todo', [function (req, res, next) {
+          req.body.before = ['before first'];
+          next();
+        }, function (req, res, next) {
+          req.body.before.push('before second');
+          next();
+        }], {
+            create (data) {
+              return Promise.resolve(data);
+            }
+          }, [function (req, res, next) {
+            res.data.after = ['after first'];
+            next();
+          }], function (req, res, next) {
+            res.data.after.push('after second');
+            next();
+          });
+
+      const server = app.listen(4776);
+
+      return axios.post('http://localhost:4776/todo', { text: 'Do dishes' })
+        .then(res => {
+          assert.deepStrictEqual(res.data, {
+            text: 'Do dishes',
+            before: ['before first', 'before second'],
+            after: ['after first', 'after second']
+          });
+        })
+        .then(() => server.close());
+    });
+
     it('allows an array of middleware without a service', () => {
       const app = expressify(feathers());
       const middlewareArray = [


### PR DESCRIPTION
Using as many middleware arrays or functions as you want is valid for express, since it uses `array-flatten` on passed arguments ([1](https://github.com/expressjs/express/blob/e1b45ebd050b6f06aa38cda5aaf0c21708b0c71e/lib/router/index.js#L448), [2](https://github.com/expressjs/express/blob/e1b45ebd050b6f06aa38cda5aaf0c21708b0c71e/lib/router/route.js#L194)).

Now does not throw on valid usage for express and allows to use arrays of middleware before and after feathers service.