### PR TITLE
Allow more specific types to be specified for `create` parameter

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -25,16 +25,16 @@ export interface ServiceOptions {
   filters: string[];
 }
 
-export interface InternalServiceMethods<T = any> {
+export interface InternalServiceMethods<T = any, TCreateReq = Partial<T>> {
     _find (params?: Params): Promise<T | T[] | Paginated<T>>;
     _get (id: Id, params?: Params): Promise<T>;
-    _create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
+    _create (data: TCreateReq | TCreateReq[], params?: Params): Promise<T | T[]>;
     _update (id: Id, data: T, params?: Params): Promise<T>;
     _patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
     _remove (id: NullableId, params?: Params): Promise<T | T[]>;
 }
 
-export class AdapterService<T = any> implements ServiceMethods<T> {
+export class AdapterService<T = any, TCreateReq = Partial<T>> implements ServiceMethods<T, TCreateReq> {
   options: ServiceOptions;
 
   constructor (options: Partial<ServiceOptions>) {
@@ -94,7 +94,7 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_get', id, params);
   }
 
-  create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]> {
+  create (data: TCreateReq | TCreateReq[], params?: Params): Promise<T | T[]> {
     if (Array.isArray(data) && !this.allowsMulti('create')) {
       return Promise.reject(new MethodNotAllowed(`Can not create multiple entries`));
     }

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -136,14 +136,14 @@ declare namespace createApplication {
         finally?: Partial<HookMap<T>> | Hook<T> | Hook<T>[];
     }
 
-    interface ServiceMethods<T> {
+    interface ServiceMethods<T, TCreateReq = Partial<T>> {
         [key: string]: any;
 
         find (params?: Params): Promise<T | T[] | Paginated<T>>;
 
         get (id: Id, params?: Params): Promise<T>;
 
-        create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
+        create (data: TCreateReq | TCreateReq[], params?: Params): Promise<T | T[]>;
 
         update (id: NullableId, data: T, params?: Params): Promise<T | T[]>;
 
@@ -156,10 +156,10 @@ declare namespace createApplication {
         setup (app: Application, path: string): void;
     }
 
-    interface ServiceOverloads<T> {
-        create? (data: Partial<T>, params?: Params): Promise<T>;
+    interface ServiceOverloads<T, TCreateReq = Partial<T>> {
+        create? (data: TCreateReq, params?: Params): Promise<T>;
 
-        create? (data: Partial<T>[], params?: Params): Promise<T[]>;
+        create? (data: TCreateReq[], params?: Params): Promise<T[]>;
 
         update? (id: Id, data: T, params?: Params): Promise<T>;
 
@@ -181,7 +181,7 @@ declare namespace createApplication {
         hooks (hooks: Partial<HooksObject>): this;
     }
 
-    type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T>;
+    type Service<T, TCreateReq = Partial<T>> = ServiceOverloads<T, TCreateReq> & ServiceAddons<T> & ServiceMethods<T, TCreateReq>;
 
     type ServiceMixin = (service: Service<any>, path: string) => void;
 


### PR DESCRIPTION
This PR allow more specific types to be specified for `create` service method.

```ts
interface MessageResponse {
  text: string;
  createdAt: string;
  updatedAt: string;
}

type MessageRequest = Omit<MessageResponse, 'createdAt' | 'updatedAt'>

declare var MyService: Service<MessageResponse, MessageRequest>;
const x = MyService.create({
  // Error: Property 'text' is missing in type '{}'
});
```