### PR TITLE
fix: typo in password

### DIFF
--- a/packages/authentication-local/test/strategy.test.ts
+++ b/packages/authentication-local/test/strategy.test.ts
@@ -151,7 +151,7 @@ describe('@feathersjs/authentication-local/strategy', () => {
 
     assert.ok(accessToken);
     assert.strictEqual(authResult.user.email, email);
-    assert.strictEqual(authResult.user.passsword, undefined);
+    assert.strictEqual(authResult.user.password, undefined);
     assert.ok(authResult.user.fromGet);
 
     const decoded = await authService.verifyAccessToken(accessToken);


### PR DESCRIPTION
### Summary

password was written with 3 s (passsword) which resulted in a test that would always pass regardless of whether the password was removed from the response or not.