### PR TITLE
fix: Typing updates

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -1,5 +1,5 @@
 import { NotAuthenticated, FeathersError } from '@feathersjs/errors';
-import { Application } from '@feathersjs/feathers';
+import { Application, Params } from '@feathersjs/feathers';
 import { AuthenticationRequest, AuthenticationResult } from '@feathersjs/authentication';
 import { Storage, StorageWrapper } from './storage';
 
@@ -149,12 +149,12 @@ export class AuthenticationClient {
     return authPromise;
   }
 
-  authenticate (authentication: AuthenticationRequest): Promise<AuthenticationResult> {
+  authenticate (authentication: AuthenticationRequest, params?: Params): Promise<AuthenticationResult> {
     if (!authentication) {
       return this.reAuthenticate();
     }
 
-    const promise = this.service.create(authentication)
+    const promise = this.service.create(authentication, params)
       .then((authResult: AuthenticationResult) => {
         const { accessToken } = authResult;
 

--- a/packages/primus/index.d.ts
+++ b/packages/primus/index.d.ts
@@ -6,7 +6,6 @@ declare const configurePrimus: FeathersPrimus;
 export = configurePrimus;
 
 interface FeathersPrimus {
-  (options: any, callback?: (primus: any) => void): () => void;
-  readonly SOCKET_KEY: unique symbol;
+  (options?: any, callback?: (primus: any) => void): (app: any) => void;
   default: FeathersPrimus;
 }

--- a/packages/socketio/index.d.ts
+++ b/packages/socketio/index.d.ts
@@ -5,8 +5,8 @@ declare const socketio: FeathersSocketIO;
 export = socketio;
 
 interface FeathersSocketIO {
-  (callback?: (io: io.Server) => void): () => void;
-  (options: number | io.ServerOptions, callback?: (io: io.Server) => void): () => void;
-  (port: number, options?: io.ServerOptions, callback?: (io: io.Server) => void): () => void;
+  (callback?: (io: io.Server) => void): (app: any) => void;
+  (options: number | io.ServerOptions, callback?: (io: io.Server) => void): (app: any) => void;
+  (port: number, options?: io.ServerOptions, callback?: (io: io.Server) => void): (app: any) => void;
   default: FeathersSocketIO;
 }


### PR DESCRIPTION
- `authentication-client`: `params` as a second optional argument for `authenticate`. Useful when you implement custom auth strategies.

- `primus`: does not have `SOCKET_KEY` anymore and the options argument is [optional](https://github.com/primus/primus/blob/c3d1d13963695002d6ced1ff2b7d8fda9d1ead5b/index.js#L32).

- `socketio` and `primus`: return configure functions that take an app as an argument.

This commit have description. If you prefer to have multiple one-line pull requests instead of such combo ones, let me know.