### PR TITLE
Allow fallback value for application.get

### DIFF
--- a/packages/feathers/lib/application.js
+++ b/packages/feathers/lib/application.js
@@ -28,7 +28,10 @@ const application = {
     this.configure(events());
   },
 
-  get (name) {
+  get (name, fallback) {
+    if (!this.settings.hasOwnProperty(name)) {
+      return fallback;
+    }
     return this.settings[name];
   },
 

--- a/packages/feathers/test/application.test.js
+++ b/packages/feathers/test/application.test.js
@@ -235,6 +235,20 @@ describe('Feathers application', () => {
         assert.strictEqual(app.get('foo'), undefined);
       });
 
+      it('should return a fallback value when key unset and fallback given', () => {
+        var app = feathers();
+        assert.strictEqual(app.get('foo', 'bar'), 'bar');
+        assert.strictEqual(app.get('foo'), undefined);
+        assert.strictEqual(app.get('foo', 'baz'), 'baz');
+      });
+
+      it('should not implicitly set a key to fallback value', () => {
+        var app = feathers();
+        assert.strictEqual(app.get('foo', 'bar'), 'bar');
+        assert.strictEqual(app.get('foo'), undefined);
+        assert.strictEqual(app.settings.hasOwnProperty('foo'), false);
+      });
+
       it('should otherwise return the value', () => {
         var app = feathers();
         app.set('foo', 'bar');


### PR DESCRIPTION
### Summary
I've written several similar pieces of code like the following in our app:
``` js
let someValue = app.get('someConfigKey');
if (!someValue) {
  app.set('someConfigKey', someDefaultValue);
  someValue = app.get('someConfigKey');
}
```
these values are sometimes not set during app initialization or depending on specific environments, and there's just ended up being a lot of things that need defaults for sanity.

I would love it if they could be expressed more like python's `.get`:
``` js
const someValue = app.get('someConfigKey', someDefaultValue);
```
I don't think there are any open (or closed) issues related to this, so maybe the pattern is very specific to our own codebase. This PR had no dependencies that I'm aware of.

### Other Information
A possibly controversial piece of this PR (if the basic gist is acceptable/deemed useful) is that `.get` modifies _anything_. In python (the inspiration for this interface), the dictionary being `.get`\`d doesn't get modified by the call. That change would make my frequent-snippet into:
``` js
const someValue = app.get('someConfigKey', someDefaultValue);
app.set('someConfigKey', someValue);
```
which I think is clunkier, but it's at least still shorter and is far more explicit.

Also, not sure whether reaching all the way into `app.settings` in the test to check its properties is considered acceptable. Happy to use a suggested alternative.

Anyway, I wouldn't be heartbroken if this just doesn't seem useful! Just figured I'd toss it at the wall :)

(and if this ends up approved, I will PR feathers-docs to modify them to suit)