### PR TITLE
fix: Expire and remove authenticated real-time connections

### DIFF
--- a/packages/authentication/src/hooks/connection.ts
+++ b/packages/authentication/src/hooks/connection.ts
@@ -1,9 +1,8 @@
 import { HookContext } from '@feathersjs/feathers';
 import { omit } from 'lodash';
+import { AuthenticationBase, ConnectionEvent } from '../core';
 
-import { AuthenticationBase } from '../core';
-
-export default () => async (context: HookContext) => {
+export default (event: ConnectionEvent) => async (context: HookContext) => {
   const { result, params: { connection } } = context;
 
   if (!connection) {
@@ -11,14 +10,10 @@ export default () => async (context: HookContext) => {
   }
 
   const service = context.service as unknown as AuthenticationBase;
-  const strategies = service.getStrategies(...Object.keys(service.strategies))
-    .filter(current => typeof current.handleConnection === 'function');
 
   Object.assign(connection, omit(result, 'accessToken', 'authentication'));
 
-  for (const strategy of strategies) {
-    await strategy.handleConnection(connection, context);
-  }
+  await service.handleConnection(event, connection, result);
 
   return context;
 };

--- a/packages/authentication/src/hooks/event.ts
+++ b/packages/authentication/src/hooks/event.ts
@@ -1,12 +1,13 @@
 import Debug from 'debug';
 import { HookContext } from '@feathersjs/feathers';
+import { ConnectionEvent } from '../core';
 
 const debug = Debug('@feathersjs/authentication/hooks/connection');
 
-export default (event: string) => (context: HookContext) => {
-  const { type, app, result, params } = context;
+export default (event: ConnectionEvent) => async (context: HookContext) => {
+  const { app, result, params } = context;
 
-  if (type === 'after' && params.provider && result) {
+  if (params.provider && result) {
     debug(`Sending authentication event '${event}'`);
     app.emit(event, result, params, context);
   }

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -27,6 +27,9 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
   }
 
   async handleConnection (event: ConnectionEvent, connection: any, authResult?: AuthenticationResult): Promise<void> {
+    const isValidLogout = event === 'logout' && connection.authentication && authResult &&
+      connection.authentication.accessToken === authResult.accessToken;
+    
     if (authResult && event === 'login') {
       const { accessToken } = authResult;
       const { exp } = await this.authentication.verifyAccessToken(accessToken);
@@ -44,10 +47,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
         strategy: this.name,
         accessToken
       };
-    } else if (event === 'disconnect' || (
-      event === 'logout' && connection.authentication && authResult &&
-      connection.authentication.accessToken === authResult.accessToken
-    )) {
+    } else if (event === 'disconnect' || isValidLogout) {
       debug('Removing authentication information and expiration timer from connection');
 
       delete connection.authentication;

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -1,16 +1,18 @@
-import { NotAuthenticated } from '@feathersjs/errors';
-import { IncomingMessage } from 'http';
-import { omit } from 'lodash';
 import Debug from 'debug';
-import { Params, HookContext } from '@feathersjs/feathers';
+import { omit } from 'lodash';
+import { IncomingMessage } from 'http';
+import { NotAuthenticated } from '@feathersjs/errors';
+import { Params } from '@feathersjs/feathers';
 
 import { AuthenticationBaseStrategy } from './strategy';
-import { AuthenticationRequest, AuthenticationResult } from './core';
+import { AuthenticationRequest, AuthenticationResult, ConnectionEvent } from './core';
 
 const debug = Debug('@feathersjs/authentication/jwt');
 const SPLIT_HEADER = /(\S+)\s+(\S+)/;
 
 export class JWTStrategy extends AuthenticationBaseStrategy {
+  expirationTimers = new WeakMap();
+
   get configuration () {
     const authConfig = this.authentication.configuration;
     const config = super.configuration;
@@ -24,23 +26,33 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     };
   }
 
-  async handleConnection (connection: any, context: HookContext) {
-    const { result: { accessToken }, method } = context;
+  async handleConnection (event: ConnectionEvent, connection: any, authResult?: AuthenticationResult): Promise<void> {
+    if (authResult && event === 'login') {
+      const { accessToken } = authResult;
+      const { exp } = await this.authentication.verifyAccessToken(accessToken);
+      // The time (in ms) until the token expires
+      const duration = (exp * 1000) - new Date().getTime();
+      // This may have to be a `logout` event but right now we don't want
+      // the whole context object lingering around until the timer is gone
+      const timer = setTimeout(() => this.app.emit('disconnect', connection), duration);
 
-    if (accessToken) {
-      if (method === 'create') {
-        debug('Adding authentication information to connection');
-        connection.authentication = {
-          strategy: this.name,
-          accessToken
-        };
-      } else if (method === 'remove' && accessToken === connection.authentication.accessToken) {
-        debug('Removing authentication information from connection');
-        delete connection.authentication;
-      }
+      debug(`Registering connection expiration timer for ${duration}ms`);
+      this.expirationTimers.set(connection, timer);
+
+      debug('Adding authentication information to connection');
+      connection.authentication = {
+        strategy: this.name,
+        accessToken
+      };
+    } else if (event === 'disconnect' || (
+      event === 'logout' && connection.authentication && authResult &&
+      connection.authentication.accessToken === authResult.accessToken
+    )) {
+      debug('Removing authentication information and expiration timer from connection');
+
+      delete connection.authentication;
+      clearTimeout(this.expirationTimers.get(connection));
     }
-
-    return context;
   }
 
   verifyConfiguration () {

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -155,10 +155,9 @@ export class AuthenticationService extends AuthenticationBase implements Partial
 
     // @ts-ignore
     this.hooks({
-      after: [ connection() ],
-      finally: {
-        create: [ event('login') ],
-        remove: [ event('logout') ]
+      after: {
+        create: [ connection('login'), event('login') ],
+        remove: [ connection('logout'), event('logout') ]
       }
     });
   }

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -92,7 +92,7 @@ describe('authentication/jwt', () => {
     });
   });
 
-  describe('updateConnection', () => {
+  describe('handleConnection', () => {
     it('adds authentication information on create', async () => {
       const connection: any = {};
 
@@ -106,6 +106,27 @@ describe('authentication/jwt', () => {
         strategy: 'jwt',
         accessToken
       });
+    });
+
+    it('sends disconnect event when connection token expires and removes authentication', async () => {
+      const connection: any = {};
+      const token: string = await app.service('authentication').createAccessToken({}, {
+        subject: `${user.id}`,
+        expiresIn: '1s'
+      });
+
+      const result = await app.service('authentication').create({
+        strategy: 'jwt',
+        accessToken: token
+      }, { connection });
+
+      assert.ok(connection.authentication);
+
+      assert.strictEqual(result.accessToken, token);
+
+      const disconnection = await new Promise(resolve => app.once('disconnect', resolve));
+
+      assert.strictEqual(disconnection, connection);
     });
 
     it('deletes authentication information on remove', async () => {

--- a/packages/socketio/test/index.test.js
+++ b/packages/socketio/test/index.test.js
@@ -10,7 +10,7 @@ const methodTests = require('./methods.js');
 const eventTests = require('./events');
 const socketio = require('../lib');
 
-describe.only('@feathersjs/socketio', () => {
+describe('@feathersjs/socketio', () => {
   let app;
   let server;
   let socket;


### PR DESCRIPTION
This pull request makes sure that authenticated real-time connections will be removed from their channels if the token expires while they are still connected or if they log out.

This should be the last thing for the v4 final release.