### PR TITLE
Add 410 Gone to errors

### DIFF
--- a/packages/errors/lib/index.js
+++ b/packages/errors/lib/index.js
@@ -144,6 +144,13 @@ function Conflict (message, data) {
 
 inheritsFrom(Conflict, FeathersError);
 
+// 410 - Gone
+function Gone (message, data) {
+  FeathersError(this, message, 'Gone', 410, 'gone', data);
+}
+
+inheritsFrom(Gone, FeathersError);
+
 // 411 - Length Required
 function LengthRequired (message, data) {
   FeathersError.call(this, message, 'LengthRequired', 411, 'length-required', data);
@@ -204,6 +211,7 @@ const errors = {
   NotAcceptable,
   Timeout,
   Conflict,
+  Gone,
   LengthRequired,
   Unprocessable,
   TooManyRequests,
@@ -220,6 +228,7 @@ const errors = {
   406: NotAcceptable,
   408: Timeout,
   409: Conflict,
+  410: Gone,
   411: LengthRequired,
   422: Unprocessable,
   429: TooManyRequests,

--- a/packages/errors/test/index.test.js
+++ b/packages/errors/test/index.test.js
@@ -78,6 +78,10 @@ describe('@feathersjs/errors', () => {
       assert.notStrictEqual(typeof errors.Conflict, 'undefined', 'has Conflict');
     });
 
+    it('Gone', () => {
+      assert.notStrictEqual(typeof errors.Gone, 'undefined', 'has Gone');
+    });
+
     it('Length Required', () => {
       assert.notStrictEqual(typeof errors.LengthRequired, 'undefined', 'has LengthRequired');
     });
@@ -140,6 +144,10 @@ describe('@feathersjs/errors', () => {
 
     it('409', () => {
       assert.notStrictEqual(typeof errors[409], 'undefined', 'has Conflict alias');
+    });
+
+    it('410', () => {
+      assert.notStrictEqual(typeof errors[410], 'undefined', 'has Gone alias');
     });
 
     it('411', () => {


### PR DESCRIPTION
### Summary

This adds the 410/Gone message to feathersjs/errors. This one's been in the various RFCs for a long time,  not sure why it's missing.

