### PR TITLE
fix: minor stuff

### DIFF
--- a/packages/authentication-client/package.json
+++ b/packages/authentication-client/package.json
@@ -39,15 +39,15 @@
     "access": "public"
   },
   "dependencies": {
+    "@feathersjs/authentication": "^4.3.2",
     "@feathersjs/commons": "^4.3.0",
     "@feathersjs/errors": "^4.3.2",
+    "@feathersjs/feathers": "^4.3.2",
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@feathersjs/authentication": "^4.3.2",
     "@feathersjs/authentication-local": "^4.3.2",
     "@feathersjs/express": "^4.3.2",
-    "@feathersjs/feathers": "^4.3.2",
     "@feathersjs/primus": "^4.3.2",
     "@feathersjs/primus-client": "^4.3.2",
     "@feathersjs/rest-client": "^4.3.2",

--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -39,14 +39,14 @@
     "access": "public"
   },
   "dependencies": {
+    "@feathersjs/authentication": "^4.3.2",
     "@feathersjs/errors": "^4.3.2",
+    "@feathersjs/feathers": "^4.3.2",
     "bcryptjs": "^2.4.3",
     "debug": "^4.1.1",
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@feathersjs/authentication": "^4.3.2",
-    "@feathersjs/feathers": "^4.3.2",
     "@types/bcryptjs": "^2.4.2",
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.14.137",

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -42,6 +42,7 @@
     "@feathersjs/authentication": "^4.3.2",
     "@feathersjs/errors": "^4.3.2",
     "@feathersjs/express": "^4.3.2",
+    "@feathersjs/feathers": "^4.3.2",
     "debug": "^4.1.1",
     "express-session": "^1.16.2",
     "grant": "^4.6.2",
@@ -49,7 +50,6 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@feathersjs/feathers": "^4.3.2",
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.1",
     "@types/express-session": "^1.15.14",

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -24,13 +24,13 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   }
 
   const { strategyNames } = service;
-  
+
   // Set up all the defaults
   const { path = '/oauth' } = oauth.defaults || {};
   const port = app.get('port');
   let host = app.get('host');
   let protocol = 'https';
-  
+
   // Development environments commonly run on HTTP with an extended port
   if (app.get('env') === 'development') {
     protocol = 'http';
@@ -38,7 +38,7 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
       host += ':' + port;
     }
   }
-  
+
   const grant = merge({
     defaults: {
       path,
@@ -47,7 +47,7 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
       transport: 'session'
     }
   }, omit(oauth, 'redirect'));
-  
+
   const getUrl = (url: string) => {
     const { defaults } = grant;
     return `${defaults.protocol}://${defaults.host}${path}/${url}`;

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@feathersjs/errors": "^4.3.2",
+    "@feathersjs/feathers": "^4.3.2",
     "@feathersjs/transport-commons": "^4.3.2",
     "debug": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
@@ -48,7 +49,6 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@feathersjs/feathers": "^4.3.2",
     "@types/debug": "^4.1.5",
     "@types/jsonwebtoken": "^8.3.3",
     "@types/lodash": "^4.14.137",

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -92,14 +92,14 @@ export class AuthenticationService extends AuthenticationBase implements Partial
 
     debug('Got authentication result', authResult);
 
+    if (authResult.accessToken) {
+      return authResult;
+    }
+
     const [ payload, jwtOptions ] = await Promise.all([
       this.getPayload(authResult, params),
       this.getTokenOptions(authResult, params)
     ]);
-
-    if (authResult.accessToken) {
-      return authResult;
-    }
 
     debug('Creating JWT with', payload, jwtOptions);
 

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -44,11 +44,11 @@
     "access": "public"
   },
   "dependencies": {
+    "@feathersjs/feathers": "^4.3.2",
     "config": "^3.2.2",
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@feathersjs/feathers": "^4.3.2",
     "@types/config": "^0.0.34",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.7",

--- a/packages/configuration/src/index.ts
+++ b/packages/configuration/src/index.ts
@@ -7,7 +7,7 @@ const debug = Debug('@feathersjs/configuration');
 const separator = path.sep;
 
 export default function init () {
-  return (app: Application|undefined) => {
+  return (app?: Application) => {
     const convert = (current: any) => {
       const result: { [key: string]: any } = Array.isArray(current) ? [] : {};
 
@@ -53,7 +53,7 @@ export default function init () {
     Object.keys(conf).forEach(name => {
       const value = conf[name];
       debug(`Setting ${name} configuration value to`, value);
-      (app as Application).set(name, value);
+      app!.set(name, value);
     });
 
     return conf;

--- a/packages/feathers/lib/application.js
+++ b/packages/feathers/lib/application.js
@@ -70,7 +70,7 @@ const application = {
     const current = this.services[location];
 
     if (typeof current === 'undefined' && typeof this.defaultService === 'function') {
-      return this.use(`/${location}`, this.defaultService(location))
+      return this.use(location, this.defaultService(location))
         .service(location);
     }
 
@@ -84,9 +84,7 @@ const application = {
 
     const location = stripSlashes(path) || '/';
     const isSubApp = typeof service.service === 'function' && service.services;
-    const isService = this.methods.concat('setup').some(name =>
-      (service && typeof service[name] === 'function')
-    );
+    const isService = this.methods.concat('setup').some(name => typeof service[name] === 'function');
 
     if (isSubApp) {
       const subApp = service;


### PR DESCRIPTION
Minor stuff:

1) Moved `@feathers/*` dependencies from `devDependencies` to `dependencies` if their types are present in a package build.

2) Moved [this line](https://github.com/feathersjs/feathers/blob/13b3dbdf8133bce2833a56bfbd0f0799b0420a8a/packages/authentication/src/service.ts#L100) up, since no need to call `getPayload` and `getTokenOptions` if their result is irrelevant.

3) [Here](https://github.com/feathersjs/feathers/blob/13b3dbdf8133bce2833a56bfbd0f0799b0420a8a/packages/feathers/lib/application.js#L73) used `location` as is, without prepending slash, as it will be stripped anyway.

4) In [`@feathersjs/configuration`](https://github.com/feathersjs/feathers/blob/13b3dbdf8133bce2833a56bfbd0f0799b0420a8a/packages/configuration/src/index.ts) allow calling without an argument and use `app!.` instead of `(app as Application).`.

5) No need to `service &&` [here](https://github.com/feathersjs/feathers/blob/13b3dbdf8133bce2833a56bfbd0f0799b0420a8a/packages/feathers/lib/application.js#L88) since line before will throw if `service` is undefined, also in types `service` is non-nullable.

Note:

6) [`@feathersjs/commons`](https://github.com/feathersjs/feathers/blob/13b3dbdf8133bce2833a56bfbd0f0799b0420a8a/packages/commons/package.json#L3) seems to be stuck at `4.3.0` while everyone else is already at `4.3.2` (it skipped `4.3.1` too).