### PR TITLE
fix: Reset version number after every publish

### DIFF
--- a/packages/feathers/lib/version.js
+++ b/packages/feathers/lib/version.js
@@ -1,1 +1,1 @@
-module.exports = '4.3.3';
+module.exports = 'development';

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -29,8 +29,10 @@
   },
   "scripts": {
     "test": "mocha --opts ../../mocha.opts",
-    "update-version": "node -e \"console.log('module.exports = \\'' + require('./package.json').version + '\\';')\" > lib/version.js",
-    "version": "npm run update-version"
+    "write-version": "node -e \"console.log('module.exports = \\'' + require('./package.json').version + '\\';')\" > lib/version.js",
+    "reset-version": "node -e \"console.log('module.exports = \\'development\\';')\" > lib/version.js",
+    "version": "npm run write-version",
+    "publish": "npm run reset-version"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
This pull request makes sure that Lerna detects dependency updates properly by resetting the `app.version` in `@feathersjs/feathers` after publishing. Otherwise every version update will also cause a version bump in every package that depends on `@feathersjs/feathers` (which is pretty much all of them) and that's not really how semantic versioning should work.