### PR TITLE
Conditional removeAccessToken for 401/404 case

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -107,7 +107,7 @@ export class AuthenticationClient {
       });
   }
 
-  removeAccessToken () {
+  removeAccessToken (error?: Error) {
     return this.storage.removeItem(this.options.storageKey);
   }
 
@@ -134,7 +134,7 @@ export class AuthenticationClient {
           accessToken
         });
       }).catch((error: Error) =>
-        this.removeAccessToken().then(() => Promise.reject(error))
+        this.removeAccessToken(error).then(() => Promise.reject(error))
       );
     }
 

--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -107,8 +107,16 @@ export class AuthenticationClient {
       });
   }
 
+  removeTokenOnError () {
+    return true
+  }
+
   removeAccessToken (error?: Error) {
-    return this.storage.removeItem(this.options.storageKey);
+    if (this.removeTokenOnError(error)) {
+      return this.storage.removeItem(this.options.storageKey);
+    } else {
+      return Promise.resolve()
+    }
   }
 
   reset () {

--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -29,6 +29,7 @@ export interface AuthenticationClientOptions {
   jwtStrategy: string;
   path: string;
   Authentication: ClientConstructor;
+  removeTokenOnError (error?: Error): boolean;
 }
 
 export class AuthenticationClient {
@@ -107,15 +108,11 @@ export class AuthenticationClient {
       });
   }
 
-  removeTokenOnError () {
-    return true
-  }
-
   removeAccessToken (error?: Error) {
-    if (this.removeTokenOnError(error)) {
+    if (this.options.removeTokenOnError(error)) {
       return this.storage.removeItem(this.options.storageKey);
     } else {
-      return Promise.resolve()
+      return Promise.resolve();
     }
   }
 

--- a/packages/authentication-client/src/index.ts
+++ b/packages/authentication-client/src/index.ts
@@ -32,7 +32,8 @@ export const defaults: AuthenticationClientOptions = {
   jwtStrategy: 'jwt',
   path: '/authentication',
   Authentication: AuthenticationClient,
-  storage: defaultStorage
+  storage: defaultStorage,
+  removeTokenOnError: () => true
 };
 
 const init = (_options: Partial<AuthenticationClientOptions> = {}) => {


### PR DESCRIPTION
This would allow to override the removeAccessToken() method to conditionally not remove the token. In particular my use case is something like:

```js
if (err.code === 401 || err.code === 404) {
  // remove the token
} else {
  // temporary issue, show an error screen
}
```

Not sure this implementation is the best, maybe an option of something like `removeTokenOnError: err => bool` in `auth` would be nicer?