### PR TITLE
fix: Remove adapter commons type alternatives

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -26,7 +26,7 @@ export interface ServiceOptions {
 }
 
 export interface InternalServiceMethods<T = any> {
-    _find (params?: Params): Promise<T[] | Paginated<T>>;
+    _find (params?: Params): Promise<T | T[] | Paginated<T>>;
     _get (id: Id, params?: Params): Promise<T>;
     _create (data: Partial<T> | Array<Partial<T>>, params?: Params): Promise<T | T[]>;
     _update (id: Id, data: T, params?: Params): Promise<T>;

--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -94,9 +94,6 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_get', id, params);
   }
 
-  create (data: Partial<T>, params?: Params): Promise<T>;
-  create (data: Array<Partial<T>>, params?: Params): Promise<T[]>;
-  create (data: Partial<T> | Array<Partial<T>>, params?: Params): Promise<T | T[]>;
   create (data: Partial<T> | Array<Partial<T>>, params?: Params): Promise<T | T[]> {
     if (Array.isArray(data) && !this.allowsMulti('create')) {
       return Promise.reject(new MethodNotAllowed(`Can not create multiple entries`));
@@ -115,9 +112,6 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_update', id, data, params);
   }
 
-  patch (id: Id, data: Partial<T>, params?: Params): Promise<T>;
-  patch (id: null, data: Partial<T>, params?: Params): Promise<T[]>;
-  patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
   patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('patch')) {
       return Promise.reject(new MethodNotAllowed(`Can not patch multiple entries`));
@@ -126,9 +120,6 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_patch', id, data, params);
   }
 
-  remove (id: Id, params?: Params): Promise<T>;
-  remove (id: null, params?: Params): Promise<T[]>;
-  remove (id: NullableId, params?: Params): Promise<T | T[]>;
   remove (id: NullableId, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('remove')) {
       return Promise.reject(new MethodNotAllowed(`Can not remove multiple entries`));


### PR DESCRIPTION
Changes back some things from #1567 since it broke type compatibility in existing applications (like the feathers-chat and generated application).