### PR TITLE
feat(authentication): Add parseStrategies

### DIFF
--- a/packages/authentication-local/test/fixture.js
+++ b/packages/authentication-local/test/fixture.js
@@ -13,6 +13,7 @@ module.exports = (app = feathers()) => {
     service: 'users',
     secret: 'supersecret',
     authStrategies: [ 'local', 'jwt' ],
+    parseStrategies: [ 'jwt' ],
     local: {
       usernameField: 'email',
       passwordField: 'password'

--- a/packages/express/lib/authentication.js
+++ b/packages/express/lib/authentication.js
@@ -15,10 +15,11 @@ exports.parseAuthentication = (settings = {}) => {
       return next();
     }
 
-    const { authStrategies = [] } = service.configuration;
+    const config = service.configuration;
+    const authStrategies = config.parseStrategies || config.authStrategies || [];
 
     if (authStrategies.length === 0) {
-      debug('No `authStrategies` found in authentication configuration');
+      debug('No `authStrategies` or `parseStrategies` found in authentication configuration');
       return next();
     }
 

--- a/packages/express/test/authentication.test.js
+++ b/packages/express/test/authentication.test.js
@@ -116,9 +116,10 @@ describe('@feathersjs/express/authentication', () => {
       });
     });
 
-    it('errors when there are no authStrategies', () => {
+    it('errors when there are no authStrategies and parseStrategies', () => {
       const { accessToken } = authResult;
       app.get('authentication').authStrategies = [];
+      delete app.get('authentication').parseStrategies;
 
       return axios.get('/dummy/dave', {
         headers: {

--- a/packages/socketio/lib/middleware.js
+++ b/packages/socketio/lib/middleware.js
@@ -23,7 +23,8 @@ exports.authentication = (app, getParams, settings = {}) => (socket, next) => {
     return next();
   }
 
-  const { authStrategies = [] } = service.configuration;
+  const config = service.configuration;
+  const authStrategies = config.parseStrategies || config.authStrategies || [];
 
   if (authStrategies.length === 0) {
     return next();


### PR DESCRIPTION
To allow separate strategies for creating JWTs and parsing headers. Not every strategy should be allowed to create JWTs (e.g. API keys) and is only used for parsing HTTP requests. This adds a separate configuration value that allows that. The flow will also be clarified in the docs.