### PR TITLE
feat: add overload types for `find` service methods

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -103,7 +103,8 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
       ...params,
       query
     });
-    const [ entity = null ] = result.data ? result.data : result;
+
+    const [ entity = null ] = Array.isArray(result) ? result : result.data
 
     debug('findEntity returning', entity);
 

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -206,6 +206,22 @@ declare namespace createApplication {
 
     interface ServiceOverloads<T> {
         /**
+         * Retrieve all resources from this service.
+         *
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
+         */
+        find? (params: Params & { paginate: false}): Promise<T[]>
+
+        /**
+         * Retrieve all resources from this service.
+         *
+         * @param params - Service call parameters {@link Params}
+         * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
+         */
+        find? (params?: Params): Promise<Paginated<T>>
+
+        /**
          * Create a new resource for this service.
          *
          * @param data - Data to insert into this service.


### PR DESCRIPTION
### Summary

I thought this might be a better way to have a conversation about #1970.

The goal is to let typescript automatically infer the return type for `find` methods based on `params.paginate`.

I do not think it is dependent on any other PRs.

### Other Information

Adding these type definitions did have one unexpected side effect where TS no longer approved of line 106 in `packages/authentication-oauth/src/strategy.ts`, but it was such a little change that I included it in this PR.

I can think of two things that I would really like some feeback on:

1.  The main `ServiceMethods<T>` definition for `find` has the signature `find (params?: Params): Promise<T | T[] | Paginated<T>>;`, and the `Promise<T>` result is not included in the overloads

2. I am not sure if changes similar to the one in the `strategy.ts` file would be needed in some ecosystem libs