### PR TITLE
feat: Add `exposed` property to hook context

### DIFF
--- a/packages/express/test/rest.test.ts
+++ b/packages/express/test/rest.test.ts
@@ -159,6 +159,7 @@ describe('@feathersjs/express/rest provider', () => {
           method: 'get',
           path: 'hook',
           event: null,
+          exposed: true,
           result: { description: 'You have to do dishes' },
           addedProperty: true
         });
@@ -245,6 +246,7 @@ describe('@feathersjs/express/rest provider', () => {
               event: null,
               method: 'get',
               path: 'hook-error',
+              exposed: true,
               original: data.hook.original
             },
             error: { message: 'I blew up' }

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -270,6 +270,11 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
    */
   readonly arguments: any[];
   /**
+   * A read only property that says if the method call will return full
+   * context object or only the result.
+   */
+  readonly exposed: boolean;
+  /**
    * A writeable property containing the data of a create, update and patch service
    * method call.
    */

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -22,7 +22,10 @@ export function createContext (service: Service<any>, method: string, data: Hook
     throw new Error(`Can not create context for method ${method}`);
   }
 
-  return createContext(data) as HookContext;
+  const context = createContext(data);
+  context.exposed = true;
+
+  return context as HookContext;
 }
 
 export class FeathersHookManager<A> extends HookManager {
@@ -74,7 +77,8 @@ export function hookMixin<A> (
         method,
         service,
         event: null,
-        type: null
+        type: null,
+        exposed: false
       });
 
     return res;

--- a/packages/feathers/test/hooks/hooks.test.ts
+++ b/packages/feathers/test/hooks/hooks.test.ts
@@ -146,7 +146,7 @@ describe('hooks basics', () => {
     assert.deepStrictEqual(data, { id: 10, user: 'David', after: true });
   });
 
-  it('has context.app, context.service and context.path', async () => {
+  it('has app, service, path, method, type and exposed', async () => {
     const app = feathers().use('/dummy', {
       async get (id: any) {
         return { id };
@@ -160,6 +160,9 @@ describe('hooks basics', () => {
         assert.strictEqual(context.service, service);
         assert.strictEqual(context.app, app);
         assert.strictEqual(context.path, 'dummy');
+        assert.strictEqual(context.method, 'get');
+        assert.strictEqual(context.type, 'before');
+        assert.strictEqual(context.exposed, false);
       }
     });
 
@@ -215,6 +218,7 @@ describe('hooks basics', () => {
       assert.strictEqual(returnedContext.service, app.service('dummy'));
       assert.strictEqual(returnedContext.type, null);
       assert.strictEqual(returnedContext.path, 'dummy');
+      assert.strictEqual(returnedContext.exposed, true);
       assert.deepStrictEqual(returnedContext.result, {
         id: 10,
         params: {}


### PR DESCRIPTION
The idea is that unless a context object is returned from the call hooks that modify context returning properties other than `result` (like `statusCode` and `dispatch` or other custom ones) may be skipped as those properties will not be used outside of hooks of the call itself.

Possible alternative names: `dispatching` or `public`.