### PR TITLE
fix(authentication): Retain object references in authenticate hook

### DIFF
--- a/packages/authentication/src/hooks/authenticate.ts
+++ b/packages/authentication/src/hooks/authenticate.ts
@@ -1,4 +1,4 @@
-import { flatten, omit, merge } from 'lodash';
+import { flatten, omit } from 'lodash';
 import { HookContext } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
 import Debug from 'debug';
@@ -51,7 +51,7 @@ export default (originalSettings: string | AuthenticateHookSettings, ...original
 
       const authResult = await authService.authenticate(authentication, authParams, ...strategies);
 
-      context.params = merge({}, params, omit(authResult, 'accessToken'), { authenticated: true });
+      context.params = Object.assign({}, params, omit(authResult, 'accessToken'), { authenticated: true });
 
       return context;
     } else if (provider) {

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -112,6 +112,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
       accessToken,
       authentication: {
         strategy: 'jwt',
+        accessToken,
         payload
       }
     };

--- a/packages/authentication/test/hooks/authenticate.test.ts
+++ b/packages/authentication/test/hooks/authenticate.test.ts
@@ -112,6 +112,29 @@ describe('authentication/hooks/authenticate', () => {
     assert.deepStrictEqual(result, Object.assign({}, params, Strategy1.result));
   });
 
+  it('authenticates with first strategy, keeps references alive (#1629)', async () => {
+    const connection = {};
+    const params = {
+      connection,
+      authentication: {
+        strategy: 'first',
+        username: 'David'
+      }
+    };
+
+    app.service('users').hooks({
+      after: {
+        get: context => {
+          context.result.params = context.params;
+        }
+      }
+    });
+
+    const result = await app.service('users').get(1, params);
+
+    assert.ok(result.params.connection === connection);
+  });
+
   it('authenticates with different authentication service', async () => {
     const params = {
       authentication: {


### PR DESCRIPTION
Lodash `_.merge` makes a copy of objects including the `connection` which breaks the reference to the required object. To fix this problem, we still create a copy of `params` (so the original version does not get modified) but use the shallow `Object.assign`.

Closes #1629
Closes #1641 
Closes #1671