### PR TITLE
fix: Add jsonwebtoken TypeScript type dependency

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -42,6 +42,7 @@
     "@feathersjs/errors": "^4.3.7",
     "@feathersjs/feathers": "^4.3.7",
     "@feathersjs/transport-commons": "^4.3.7",
+    "@types/jsonwebtoken": "8.3.4",
     "debug": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
@@ -50,7 +51,6 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "@types/jsonwebtoken": "^8.3.4",
     "@types/lodash": "^4.14.144",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.12",


### PR DESCRIPTION
### Summary

This fixes the following error that occurs when compiling a TypeScript project that uses `@feathersjs/authentication`.

> node_modules/@feathersjs/authentication/lib/core.d.ts:2:52 - error TS7016: Could not find a declaration file for module 'jsonwebtoken'. 'node_modules/jsonwebtoken/index.js' implicitly has an 'any' type.
>   Try `npm install @types/jsonwebtoken` if it exists or add a new declaration (.d.ts) file containing `declare module 'jsonwebtoken';`
> 
> 2 import { SignOptions, Secret, VerifyOptions } from 'jsonwebtoken';

Since `@feathersjs/authentication` includes exports from `jsonwebtoken` in `core.d.ts`, it should include `@types/jsonwebtoken` in its `dependencies` rather than its `devDependencies`. Otherwise, users must install `@types/jsonwebtoken` manually, which is a poor user experience.
