### PR TITLE
fix: Small type improvements

### DIFF
--- a/packages/authentication/src/core.ts
+++ b/packages/authentication/src/core.ts
@@ -143,11 +143,9 @@ export class AuthenticationBase {
 
   /**
    * Get the registered authentication strategies for a list of names.
-   * The return value may contain `undefined` if the strategy does not exist.
    * @param names The list or strategy names
    */
   getStrategies (...names: string[]) {
-    // Returns all strategies for a list of names (including undefined)
     return names.map(name => this.strategies[name])
       .filter(current => !!current);
   }
@@ -209,7 +207,7 @@ export class AuthenticationBase {
    * @param allowed A list of allowed strategy names
    */
   async authenticate (authentication: AuthenticationRequest, params: Params, ...allowed: string[]) {
-    const { strategy } = authentication || ({} as AuthenticationRequest);
+    const { strategy } = authentication || {};
     const [ authStrategy ] = this.getStrategies(strategy);
     const strategyAllowed = allowed.includes(strategy);
 
@@ -246,7 +244,7 @@ export class AuthenticationBase {
    */
   async parse (req: IncomingMessage, res: ServerResponse, ...names: string[]) {
     const strategies = this.getStrategies(...names)
-      .filter(current => current && typeof current.parse === 'function');
+      .filter(current => typeof current.parse === 'function');
 
     debug('Strategies parsing HTTP header for authentication information', names);
 

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -8,7 +8,8 @@ export {
   AuthenticationBase,
   AuthenticationRequest,
   AuthenticationResult,
-  AuthenticationStrategy
+  AuthenticationStrategy,
+  ConnectionEvent
 } from './core';
 export { AuthenticationBaseStrategy } from './strategy';
 export { AuthenticationService } from './service';

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -38,7 +38,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
       debug('Adding authentication information to connection');
       const { exp } = await this.authentication.verifyAccessToken(accessToken);
       // The time (in ms) until the token expires
-      const duration = (exp * 1000) - new Date().getTime();
+      const duration = (exp * 1000) - Date.now();
       // This may have to be a `logout` event but right now we don't want
       // the whole context object lingering around until the timer is gone
       const timer = lt.setTimeout(() => this.app.emit('disconnect', connection), duration);
@@ -115,12 +115,12 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
         payload
       }
     };
-    const entityId = await this.getEntityId(result, params);
 
     if (entity === null) {
       return result;
     }
 
+    const entityId = await this.getEntityId(result, params);
     const value = await this.getEntity(entityId, params);
 
     return {

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -1,5 +1,5 @@
 import Debug from 'debug';
-import { merge, get } from 'lodash';
+import { merge } from 'lodash';
 import { NotAuthenticated } from '@feathersjs/errors';
 import { AuthenticationBase, AuthenticationResult, AuthenticationRequest } from './core';
 import { connection, event } from './hooks';
@@ -19,7 +19,13 @@ declare module '@feathersjs/feathers' {
      */
     defaultAuthentication (location?: string): AuthenticationService;
   }
+
+  interface Params {
+    authenticated?: boolean;
+  }
 }
+
+export interface AuthenticationService extends ServiceAddons<AuthenticationResult> {}
 
 export class AuthenticationService extends AuthenticationBase implements Partial<ServiceMethods<AuthenticationResult>> {
   constructor (app: Application, configKey: string = 'authentication', options = {}) {
@@ -58,12 +64,12 @@ export class AuthenticationService extends AuthenticationBase implements Partial
   async getTokenOptions (authResult: AuthenticationResult, params: Params) {
     const { service, entity, entityId } = this.configuration;
     const jwtOptions = merge({}, params.jwtOptions, params.jwt);
-    const hasEntity = service && entity && authResult[entity];
+    const value = service && entity && authResult[entity];
 
     // Set the subject to the entity id if it is available
-    if (hasEntity && !jwtOptions.subject) {
+    if (value && !jwtOptions.subject) {
       const idProperty = entityId || this.app.service(service).id;
-      const subject = get(authResult, [ entity, idProperty ]);
+      const subject = value[idProperty];
 
       if (subject === undefined) {
         throw new NotAuthenticated(`Can not set subject from ${entity}.${idProperty}`);
@@ -131,7 +137,7 @@ export class AuthenticationService extends AuthenticationBase implements Partial
   /**
    * Validates the service configuration.
    */
-  setup (this: AuthenticationService & ServiceAddons<AuthenticationResult>) {
+  setup () {
     // The setup method checks for valid settings and registers the
     // connection and event (login, logout) hooks
     const { secret, service, entity, entityId } = this.configuration;

--- a/packages/errors/index.d.ts
+++ b/packages/errors/index.d.ts
@@ -98,6 +98,22 @@ export interface Errors {
   NotImplemented: NotImplemented;
   BadGateway: BadGateway;
   Unavailable: Unavailable;
+  400: BadRequest;
+  401: NotAuthenticated;
+  402: PaymentError;
+  403: Forbidden;
+  404: NotFound;
+  405: MethodNotAllowed;
+  406: NotAcceptable;
+  408: Timeout;
+  409: Conflict;
+  411: LengthRequired;
+  422: Unprocessable;
+  429: TooManyRequests;
+  500: GeneralError;
+  501: NotImplemented;
+  502: BadGateway;
+  503: Unavailable;
 }
 
 export function convert (error: any): FeathersError;

--- a/packages/express/index.d.ts
+++ b/packages/express/index.d.ts
@@ -16,6 +16,7 @@ interface FeathersExpress extends Express {
     rest: {
         (handler?: express.RequestHandler): () => void;
         formatter: express.RequestHandler;
+        httpMethod: (verb: string, uris?: string | string[]) => <T>(method: T) => T;
     };
 
     original: Express;
@@ -38,6 +39,9 @@ declare namespace feathersExpress {
 }
 
 declare module 'express-serve-static-core' {
+    interface Application extends FeathersApplication<any> {
+    }
+
     interface Request {
         feathers?: Partial<FeathersParams>;
     }

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -181,6 +181,7 @@ declare namespace createApplication {
     interface ServiceAddons<T> extends EventEmitter {
         id?: any;
         _serviceEvents: string[];
+        methods: {[method: string]: string[]};
         hooks (hooks: Partial<HooksObject>): this;
     }
 


### PR DESCRIPTION
- `getStrategies` in `AuthenticationBase` does not return `undefined` values.
- export `ConnectionEvent` in `@feathersjs/authentication`.
- `Date.now()` instead of `new Date().getTime()`.
- Add `authenticated` to `Params` definition.
- Do not use `_.get` where simply getting property works.
- Type numbered errors in `@feathersjs/errors`.
- Continuing #1609, extend express application type with feathers application.
- Reverting one change in #1605, add `AuthenticationService extends ServiceAddons<AuthenticationResult>` to use `.hooks` and `.publish` on a service instance.
- Type `methods` in a service.
- Type `httpMethod` for express rest.