### PR TITLE
fix: @feathersjs/express: replace `reduce` with `map`

### DIFF
--- a/packages/express/lib/rest/getHandler.js
+++ b/packages/express/lib/rest/getHandler.js
@@ -32,16 +32,16 @@ function getAllowedMethods (service, routes) {
 }
 
 function makeArgsGetter (argsOrder) {
-  return (req, params) => argsOrder.reduce((result, argName) => {
+  return (req, params) => argsOrder.map((argName) => {
     switch (argName) {
       case 'id':
-        return [ ...result, req.params.__feathersId || null ];
+        return req.params.__feathersId || null;
       case 'data':
-        return [ ...result, req.body ];
+        return req.body;
       case 'params':
-        return [ ...result, params ];
+        return params;
     }
-  }, []);
+  });
 }
 
 // A function that returns the middleware for a given method and service


### PR DESCRIPTION
Easier to read and faster 4 times: 500,000 vs 2,000,000 ops/sec.

Also small difference (fix): before if you `activateHooks()` some method with a nonstandard argument resulted express args getter will throw an error, now it returns valid array with `undefined` for unknown arguments. (Vanilla feathers supports nonstandard arguments, but there is no test for such case.)

Also [`makeArguments`](https://github.com/feathersjs/feathers/blob/9585ac0ee8b051c869e1b351b15da202604af244/packages/commons/src/hooks.ts#L52) and [`defaultMakeArguments`](https://github.com/feathersjs/feathers/blob/9585ac0ee8b051c869e1b351b15da202604af244/packages/commons/src/hooks.ts#L34) can be safely removed before major release, since they have been replaced with [new system](https://github.com/feathersjs/feathers/blob/9585ac0ee8b051c869e1b351b15da202604af244/packages/feathers/lib/hooks/index.js#L56) and not used anywhere. If for some backward compatibility reason you want to keep them, we can replace their internals with same one liner:

```js
return hook.service.methods[hook.method].map((value) => hook[value]);
```