### PR TITLE
fix(core): Improve hook missing parameter message by adding the service name

### DIFF
--- a/packages/feathers/lib/hooks/base.js
+++ b/packages/feathers/lib/hooks/base.js
@@ -16,15 +16,15 @@ const assignArguments = context => {
 };
 
 const validate = context => {
-  const { service, method } = context;
+  const { service, method, path } = context;
   const parameters = service.methods[method];
 
   if (parameters.includes('id') && context.id === undefined) {
-    throw new Error(`An id must be provided to the '${method}' method`);
+    throw new Error(`An id must be provided to the '${path}.${method}' method`);
   }
 
   if (parameters.includes('data') && !_.isObjectOrArray(context.data)) {
-    throw new Error(`A data object must be provided to the '${method}' method`);
+    throw new Error(`A data object must be provided to the '${path}.${method}' method`);
   }
 
   return context;

--- a/packages/feathers/test/hooks/hooks.test.js
+++ b/packages/feathers/test/hooks/hooks.test.js
@@ -18,11 +18,11 @@ describe('hooks basics', () => {
 
       return app.service('dummy').get();
     }).catch(e => {
-      assert.strictEqual(e.message, `An id must be provided to the 'get' method`);
+      assert.strictEqual(e.message, `An id must be provided to the 'dummy.get' method`);
     }).then(() =>
       app.service('dummy').create()
     ).catch(e => {
-      assert.strictEqual(e.message, `A data object must be provided to the 'create' method`);
+      assert.strictEqual(e.message, `A data object must be provided to the 'dummy.create' method`);
     });
   });
 
@@ -201,7 +201,7 @@ describe('hooks basics', () => {
         assert.strictEqual(context.service, app.service('dummy'));
         assert.strictEqual(context.type, 'error');
         assert.strictEqual(context.path, 'dummy');
-        assert.strictEqual(context.error.message, 'An id must be provided to the \'get\' method');
+        assert.strictEqual(context.error.message, 'An id must be provided to the \'dummy.get\' method');
       });
     });
 

--- a/packages/rest-client/test/index.test.js
+++ b/packages/rest-client/test/index.test.js
@@ -79,19 +79,19 @@ describe('REST client tests', function () {
     const service = app.service('todos');
 
     return service.get().catch(error => {
-      assert.strictEqual(error.message, `An id must be provided to the 'get' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'todos.get' method`);
 
       return service.remove();
     }).catch(error => {
-      assert.strictEqual(error.message, `An id must be provided to the 'remove' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'todos.remove' method`);
 
       return service.update();
     }).catch(error => {
-      assert.strictEqual(error.message, `An id must be provided to the 'update' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'todos.update' method`);
 
       return service.patch();
     }).catch(error => {
-      assert.strictEqual(error.message, `An id must be provided to the 'patch' method`);
+      assert.strictEqual(error.message, `An id must be provided to the 'todos.patch' method`);
     });
   });
 });


### PR DESCRIPTION
Otherwise it's pretty difficult to figure out where it happened. Still not ideal but will be improved further with the new hook system.