### PR TITLE
chore: Fix Node engines version to current LTS (10)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -22,7 +22,6 @@
     "**/yarn.lock",
     "**/test/**",
     "lerna.json",
-    "readme.md",
-    "package.json"
+    "readme.md"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "install": "lerna bootstrap",

--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "main": "lib/",
   "types": "lib/",

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "main": "lib/index.js",
   "scripts": {

--- a/packages/authentication-client/package.json
+++ b/packages/authentication-client/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "prepublish": "npm run compile",

--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "prepublish": "npm run compile",

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "start": "ts-node test/app",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "prepublish": "npm run compile",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,7 +21,7 @@
   ],
   "author": "Feathers contributors",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "main": "lib/",
   "types": "lib/",

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "prepublish": "npm run compile",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -24,7 +24,7 @@
 		"url": "https://github.com/feathersjs/feathers/issues"
 	},
 	"engines": {
-		"node": ">= 12"
+		"node": ">= 10"
 	},
 	"directories": {
 		"lib": "lib"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "test": "mocha --opts ../../mocha.opts"

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -39,7 +39,7 @@
     "publish": "npm run reset-version"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/primus/package.json
+++ b/packages/primus/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "test": "mocha --opts ../../mocha.opts"

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "test": "mocha --opts ../../mocha.opts"

--- a/packages/socketio-client/package.json
+++ b/packages/socketio-client/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "test": "mocha --opts ../../mocha.opts"

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "test": "mocha --opts ../../mocha.opts"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "prepublish": "npm run compile",

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/feathersjs/feathers/issues"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 10"
   },
   "scripts": {
     "prepublish": "npm run compile",


### PR DESCRIPTION
Made a mistake in setting `engines` to 12 but it should be 10 which is the current LTS.