### PR TITLE
fix: Add info to express error handler logger type

### DIFF
--- a/packages/express/index.d.ts
+++ b/packages/express/index.d.ts
@@ -22,7 +22,7 @@ interface FeathersExpress extends Express {
 
     errorHandler (options?: {
         public?: string,
-        logger?: { error?: (msg: string) => void | null },
+        logger?: { error: (msg: any) => void, info: (msg: any) => void },
         html?: any,
         json?: any
     }): express.ErrorRequestHandler;


### PR DESCRIPTION
If provided a logger should have `info` property, which is used [here](https://github.com/feathersjs/feathers/blob/eae036b16f0bb3597cd96945ca1b8b4c78b8819c/packages/express/lib/error-handler.js#L34).

Instead of `void | null`, just `void` for return type of logging functions.

`msg` is not a `string`, but `any` since it is used to log errors (as shown in link above) and they might not be a string.

`error` property is required now, if you don't want to log stuff, just do not provide `logger` since it is optional already.