### PR TITLE
allow qs options to be passed through

### DIFF
--- a/packages/rest-client/lib/base.js
+++ b/packages/rest-client/lib/base.js
@@ -18,6 +18,7 @@ class Base {
     this.options = settings.options;
     this.connection = settings.connection;
     this.base = `${settings.base}/${this.name}`;
+    this.qsStringifyOptions = this.options.qsStringifyOptions || {};
   }
 
   makeUrl (query, id) {
@@ -33,7 +34,7 @@ class Base {
 
   getQuery (query) {
     if (Object.keys(query).length !== 0) {
-      const queryString = qs.stringify(query);
+      const queryString = qs.stringify(query, this.qsStringifyOptions);
 
       return `?${queryString}`;
     }

--- a/packages/rest-client/lib/base.js
+++ b/packages/rest-client/lib/base.js
@@ -15,7 +15,7 @@ function toError (error) {
 class Base {
   constructor (settings) {
     this.name = stripSlashes(settings.name);
-    this.options = settings.options;
+    this.options = settings.options || {};
     this.connection = settings.connection;
     this.base = `${settings.base}/${this.name}`;
     this.qsStringifyOptions = this.options.qsStringifyOptions || {};


### PR DESCRIPTION
Allows for adding additional options for the qs.stringify method. I came to this as it's currently not possible at least from my trial and error, to be able to override the rest client so that `getQuery` can be extended so I can provide my own `qs` with options.

```js
const feathersClient = feathers()
  .configure(restClient.fetch(fetch, {
    qsStringifyOptions: {
      strictNullHandling: true
    }
  }));
```
