### PR TITLE
fix: Only initialize default Express session if oAuth is actually used

### DIFF
--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import { express as grantExpress } from 'grant';
 import Debug from 'debug';
+import session from 'express-session';
 import { Application } from '@feathersjs/feathers';
 import { AuthenticationResult } from '@feathersjs/authentication';
 import qs from 'querystring';
@@ -26,10 +27,15 @@ export default (options: OauthSetupSettings) => {
     }
 
     const { path } = config.defaults;
+    const expressSession = options.expressSession || session({
+      secret: Math.random().toString(36).substring(7),
+      saveUninitialized: true,
+      resave: true
+    });
     const grantApp = grant(config);
     const authApp = express();
 
-    authApp.use(options.expressSession);
+    authApp.use(expressSession);
 
     authApp.get('/:name', (req, res) => {
       const { feathers_token, ...query } = req.query;

--- a/packages/authentication-oauth/src/utils.ts
+++ b/packages/authentication-oauth/src/utils.ts
@@ -1,21 +1,15 @@
 import { RequestHandler } from 'express';
-import session from 'express-session';
 import { Application } from '@feathersjs/feathers';
 
 export interface OauthSetupSettings {
   authService?: string;
+  expressSession?: RequestHandler;
   linkStrategy: string;
-  expressSession: RequestHandler;
 }
 
 export const getDefaultSettings = (_app: Application, other?: Partial<OauthSetupSettings>) => {
   const defaults: OauthSetupSettings = {
     linkStrategy: 'jwt',
-    expressSession: session({
-      secret: Math.random().toString(36).substring(7),
-      saveUninitialized: true,
-      resave: true
-    }),
     ...other
   };
 


### PR DESCRIPTION
Apparently `express-session` always throws a warning in production when it is initialized even if the middleware is not used. This PR makes initialization on-demand.

Closes #1646