### PR TITLE
fix(authentication-oauth): Allow req.feathers to be used in oAuth authentication requests

### DIFF
--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -61,6 +61,7 @@ export default (options: OauthSetupSettings) => {
       const service = app.defaultAuthentication(authService);
       const [ strategy ] = service.getStrategies(name) as OAuthStrategy[];
       const params = {
+        ...req.feathers,
         authStrategies: [ name ],
         authentication: accessToken ? {
           strategy: linkStrategy,

--- a/packages/authentication-oauth/test/express.test.ts
+++ b/packages/authentication-oauth/test/express.test.ts
@@ -27,6 +27,7 @@ describe('@feathersjs/authentication-oauth/express', () => {
 
     assert.ok(data.accessToken);
     assert.equal(data.user.testId, 'expressTest');
+    assert.equal(data.fromMiddleware, 'testing');
   });
 
   it('oauth/test/authenticate with redirect', async () => {

--- a/packages/authentication-oauth/test/fixture.ts
+++ b/packages/authentication-oauth/test/fixture.ts
@@ -11,8 +11,19 @@ export class TestOAuthStrategy extends OAuthStrategy {
     if (!data.id) {
       throw new Error('Data needs an id');
     }
-
+    
     return data;
+  }
+
+  async authenticate (data: AuthenticationRequest, params: Params) {
+    const { fromMiddleware } = params;
+    const authResult = await super.authenticate(data, params);
+
+    if (fromMiddleware) {
+      authResult.fromMiddleware = fromMiddleware;
+    }
+
+    return authResult;
   }
 }
 
@@ -46,6 +57,10 @@ app.set('authentication', {
   }
 });
 
+app.use((req, _res, next) => {
+  req.feathers = { fromMiddleware: 'testing' };
+  next();
+});
 app.use('/authentication', auth);
 app.use('/users', memory());
 


### PR DESCRIPTION
This pull request allows to use `req.feathers` in oAuth strategies as mentioned in https://github.com/feathersjs/feathers/pull/1869#issuecomment-601221026.

- Closes https://github.com/feathersjs/docs/pull/1447
- Closes https://github.com/feathersjs/feathers/pull/1869