### PR TITLE
__hooks become writable and configurable

### DIFF
--- a/packages/commons/src/hooks.ts
+++ b/packages/commons/src/hooks.ts
@@ -154,7 +154,9 @@ export function enableHooks (obj: any, methods: string[], types: string[]) {
 
   // Add non-enumerable `__hooks` property to the object
   Object.defineProperty(obj, '__hooks', {
-    value: hookData
+    configurable: true,
+    value: hookData,
+    writable: true
   });
 
   return Object.assign(obj, {


### PR DESCRIPTION
We should be able to modify or delete this value.

In a particular case it will avoid me this kind of error:
```
Uncaught TypeError: Cannot redefine property: __hooks
```
```
Uncaught TypeError: Cannot delete property '__hooks' of #<Object>
```
