### PR TITLE
fix: Improve authentication client default storage initialization

### DIFF
--- a/packages/authentication-client/src/index.ts
+++ b/packages/authentication-client/src/index.ts
@@ -15,12 +15,19 @@ declare module '@feathersjs/feathers' {
   }
 }
 
+export const getDefaultStorage = () => {
+  try {
+    return new StorageWrapper(window.localStorage);
+  } catch (error) {}
+
+  return new MemoryStorage();
+};
+
 export { AuthenticationClient, AuthenticationClientOptions, Storage, MemoryStorage, hooks };
 
 export type ClientConstructor = new (app: Application, options: AuthenticationClientOptions) => AuthenticationClient;
 
-export const defaultStorage: Storage = typeof window !== 'undefined' ?
-  new StorageWrapper(window.localStorage) : new MemoryStorage();
+export const defaultStorage: Storage = getDefaultStorage();
 
 export const defaults: AuthenticationClientOptions = {
   header: 'Authorization',


### PR DESCRIPTION
In some cases browsers (like Brave when all cookies are blocked) throw an error when accessing `window.localStorage`. This pull request improves the initialization to return a fallback memory storage on any localStorage initialization error.

Closes #1344