### PR TITLE
chore(docs): Add inline docs to service methods

### DIFF
--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -299,6 +299,7 @@ declare namespace createApplication {
          * Retrieve all resources from this service, skipping any service-level hooks.
          *
          * @param params - Service call parameters {@link Params}
+         * @see {@link HookLessServiceMethods}
          * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
          */
         _find (params?: Params): Promise<T | T[] | Paginated<T>>;
@@ -308,6 +309,7 @@ declare namespace createApplication {
          *
          * @param id - ID of the resource to locate
          * @param params - Service call parameters {@link Params}
+         * @see {@link HookLessServiceMethods}
          * @see {@link https://docs.feathersjs.com/api/services.html#get-id-params|Feathers API Documentation: .get(id, params)}
          */
         _get (id: Id, params?: Params): Promise<T>;
@@ -317,6 +319,7 @@ declare namespace createApplication {
          *
          * @param data - Data to insert into this service.
          * @param params - Service call parameters {@link Params}
+         * @see {@link HookLessServiceMethods}
          * @see {@link https://docs.feathersjs.com/api/services.html#create-data-params|Feathers API Documentation: .create(data, params)}
          */
         _create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
@@ -327,6 +330,7 @@ declare namespace createApplication {
          * @param id - ID of the resource to be updated
          * @param data - Data to be put in place of the current resource.
          * @param params - Service call parameters {@link Params}
+         * @see {@link HookLessServiceMethods}
          * @see {@link https://docs.feathersjs.com/api/services.html#update-id-data-params|Feathers API Documentation: .update(id, data, params)}
          */
         _update (id: NullableId, data: T, params?: Params): Promise<T | T[]>;
@@ -337,6 +341,7 @@ declare namespace createApplication {
          * @param id - ID of the resource to be patched
          * @param data - Data to merge with the current resource.
          * @param params - Service call parameters {@link Params}
+         * @see {@link HookLessServiceMethods}
          * @see {@link https://docs.feathersjs.com/api/services.html#patch-id-data-params|Feathers API Documentation: .patch(id, data, params)}
          */
         _patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
@@ -346,6 +351,7 @@ declare namespace createApplication {
          *
          * @param id - ID of the resource to be removed
          * @param params - Service call parameters {@link Params}
+         * @see {@link HookLessServiceMethods}
          * @see {@link https://docs.feathersjs.com/api/services.html#remove-id-params|Feathers API Documentation: .remove(id, params)}
          */
         _remove (id: NullableId, params?: Params): Promise<T | T[]>;

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -282,6 +282,63 @@ declare namespace createApplication {
         remove? (id: null, params?: Params): Promise<T[]>;
     }
 
+    interface HookLessServiceMethods<T> {
+        /**
+         * Retrieve all resources from this service, skipping any service-level hooks.
+         *
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
+         */
+        _find (params?: Params): Promise<T | T[] | Paginated<T>>;
+
+        /**
+         * Retrieve a single resource matching the given ID, skipping any service-level hooks.
+         *
+         * @param id - ID of the resource to locate
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#get-id-params|Feathers API Documentation: .get(id, params)}
+         */
+        _get (id: Id, params?: Params): Promise<T>;
+
+        /**
+         * Create a new resource for this service, skipping any service-level hooks.
+         *
+         * @param data - Data to insert into this service.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#create-data-params|Feathers API Documentation: .create(data, params)}
+         */
+        _create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
+
+        /**
+         * Replace any resources matching the given ID with the given data, skipping any service-level hooks.
+         *
+         * @param id - ID of the resource to be updated
+         * @param data - Data to be put in place of the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#update-id-data-params|Feathers API Documentation: .update(id, data, params)}
+         */
+        _update (id: NullableId, data: T, params?: Params): Promise<T | T[]>;
+
+        /**
+         * Merge any resources matching the given ID with the given data, skipping any service-level hooks.
+         *
+         * @param id - ID of the resource to be patched
+         * @param data - Data to merge with the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#patch-id-data-params|Feathers API Documentation: .patch(id, data, params)}
+         */
+        _patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
+
+        /**
+         * Remove resources matching the given ID from the this service, skipping any service-level hooks.
+         *
+         * @param id - ID of the resource to be removed
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#remove-id-params|Feathers API Documentation: .remove(id, params)}
+         */
+        _remove (id: NullableId, params?: Params): Promise<T | T[]>;
+    }
+
     interface ServiceAddons<T> extends EventEmitter {
         id?: any;
         _serviceEvents: string[];
@@ -289,7 +346,7 @@ declare namespace createApplication {
         hooks (hooks: Partial<HooksObject>): this;
     }
 
-    type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T>;
+    type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T> & HookLessServiceMethods<T>;
 
     type ServiceMixin = (service: Service<any>, path: string) => void;
 

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -31,6 +31,11 @@ declare namespace createApplication {
     type ClientSideParams = Pick<Params, 'query' | 'paginate'>;
     type ServerSideParams = Params;
 
+    /**
+     * Service call parameters
+     *
+     * @see {@link https://docs.feathersjs.com/api/services.html#params}
+     */
     interface Params {
         query?: Query;
         paginate?: false | Pick<PaginationOptions, 'max'>;
@@ -136,41 +141,144 @@ declare namespace createApplication {
         finally?: Partial<HookMap<T>> | Hook<T> | Hook<T>[];
     }
 
-    interface ServiceMethods<T> {
-        [key: string]: any;
-
-        find (params?: Params): Promise<T | T[] | Paginated<T>>;
-
-        get (id: Id, params?: Params): Promise<T>;
-
-        create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
-
-        update (id: NullableId, data: T, params?: Params): Promise<T | T[]>;
-
-        patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
-
-        remove (id: NullableId, params?: Params): Promise<T | T[]>;
-    }
-
     interface SetupMethod {
         setup (app: Application, path: string): void;
     }
 
+    interface ServiceMethods<T> {
+        [key: string]: any;
+
+        /**
+         * Retrieve all resources from this service.
+         *
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
+         */
+        find (params?: Params): Promise<T | T[] | Paginated<T>>;
+
+        /**
+         * Retrieve a single resource matching the given ID.
+         *
+         * @param id - ID of the resource to locate
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#get-id-params|Feathers API Documentation: .get(id, params)}
+         */
+        get (id: Id, params?: Params): Promise<T>;
+
+        /**
+         * Create a new resource for this service.
+         *
+         * @param data - Data to insert into this service.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#create-data-params|Feathers API Documentation: .create(data, params)}
+         */
+        create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
+
+        /**
+         * Replace any resources matching the given ID with the given data.
+         *
+         * @param id - ID of the resource to be updated
+         * @param data - Data to be put in place of the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#update-id-data-params|Feathers API Documentation: .update(id, data, params)}
+         */
+        update (id: NullableId, data: T, params?: Params): Promise<T | T[]>;
+
+        /**
+         * Merge any resources matching the given ID with the given data.
+         *
+         * @param id - ID of the resource to be patched
+         * @param data - Data to merge with the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#patch-id-data-params|Feathers API Documentation: .patch(id, data, params)}
+         */
+        patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
+
+        /**
+         * Remove resources matching the given ID from the this service.
+         *
+         * @param id - ID of the resource to be removed
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#remove-id-params|Feathers API Documentation: .remove(id, params)}
+         */
+        remove (id: NullableId, params?: Params): Promise<T | T[]>;
+    }
+
     interface ServiceOverloads<T> {
+        /**
+         * Create a new resource for this service.
+         *
+         * @param data - Data to insert into this service.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#create-data-params|Feathers API Documentation: .create(data, params)}
+         */
         create? (data: Partial<T>, params?: Params): Promise<T>;
 
+        /**
+         * Create a new resource for this service.
+         *
+         * @param data - Data to insert into this service.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#create-data-params|Feathers API Documentation: .create(data, params)}
+         */
         create? (data: Partial<T>[], params?: Params): Promise<T[]>;
 
+        /**
+         * Replace any resources matching the given ID with the given data.
+         *
+         * @param id - ID of the resource to be updated
+         * @param data - Data to be put in place of the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#update-id-data-params|Feathers API Documentation: .update(id, data, params)}
+         */
         update? (id: Id, data: T, params?: Params): Promise<T>;
 
+        /**
+         * Replace any resources matching the given ID with the given data.
+         *
+         * @param id - ID of the resource to be updated
+         * @param data - Data to be put in place of the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#update-id-data-params|Feathers API Documentation: .update(id, data, params)}
+         */
         update? (id: null, data: T, params?: Params): Promise<T[]>;
 
+        /**
+         * Merge any resources matching the given ID with the given data.
+         *
+         * @param id - ID of the resource to be patched
+         * @param data - Data to merge with the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#patch-id-data-params|Feathers API Documentation: .patch(id, data, params)}
+         */
         patch? (id: Id, data: Partial<T>, params?: Params): Promise<T>;
 
+        /**
+         * Merge any resources matching the given ID with the given data.
+         *
+         * @param id - ID of the resource to be patched
+         * @param data - Data to merge with the current resource.
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#patch-id-data-params|Feathers API Documentation: .patch(id, data, params)}
+         */
         patch? (id: null, data: Partial<T>, params?: Params): Promise<T[]>;
 
+        /**
+         * Remove resources matching the given ID from the this service.
+         *
+         * @param id - ID of the resource to be removed
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#remove-id-params|Feathers API Documentation: .remove(id, params)}
+         */
         remove? (id: Id, params?: Params): Promise<T>;
 
+        /**
+         * Remove resources matching the given ID from the this service.
+         *
+         * @param id - ID of the resource to be removed
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#remove-id-params|Feathers API Documentation: .remove(id, params)}
+         */
         remove? (id: null, params?: Params): Promise<T[]>;
     }
 

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -282,81 +282,6 @@ declare namespace createApplication {
         remove? (id: null, params?: Params): Promise<T[]>;
     }
 
-    /**
-     * Hook-less service methods. Directly call database adapter service methods without
-     * running any service-level hooks. This can be useful if you need the raw data
-     * from the service and don't want to trigger any of its hooks.
-     *
-     * Important: These methods are only available internally on the server, not on the client
-     * side and only for the Feathers database adapters.
-     *
-     * These methods do not trigger events.
-     *
-     * @see {@link https://docs.feathersjs.com/guides/migrating.html#hook-less-service-methods}
-     */
-    interface HookLessServiceMethods<T> {
-        /**
-         * Retrieve all resources from this service, skipping any service-level hooks.
-         *
-         * @param params - Service call parameters {@link Params}
-         * @see {@link HookLessServiceMethods}
-         * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
-         */
-        _find (params?: Params): Promise<T | T[] | Paginated<T>>;
-
-        /**
-         * Retrieve a single resource matching the given ID, skipping any service-level hooks.
-         *
-         * @param id - ID of the resource to locate
-         * @param params - Service call parameters {@link Params}
-         * @see {@link HookLessServiceMethods}
-         * @see {@link https://docs.feathersjs.com/api/services.html#get-id-params|Feathers API Documentation: .get(id, params)}
-         */
-        _get (id: Id, params?: Params): Promise<T>;
-
-        /**
-         * Create a new resource for this service, skipping any service-level hooks.
-         *
-         * @param data - Data to insert into this service.
-         * @param params - Service call parameters {@link Params}
-         * @see {@link HookLessServiceMethods}
-         * @see {@link https://docs.feathersjs.com/api/services.html#create-data-params|Feathers API Documentation: .create(data, params)}
-         */
-        _create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
-
-        /**
-         * Replace any resources matching the given ID with the given data, skipping any service-level hooks.
-         *
-         * @param id - ID of the resource to be updated
-         * @param data - Data to be put in place of the current resource.
-         * @param params - Service call parameters {@link Params}
-         * @see {@link HookLessServiceMethods}
-         * @see {@link https://docs.feathersjs.com/api/services.html#update-id-data-params|Feathers API Documentation: .update(id, data, params)}
-         */
-        _update (id: NullableId, data: T, params?: Params): Promise<T | T[]>;
-
-        /**
-         * Merge any resources matching the given ID with the given data, skipping any service-level hooks.
-         *
-         * @param id - ID of the resource to be patched
-         * @param data - Data to merge with the current resource.
-         * @param params - Service call parameters {@link Params}
-         * @see {@link HookLessServiceMethods}
-         * @see {@link https://docs.feathersjs.com/api/services.html#patch-id-data-params|Feathers API Documentation: .patch(id, data, params)}
-         */
-        _patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
-
-        /**
-         * Remove resources matching the given ID from the this service, skipping any service-level hooks.
-         *
-         * @param id - ID of the resource to be removed
-         * @param params - Service call parameters {@link Params}
-         * @see {@link HookLessServiceMethods}
-         * @see {@link https://docs.feathersjs.com/api/services.html#remove-id-params|Feathers API Documentation: .remove(id, params)}
-         */
-        _remove (id: NullableId, params?: Params): Promise<T | T[]>;
-    }
-
     interface ServiceAddons<T> extends EventEmitter {
         id?: any;
         _serviceEvents: string[];
@@ -364,7 +289,7 @@ declare namespace createApplication {
         hooks (hooks: Partial<HooksObject>): this;
     }
 
-    type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T> & HookLessServiceMethods<T>;
+    type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T>;
 
     type ServiceMixin = (service: Service<any>, path: string) => void;
 

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -282,6 +282,18 @@ declare namespace createApplication {
         remove? (id: null, params?: Params): Promise<T[]>;
     }
 
+    /**
+     * Hook-less service methods. Directly call database adapter service methods without
+     * running any service-level hooks. This can be useful if you need the raw data
+     * from the service and don't want to trigger any of its hooks.
+     *
+     * Important: These methods are only available internally on the server, not on the client
+     * side and only for the Feathers database adapters.
+     *
+     * These methods do not trigger events.
+     *
+     * @see {@link https://docs.feathersjs.com/guides/migrating.html#hook-less-service-methods}
+     */
     interface HookLessServiceMethods<T> {
         /**
          * Retrieve all resources from this service, skipping any service-level hooks.


### PR DESCRIPTION
Yet another TypeScript type definition tweak here 😊

This pull request adds the hook-less service methods described in [the Feathers migration documentation](https://docs.feathersjs.com/guides/migrating.html#hook-less-service-methods) to the `Service` type, allowing for usage of these methods with proper type hinting.

Additionally; I've gone ahead and added inline documentation to all service methods in the form of JSDocs, allowing for nice quick-reference documentation for those running modern code editors and IDEs.

[![image](https://user-images.githubusercontent.com/4034561/80670389-619fe480-8aaf-11ea-947e-434d6f930703.png)](https://globglo.gabgalab.io/x45h9Y3DWUci)




