### PR TITLE
Nudge grant version up

### DIFF
--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -45,7 +45,7 @@
     "@feathersjs/feathers": "^4.3.3",
     "debug": "^4.1.1",
     "express-session": "^1.16.2",
-    "grant": "^4.6.2",
+    "grant": "^4.6.3",
     "grant-profile": "^0.0.5",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
Getting this error when updating packages via npm.

Warning "@feathersjs/authentication-oauth > grant-profile@0.0.5" has incorrect peer dependency "grant@>=4.6.3".

Seems grant-profile is set to depend on grant 4.6.3 or higher where as we are using 4.6.2
Pretty straight forward update.
Might be some other changes to take note of [here](https://github.com/simov/grant/blob/master/CHANGELOG.md#v463-20190907).