### PR TITLE
Omit standard protocol ports from the default hostname

### DIFF
--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -26,11 +26,12 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   const { strategyNames } = service;
   const { path = '/oauth' } = oauth.defaults || {};
   const port = String(app.get('port'));
-  const protocol = app.get('env') === 'production' ? 'https' : 'http';
+  const protocol = app.get('env') !== 'development' ? 'https' : 'http';
   
-  // Omit standard protocol ports from the default hostname
+  // Dev environments commonly run on an extended port, so we need to append the port
+  // to the default hostname, unless it is the standard port
   let host = app.get('host');
-  if ((protocol === 'https' && port !== '443') || (protocol === 'http' && port !== '80')) {
+  if (app.get('env') === 'development' && port !== '80') {
     host += ':' + port;
   }
   

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -25,17 +25,26 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
 
   const { strategyNames } = service;
   const { path = '/oauth' } = oauth.defaults || {};
+  const port = String(app.get('port'));
+  const protocol = app.get('env') === 'production' ? 'https' : 'http';
+  
+  // Omit standard protocol ports from the default hostname
+  let host = app.get('host');
+  if ((protocol === 'https' && port !== '443') || (protocol === 'http' && port !== '80')) {
+    host += ':' + port;
+  }
+  
   const grant = merge({
     defaults: {
       path,
-      host: `${app.get('host')}:${app.get('port')}`,
-      protocol: app.get('env') === 'production' ? 'https' : 'http',
+      host,
+      protocol,
       transport: 'session'
     }
   }, omit(oauth, 'redirect'));
+  
   const getUrl = (url: string) => {
     const { defaults } = grant;
-
     return `${defaults.protocol}://${defaults.host}${path}/${url}`;
   };
 

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -24,15 +24,19 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   }
 
   const { strategyNames } = service;
-  const { path = '/oauth' } = oauth.defaults || {};
-  const port = String(app.get('port'));
-  const protocol = app.get('env') !== 'development' ? 'https' : 'http';
   
-  // Dev environments commonly run on an extended port, so we need to append the port
-  // to the default hostname, unless it is the standard port
+  // Set up all the defaults
+  const { path = '/oauth' } = oauth.defaults || {};
+  const port = app.get('port');
   let host = app.get('host');
-  if (app.get('env') === 'development' && port !== '80') {
-    host += ':' + port;
+  let protocol = 'https';
+  
+  // Development environments commonly run on HTTP with an extended port
+  if (app.get('env') === 'development') {
+    protocol = 'http';
+    if (String(port) !== '80') {
+      host += ':' + port;
+    }
   }
   
   const grant = merge({


### PR DESCRIPTION
When running on the standard port for the protocol (80 for http, 443 for https), the default oauth `redirect_uri` contains the port, which is redundant and causes the authentication request to fail in most cases.