### PR TITLE
Use stricter type for HookContext 'method' prop

### DIFF
--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -77,7 +77,7 @@ declare namespace createApplication {
          * A read only property with the name of the service method (one of find, get,
          * create, update, patch, remove).
          */
-        readonly method: string;
+        readonly method: 'find' | 'get' | 'create' | 'update' | 'patch' | 'remove';
         /**
          * A writeable property that contains the service method parameters (including
          * params.query).


### PR DESCRIPTION
A simple tweak to the HookContext's `method` property type declaration. This specifies a union type with the possible string types for the `method` property. Essentially allowing for autocompletes by the IDEs that support TypeScript, as well as warnings should you mistype a method name.