### PR TITLE
feat: application service types default to any

### DIFF
--- a/packages/authentication-client/src/index.ts
+++ b/packages/authentication-client/src/index.ts
@@ -4,7 +4,7 @@ import { Application } from '@feathersjs/feathers';
 import { Storage, MemoryStorage, StorageWrapper } from './storage';
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  interface Application<ServiceTypes = {}> { // eslint-disable-line
+  interface Application<ServiceTypes, AppSettings> { // eslint-disable-line
     io?: any;
     rest?: any;
     authentication: AuthenticationClient;

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -10,7 +10,7 @@ import jsonwebtoken from 'jsonwebtoken';
 const debug = Debug('@feathersjs/authentication/service');
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  interface FeathersApplication<ServiceTypes = {}, AppSettings = {}> { // eslint-disable-line
+  interface FeathersApplication<ServiceTypes, AppSettings> { // eslint-disable-line
     /**
      * Returns the default authentication service or the
      * authentication service for a given path.

--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -25,7 +25,7 @@ export interface ExpressOverrides<ServiceTypes> {
   use: ExpressUseHandler<this, ServiceTypes>;
 }
 
-export type Application<ServiceTypes = {}, AppSettings = {}> =
+export type Application<ServiceTypes = any, AppSettings = any> =
   Omit<Express, 'listen'|'use'> &
   FeathersApplication<ServiceTypes, AppSettings> &
   ExpressOverrides<ServiceTypes>;

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -21,7 +21,7 @@ export * from './declarations';
 
 const debug = Debug('@feathersjs/express');
 
-export default function feathersExpress<S = {}, C = {}> (feathersApp?: FeathersApplication, expressApp: Express = express()): Application<S, C> {
+export default function feathersExpress<S = any, C = any> (feathersApp?: FeathersApplication, expressApp: Express = express()): Application<S, C> {
   if (!feathersApp) {
     return expressApp as any;
   }

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -105,7 +105,7 @@ export type ServiceMixin<A> = (service: FeathersService<A>, path: string, option
 export type ServiceGenericType<S> = S extends ServiceInterface<infer T> ? T : any;
 export type ServiceGenericData<S> = S extends ServiceInterface<infer _T, infer D> ? D : any;
 
-export interface FeathersApplication<ServiceTypes = {}, AppSettings = {}> {
+export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
   /**
    * The Feathers application version
    */
@@ -145,9 +145,7 @@ export interface FeathersApplication<ServiceTypes = {}, AppSettings = {}> {
    *
    * @param name The setting name
    */
-  get<L extends keyof AppSettings> (
-    name: AppSettings[L] extends never ? string : L
-  ): (AppSettings[L] extends never ? any : AppSettings[L]);
+  get<L extends keyof AppSettings & string> (name: L): AppSettings[L];
 
   /**
    * Set an application setting
@@ -155,10 +153,7 @@ export interface FeathersApplication<ServiceTypes = {}, AppSettings = {}> {
    * @param name The setting name
    * @param value The setting value
    */
-  set<L extends keyof AppSettings> (
-    name: AppSettings[L] extends never ? string : L,
-    value: AppSettings[L] extends never ? any : AppSettings[L]
-  ): this;
+  set<L extends keyof AppSettings & string> (name: L, value: AppSettings[L]): this;
 
   /**
    * Runs a callback configure function with the current application instance.
@@ -186,11 +181,9 @@ export interface FeathersApplication<ServiceTypes = {}, AppSettings = {}> {
    * Feathers application to use a sub-app under the `path` prefix.
    * @param options The options for this service
    */
-  use<L extends keyof ServiceTypes> (
-    path: ServiceTypes[L] extends never ? string : L,
-    service: (ServiceTypes[L] extends never ?
-      ServiceInterface<any> : ServiceTypes[L]
-    ) | Application,
+  use<L extends keyof ServiceTypes & string> (
+    path: L,
+    service: (keyof any extends keyof ServiceTypes ? ServiceInterface<any> : ServiceTypes[L]) | Application,
     options?: ServiceOptions
   ): this;
 
@@ -201,12 +194,9 @@ export interface FeathersApplication<ServiceTypes = {}, AppSettings = {}> {
    *
    * @param path The name of the service.
    */
-  service<L extends keyof ServiceTypes> (
-    path: ServiceTypes[L] extends never ? string : L
-  ): (ServiceTypes[L] extends never
-    ? FeathersService<this, Service<any>>
-    : FeathersService<this, ServiceTypes[L]>
-  );
+  service<L extends keyof ServiceTypes & string> (
+    path: L
+  ): FeathersService<this, keyof any extends keyof ServiceTypes ? Service<any> : ServiceTypes[L]>;
 
   setup (server?: any): Promise<this>;
 
@@ -220,7 +210,7 @@ export interface FeathersApplication<ServiceTypes = {}, AppSettings = {}> {
 
 // This needs to be an interface instead of a type
 // so that the declaration can be extended by other modules
-export interface Application<ServiceTypes = {}, AppSettings = {}> extends FeathersApplication<ServiceTypes, AppSettings>, EventEmitter {
+export interface Application<ServiceTypes = any, AppSettings = any> extends FeathersApplication<ServiceTypes, AppSettings>, EventEmitter {
 
 }
 

--- a/packages/feathers/src/index.ts
+++ b/packages/feathers/src/index.ts
@@ -4,7 +4,7 @@ import version from './version';
 import { Feathers } from './application';
 import { Application } from './declarations';
 
-export function feathers<T = {}, S = {}> () {
+export function feathers<T = any, S = any> () {
   return new Feathers<T, S>() as Application<T, S>;
 }
 

--- a/packages/socketio/src/index.ts
+++ b/packages/socketio/src/index.ts
@@ -9,7 +9,7 @@ import { disconnect, params, authentication, FeathersSocket } from './middleware
 const debug = Debug('@feathersjs/socketio');
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  interface Application<ServiceTypes = {}, AppSettings = {}> { // eslint-disable-line
+  interface Application<ServiceTypes, AppSettings> { // eslint-disable-line
     io: Server;
     listen (options: any): Promise<http.Server>;
   }

--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -18,7 +18,7 @@ declare module '@feathersjs/feathers/lib/declarations' {
     registerPublisher (event: Event, publisher: Publisher<ServiceGenericType<S>>): this;
   }
 
-  interface Application<ServiceTypes = {}, AppSettings = {}> {
+  interface Application<ServiceTypes, AppSettings> { // eslint-disable-line
     channels: string[];
 
     channel (name: string[]): Channel;

--- a/packages/transport-commons/src/routing/index.ts
+++ b/packages/transport-commons/src/routing/index.ts
@@ -7,7 +7,7 @@ declare module '@feathersjs/feathers/lib/declarations' {
     params: { [key: string]: string }
   }
 
-  interface Application<ServiceTypes = {}, AppSettings = {}> { // eslint-disable-line
+  interface Application<ServiceTypes, AppSettings> {  // eslint-disable-line
     routes: Router<any>;
     lookup (path: string): RouteLookup;
   }


### PR DESCRIPTION
In #1364 `ServiceTypes` default changed from `any` to `{}` with an intention to make `app.service()` act more strict when `ServiceTypes` is provided. Desired outcome and expected type resolution (specified in second comment from that PR) were right, but the solution had a flaw.

When you make `ServiceTypes` default to `{}`, `Application` without parameters (like in [`HookContext`](https://github.com/feathersjs/feathers/blob/13b3dbdf8133bce2833a56bfbd0f0799b0420a8a/packages/feathers/index.d.ts#L59)) becomes `Application< {} >`. And you can't assign `Application< {} >` to `Application< MyServiceTypes >`:

```ts
const app: Application< MyServiceTypes > = context.app; // error
const app: Application< MyServiceTypes > = context.app as Application< any >; // works
```

As shown `Application< any >` does not have such drawback.

To achieve desired outcome right solution is to simply remove second catch-all `service()` overload, because when `ServiceTypes` is `any` first definition is already catch-all and when `ServiceTypes` is not `any` then first definition acts as a strict one.

There is a little breaking change (that why it is not a fix, but a feat) since now `{}` stops acting as wildcard and not a default value.