### PR TITLE
Add type keys to service pagination options.

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -20,7 +20,10 @@ export interface ServiceOptions {
   events: string[];
   multi: boolean|string[];
   id: string;
-  paginate: any;
+  paginate: {
+    default?: number;
+    max?: number;
+  }
   whitelist: string[];
   filters: string[];
 }


### PR DESCRIPTION
Just a simple tweak that defines the missing types for the [`pagination`](packages/adapter-commons/src/service.ts#L23) options of [`ServiceOptions`](packages/adapter-commons/src/service.ts#L19). Here I'm assuming that the only supported options are `max` and `default`. 

I was unable to find anything that would indicate that there are additional options. But I assume the available options could be tied to the database adapter in use? If the pagination object should accept any list of customizable options, perhaps we could consider refactoring to something like the following snippet;
```ts
export interface ServiceOptions {
  events: string[];
  multi: boolean|string[];
  id: string;
  paginate: {
    [key: string]: any;
    default?: number;
    max?: number;
  }
  whitelist: string[];
  filters: string[];
}
```

This would keep type-hinting for the two [documented pagination options](https://docs.feathersjs.com/api/databases/common.html#pagination) while allowing for use of additional options.