### PR TITLE
fix: Remove unnecessary top level export files in @feathersjs/express

### DIFF
--- a/packages/express/errors.js
+++ b/packages/express/errors.js
@@ -1,1 +1,0 @@
-module.exports = require('@feathersjs/errors/handler');

--- a/packages/express/rest.js
+++ b/packages/express/rest.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/rest');

--- a/packages/express/rest.js
+++ b/packages/express/rest.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/rest');


### PR DESCRIPTION
It is already available via `const { errorHandler } = require('@feathersjs/express');`

Closes #1441