### PR TITLE
feat(authentication-oauth): callback for proxying raw request params into authentication service

### DIFF
--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -17,7 +17,7 @@ const debug = Debug('@feathersjs/authentication-oauth/express');
 
 export default (options: OauthSetupSettings) => {
   return (feathersApp: Application) => {
-    const { authService, linkStrategy } = options;
+    const { authService, linkStrategy, serviceParamsCallback } = options;
     const app = feathersApp as ExpressApplication;
     const config = app.get('grant');
 
@@ -61,6 +61,7 @@ export default (options: OauthSetupSettings) => {
       const service = app.defaultAuthentication(authService);
       const [ strategy ] = service.getStrategies(name) as OAuthStrategy[];
       const params = {
+        ...serviceParamsCallback(req),
         authStrategies: [ name ],
         authentication: accessToken ? {
           strategy: linkStrategy,

--- a/packages/authentication-oauth/src/utils.ts
+++ b/packages/authentication-oauth/src/utils.ts
@@ -4,12 +4,14 @@ import { Application } from '@feathersjs/feathers';
 export interface OauthSetupSettings {
   authService?: string;
   expressSession?: RequestHandler;
+  serviceParamsCallback: (req: object) => object,
   linkStrategy: string;
 }
 
 export const getDefaultSettings = (_app: Application, other?: Partial<OauthSetupSettings>) => {
   const defaults: OauthSetupSettings = {
     linkStrategy: 'jwt',
+    serviceParamsCallback: () => ({}),
     ...other
   };
 


### PR DESCRIPTION
**Problem**: I can't get user's IP address on registration and login via OAuth.

This PR was created after this issue: #1833

Also I have related PR to feathersjs/docs#1447

**Case**: I have app with Facebook OAuth login flow (JWT). I need to save users IP addresses when they're registered or logged in and expected to use hooks for authentication service. Middleware for throwing raw request data to Feathers (IP address in this case) is added to `middleware/index.js`, assigning new keys to `req.feathers` object. I can see this data in context.params of all hooks except authentication service hooks (`after: create()`). I noticed that params are limited here and not carrying any of custom params from req.feathers object in [authentication-oauth/src/express.ts](https://github.com/feathersjs/feathers/blob/master/packages/authentication-oauth/src/express.ts#L63)

**Example of use**

middleware:
```js
  app.use((req, res, next) => {
    if (! req.feathers) {
      req.feathers = {};
    }

    req.feathers.ip = req.connection.remoteAddress;
    req.feathers.userAgent = req.headers ['user-agent'];
    next();
  });
```

authentication config:
```js
  app.configure(expressOauth({
    serviceParamsCallback: req => {
      const { ip, userAgent } = req.feathers;

      return { ip, userAgent };
    },
  }));
```