### PR TITLE
docs: Fix simple typo, serivce -> service

### DIFF
--- a/packages/express/lib/index.js
+++ b/packages/express/lib/index.js
@@ -51,7 +51,7 @@ function feathersExpress (feathersApp, expressApp = express()) {
       }
 
       debug('Registering service with middleware', middleware);
-      // Since this is a serivce, call Feathers `.use`
+      // Since this is a service, call Feathers `.use`
       feathersApp.use.call(this, location, service, { middleware });
 
       return this;


### PR DESCRIPTION
There is a small typo in packages/express/lib/index.js.

Should read `service` rather than `serivce`.

