### PR TITLE
Return type narrowing for service multi CRUD.

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -94,6 +94,10 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_get', id, params);
   }
 
+  create (data: Partial<T>, params?: Params): Promise<T>;
+
+  create (data: Array<Partial<T>>, params?: Params): Promise<T[]>;
+
   create (data: Partial<T> | Array<Partial<T>>, params?: Params): Promise<T | T[]> {
     if (Array.isArray(data) && !this.allowsMulti('create')) {
       return Promise.reject(new MethodNotAllowed(`Can not create multiple entries`));
@@ -112,6 +116,10 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_update', id, data, params);
   }
 
+  patch (id: Id, data: Partial<T>, params?: Params): Promise<T>;
+
+  patch (id: null, data: Partial<T>, params?: Params): Promise<T[]>;
+
   patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('patch')) {
       return Promise.reject(new MethodNotAllowed(`Can not patch multiple entries`));
@@ -119,6 +127,10 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
 
     return callMethod(this, '_patch', id, data, params);
   }
+
+  remove (id: Id, params?: Params): Promise<T>;
+
+  remove (id: null, params?: Params): Promise<T[]>;
 
   remove (id: NullableId, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('remove')) {

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -147,13 +147,19 @@ declare namespace createApplication {
 
         get (id: Id, params?: Params): Promise<T>;
 
-        create (data: Partial<T> | Array<Partial<T>>, params?: Params): Promise<T | T[]>;
+        create (data: Partial<T>, params?: Params): Promise<T>;
+
+        create (data: Array<Partial<T>>, params?: Params): Promise<T[]>;
 
         update (id: NullableId, data: T, params?: Params): Promise<T | T[]>;
 
-        patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
+        patch (id: Id, data: Partial<T>, params?: Params): Promise<T>;
 
-        remove (id: NullableId, params?: Params): Promise<T | T[]>;
+        patch (id: null, data: Partial<T>, params?: Params): Promise<T[]>;
+
+        remove (id: Id, params?: Params): Promise<T>;
+
+        remove (id: null, params?: Params): Promise<T[]>;
     }
 
     interface SetupMethod {

--- a/packages/transport-commons/test/socket/index.test.ts
+++ b/packages/transport-commons/test/socket/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { EventEmitter } from 'events';
-import feathers, { Application } from '@feathersjs/feathers';
+import feathers, { Application, Params } from '@feathersjs/feathers';
 
 import { socket as commons, SocketOptions } from '../../src/socket';
 
@@ -29,7 +29,7 @@ describe('@feathersjs/transport-commons', () => {
           return Promise.resolve({ id, params });
         },
 
-        create (data, params) {
+        create (data: any, params: Params) {
           return Promise.resolve(Object.assign({ params }, data));
         }
       });


### PR DESCRIPTION
This PR narrow the return type of service `multi` `create`, `patch` and `remove` methods.

Consider the following database service:

```ts
type Message = { text: string }

// Return type: Promise<Message>
service.create({ text: 'msg' });
// Return type: Promise<Message[]>
service.create([{ text: 'msg' }]);

// Return type: Promise<Message>
service.update(1, { text: 'msg' });
// Typing error remains (Database adapter does not support multi update)
service.update(null, { text: 'msg' });

// Return type: Promise<Message>
service.patch(1, { text: 'msg' });
// Return type: Promise<Message[]>
service.patch(null, { text: 'msg' });
```