### PR TITLE
Removed opinionated protocol setting

### DIFF
--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -24,21 +24,21 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   }
 
   const { strategyNames } = service;
-  
+
   // Set up all the defaults
   const { path = '/oauth' } = oauth.defaults || {};
   const port = app.get('port');
+  const ignorePort = (app.get('ignorePort') === true) ? true : false;
+
   let host = app.get('host');
-  let protocol = 'https';
-  
+  let protocol = app.get('protocol');
   // Development environments commonly run on HTTP with an extended port
-  if (app.get('env') === 'development') {
-    protocol = 'http';
-    if (String(port) !== '80') {
-      host += ':' + port;
-    }
+  if (!protocol) {
+    protocol = (app.get('env') === 'development') ? 'http' : 'https';
   }
-  
+
+  if (!ignorePort && ((protocol === 'http' && String(port) != '80') || (protocol === 'https' && String(port) != '443'))) host += ':' + String(port);
+
   const grant = merge({
     defaults: {
       path,
@@ -47,7 +47,7 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
       transport: 'session'
     }
   }, omit(oauth, 'redirect'));
-  
+
   const getUrl = (url: string) => {
     const { defaults } = grant;
     return `${defaults.protocol}://${defaults.host}${path}/${url}`;


### PR DESCRIPTION
**Problem**
OAuth requests do not possess the ability to set the protocol and port from the configuration.
In addition, when in a development environment, the opinionated nature of the protocol setting forced a `redirect_url` with only a `http://` protocol.