### PR TITLE
fix: Improve Service typings for DB Common API

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -94,6 +94,10 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_get', id, params);
   }
 
+  create (data: Partial<T>, params?: Params): Promise<T>;
+
+  create (data: Partial<T>[], params?: Params): Promise<T[]>;
+
   create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]> {
     if (Array.isArray(data) && !this.allowsMulti('create')) {
       return Promise.reject(new MethodNotAllowed(`Can not create multiple entries`));
@@ -112,6 +116,10 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     return callMethod(this, '_update', id, data, params);
   }
 
+  patch (id: Id, data: Partial<T>, params?: Params): Promise<T>;
+
+  patch (id: null, data: Partial<T>, params?: Params): Promise<T[]>;
+
   patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('patch')) {
       return Promise.reject(new MethodNotAllowed(`Can not patch multiple entries`));
@@ -119,6 +127,10 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
 
     return callMethod(this, '_patch', id, data, params);
   }
+
+  remove (id: Id, params?: Params): Promise<T>;
+
+  remove (id: null, params?: Params): Promise<T[]>;
 
   remove (id: NullableId, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('remove')) {


### PR DESCRIPTION
Similar to #1567, improve typings for `create`, `patch`, `remove` overloads for DB Common API.


