### PR TITLE
feat: helper script to fail tests on unhandled rejections

### DIFF
--- a/packages/adapter-tests/lib/rejections.js
+++ b/packages/adapter-tests/lib/rejections.js
@@ -1,0 +1,15 @@
+/* tslint:disable:no-console */
+
+let count = 0;
+
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled rejection:', reason);
+  count++;
+});
+
+process.on('exit', (code) => {
+  if (count !== 0) {
+    console.error(`Total count of unhandled rejections: ${count}`);
+    process.exitCode = code || 1;
+  }
+});


### PR DESCRIPTION
Usage with mocha: `--require @feathersjs/adapter-tests/lib/rejections`.