### PR TITLE
fix(authentication): Remove entity from connection information on logout

### DIFF
--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -55,10 +55,11 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     } else if (event === 'disconnect' || isValidLogout) {
       debug('Removing authentication information and expiration timer from connection');
 
-      Object.keys(connection).forEach(name => {
-        delete connection[name];
-      });
-      
+      const { entity } = this.configuration;
+
+      delete connection[entity];
+      delete connection.authentication;
+
       lt.clearTimeout(this.expirationTimers.get(connection));
       this.expirationTimers.delete(connection);
     }

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -55,7 +55,10 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     } else if (event === 'disconnect' || isValidLogout) {
       debug('Removing authentication information and expiration timer from connection');
 
-      delete connection.authentication;
+      Object.keys(connection).forEach(name => {
+        delete connection[name];
+      });
+      
       lt.clearTimeout(this.expirationTimers.get(connection));
       this.expirationTimers.delete(connection);
     }

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -149,6 +149,7 @@ describe('authentication/jwt', () => {
       });
 
       assert.ok(!connection.authentication);
+      assert.ok(!connection.user);
     });
 
     it('does not remove if accessToken does not match', async () => {

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -108,7 +108,7 @@ describe('authentication/jwt', () => {
       });
     });
 
-    it('sends disconnect event when connection token expires and removes authentication', async () => {
+    it('sends disconnect event when connection token expires and removes all connection information', async () => {
       const connection: any = {};
       const token: string = await app.service('authentication').createAccessToken({}, {
         subject: `${user.id}`,
@@ -129,6 +129,8 @@ describe('authentication/jwt', () => {
       assert.strictEqual(disconnection, connection);
 
       assert.ok(!connection.authentication);
+      assert.ok(!connection.user);
+      assert.strictEqual(Object.keys(connection).length, 0);
     });
 
     it('deletes authentication information on remove', async () => {


### PR DESCRIPTION
This pull request makes sure that all connection information gets removed on logout.

Closes #1883