### PR TITLE
chore(dependencies)!: update grant from 4.x to 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,19 +13,19 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.4.tgz",
-			"integrity": "sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==",
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
+			"integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.4",
-				"@babel/helper-module-transforms": "^7.11.0",
-				"@babel/helpers": "^7.10.4",
-				"@babel/parser": "^7.11.4",
+				"@babel/generator": "^7.12.1",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helpers": "^7.12.1",
+				"@babel/parser": "^7.12.3",
 				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.11.0",
-				"@babel/types": "^7.11.0",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
@@ -37,12 +37,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"semver": {
@@ -54,12 +54,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
-			"integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+			"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0",
+				"@babel/types": "^7.12.1",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
@@ -85,35 +85,37 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+			"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+			"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
 				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.11.0",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
 				"lodash": "^4.17.19"
 			}
 		},
@@ -127,25 +129,24 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+			"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
 				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -164,14 +165,14 @@
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
+			"integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/highlight": {
@@ -186,9 +187,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.11.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
-			"integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+			"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
 			"dev": true
 		},
 		"@babel/template": {
@@ -203,37 +204,37 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-			"integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+			"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.0",
+				"@babel/generator": "^7.12.1",
 				"@babel/helper-function-name": "^7.10.4",
 				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.11.0",
-				"@babel/types": "^7.11.0",
+				"@babel/parser": "^7.12.1",
+				"@babel/types": "^7.12.1",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-			"integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+			"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
@@ -1238,9 +1239,9 @@
 			"dev": true
 		},
 		"@npmcli/git": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.3.tgz",
-			"integrity": "sha512-c/ODsV5ppjB12VDXKc6hzVNgg6ZJX/etILUn3WgF5NLAYBhQLJ3fBq6uB2jQD4OwqOzJdPT1/xA3Xh3aaWGk5w==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.4.tgz",
+			"integrity": "sha512-OJZCmJ9DNn1cz9HPXXsPmUBnqaArot3CGYo63CyajHQk+g87rPXVOJByGsskQJhPsUUEXJcsZ2Q6bWd2jSwnBA==",
 			"dev": true,
 			"requires": {
 				"@npmcli/promise-spawn": "^1.1.0",
@@ -1255,9 +1256,9 @@
 			},
 			"dependencies": {
 				"hosted-git-info": {
-					"version": "3.0.5",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-					"integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+					"integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -1279,12 +1280,12 @@
 					"dev": true
 				},
 				"npm-package-arg": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.1.tgz",
-					"integrity": "sha512-/h5Fm6a/exByzFSTm7jAyHbgOqErl9qSNJDQF32Si/ZzgwT2TERVxRxn3Jurw1wflgyVVAxnFR4fRHPM7y1ClQ==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
+					"integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.2",
+						"hosted-git-info": "^3.0.6",
 						"semver": "^7.0.0",
 						"validate-npm-package-name": "^3.0.0"
 					}
@@ -1352,6 +1353,12 @@
 				}
 			}
 		},
+		"@npmcli/node-gyp": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz",
+			"integrity": "sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==",
+			"dev": true
+		},
 		"@npmcli/promise-spawn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-1.2.0.tgz",
@@ -1362,40 +1369,127 @@
 			}
 		},
 		"@npmcli/run-script": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.5.0.tgz",
-			"integrity": "sha512-z7AzLmsMtVntMRJt35M5VAjb/jH6yH37Q8Ku011JVR7rEoy+p2a6/NkwqChCRZORlJaS9rwjXmZKM6UmwXLkqA==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.2.tgz",
+			"integrity": "sha512-EZO9uXrZrfzdIJsNi/WwrP2jt1P0lbFSxOq15ljgYn1/rr4UyQXUKBZRURioFVbUb7Z1BJDEKswnWrtRybZPzw==",
 			"dev": true,
 			"requires": {
+				"@npmcli/node-gyp": "^1.0.0",
 				"@npmcli/promise-spawn": "^1.2.0",
 				"infer-owner": "^1.0.4",
-				"node-gyp": "^6.1.0",
+				"node-gyp": "^7.1.0",
 				"read-package-json-fast": "^1.1.3"
 			},
 			"dependencies": {
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
+				"fs-minipass": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"minipass": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
 				"node-gyp": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz",
-					"integrity": "sha512-h4A2zDlOujeeaaTx06r4Vy+8MZ1679lU+wbCKDS4ZtvY2A37DESo37oejIw0mtmR3+rvNwts5B6Kpt1KrNYdNw==",
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+					"integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
 					"dev": true,
 					"requires": {
 						"env-paths": "^2.2.0",
 						"glob": "^7.1.4",
-						"graceful-fs": "^4.2.2",
-						"mkdirp": "^0.5.1",
-						"nopt": "^4.0.1",
+						"graceful-fs": "^4.2.3",
+						"nopt": "^5.0.0",
 						"npmlog": "^4.1.2",
-						"request": "^2.88.0",
-						"rimraf": "^2.6.3",
-						"semver": "^5.7.1",
-						"tar": "^4.4.12",
-						"which": "^1.3.1"
+						"request": "^2.88.2",
+						"rimraf": "^3.0.2",
+						"semver": "^7.3.2",
+						"tar": "^6.0.2",
+						"which": "^2.0.2"
+					}
+				},
+				"nopt": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+					"dev": true,
+					"requires": {
+						"abbrev": "1"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				},
+				"tar": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+					"integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+					"dev": true,
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -1410,20 +1504,20 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
-			"integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.8.tgz",
+			"integrity": "sha512-MuRrgv+bM4Q+e9uEvxAB/Kf+Sj0O2JAOBA131uo1o6lgdq1iS8ejKwtqHgdfY91V3rN9R/hdGKFiQYMzVzVBEQ==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^5.0.0",
-				"is-plain-object": "^4.0.0",
+				"is-plain-object": "^5.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				},
 				"universal-user-agent": {
@@ -1488,17 +1582,17 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.7",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-			"integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+			"version": "5.4.9",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+			"integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
 				"@octokit/types": "^5.0.0",
 				"deprecation": "^2.0.0",
-				"is-plain-object": "^4.0.0",
-				"node-fetch": "^2.3.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.1",
 				"once": "^1.4.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -1515,9 +1609,9 @@
 					}
 				},
 				"is-plain-object": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				},
 				"universal-user-agent": {
@@ -1575,9 +1669,9 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
-			"integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+			"integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
@@ -1604,12 +1698,6 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
-		},
 		"@types/glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -1633,9 +1721,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-			"integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -1700,9 +1788,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-			"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -2046,12 +2134,11 @@
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -2119,9 +2206,9 @@
 					}
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -2447,9 +2534,9 @@
 			"dev": true
 		},
 		"cli-boxes": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
 			"dev": true
 		},
 		"cli-cursor": {
@@ -2604,9 +2691,9 @@
 			}
 		},
 		"commander": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
-			"integrity": "sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+			"integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
 			"dev": true
 		},
 		"commondir": {
@@ -2626,9 +2713,9 @@
 			},
 			"dependencies": {
 				"dot-prop": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+					"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 					"dev": true,
 					"requires": {
 						"is-obj": "^2.0.0"
@@ -2691,9 +2778,9 @@
 			},
 			"dependencies": {
 				"dot-prop": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+					"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 					"dev": true,
 					"requires": {
 						"is-obj": "^2.0.0"
@@ -3381,9 +3468,9 @@
 			"dev": true
 		},
 		"envinfo": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.2.tgz",
-			"integrity": "sha512-k3Eh5bKuQnZjm49/L7H4cHzs2FlL5QjbTB3JrPxoTI8aJG7hVMe4uKyJxSYH4ahseby2waUwk5OaKX/nAsaYgg==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
+			"integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
 			"dev": true
 		},
 		"err-code": {
@@ -3402,20 +3489,20 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+			"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.2.0",
-				"is-regex": "^1.1.0",
-				"object-inspect": "^1.7.0",
+				"is-callable": "^1.2.2",
+				"is-regex": "^1.1.1",
+				"object-inspect": "^1.8.0",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
+				"object.assign": "^4.1.1",
 				"string.prototype.trimend": "^1.0.1",
 				"string.prototype.trimstart": "^1.0.1"
 			}
@@ -4454,9 +4541,9 @@
 			}
 		},
 		"git-url-parse": {
-			"version": "11.1.3",
-			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.3.tgz",
-			"integrity": "sha512-GPsfwticcu52WQ+eHp0IYkAyaOASgYdtsQDIt4rUp6GbiNt1P9ddrh3O0kQB0eD4UJZszVqNT3+9Zwcg40fywA==",
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.3.0.tgz",
+			"integrity": "sha512-i3XNa8IKmqnUqWBcdWBjOcnyZYfN3C1WRvnKI6ouFWwsXCZEnlgbwbm55ZpJ3OJMhfEP/ryFhqW8bBhej3C5Ug==",
 			"dev": true,
 			"requires": {
 				"git-up": "^4.0.0"
@@ -4665,9 +4752,9 @@
 			"dev": true
 		},
 		"hasha": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
-			"integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+			"integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
 			"dev": true,
 			"requires": {
 				"is-stream": "^2.0.0",
@@ -4986,9 +5073,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
 			"dev": true
 		},
 		"is-ci": {
@@ -5101,6 +5188,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+			"dev": true
+		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
 			"dev": true
 		},
 		"is-npm": {
@@ -5385,9 +5478,9 @@
 					}
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5407,12 +5500,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"source-map": {
@@ -5480,9 +5573,9 @@
 			"dev": true
 		},
 		"json-parse-even-better-errors": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
-			"integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
 		"json-parse-helpfulerror": {
@@ -5812,9 +5905,9 @@
 			}
 		},
 		"meow": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
-			"integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+			"integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
 			"dev": true,
 			"requires": {
 				"@types/minimist": "^1.2.0",
@@ -5859,14 +5952,14 @@
 					}
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -6056,9 +6149,9 @@
 			}
 		},
 		"minipass-fetch": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.0.tgz",
-			"integrity": "sha512-Yb23ESZZ/8QxiBvSpJ4atbVMVDx2CXrerzrtQzQ67eLqKg+zFIkYFTagk3xh6fdo+e/FvDtVuCD4QcuYDRR3hw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.2.tgz",
+			"integrity": "sha512-/i4fX1ss+Dtwyk++OsAI6SEV+eE1dvI6W+0hORdjfruQ7VD5uYTetJIHcEMjWiEiszWjn2aAtP1CB/Q4KfeoYA==",
 			"dev": true,
 			"requires": {
 				"encoding": "^0.1.12",
@@ -6352,9 +6445,9 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
 			"dev": true
 		},
 		"node-fetch-npm": {
@@ -6477,12 +6570,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6573,9 +6665,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -6673,9 +6765,9 @@
 			}
 		},
 		"npm-registry-fetch": {
-			"version": "8.1.4",
-			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.4.tgz",
-			"integrity": "sha512-UaLGFQP7VCuyBsb7S5P5od3av/Zy9JW6K5gbMigjZCYnEpIkWWRiLQTKVpxM4QocfPcsjm+xtyrDNm4jdqwNEg==",
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.5.tgz",
+			"integrity": "sha512-yZPNoJK9clx1jhSXU54kU6Aj1SV2p7mXUs1W/6OjQvek3wb1RrjDCrt4iY1+VX9eBQvvSGEpzNmYkRUaTL8rqg==",
 			"dev": true,
 			"requires": {
 				"@npmcli/ci-detect": "^1.0.0",
@@ -6740,12 +6832,12 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"fs-minipass": {
@@ -6758,9 +6850,9 @@
 					}
 				},
 				"hosted-git-info": {
-					"version": "3.0.5",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-					"integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+					"integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -6803,9 +6895,9 @@
 					}
 				},
 				"make-fetch-happen": {
-					"version": "8.0.9",
-					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.9.tgz",
-					"integrity": "sha512-uHa4gv/NIdm9cUvfOhYb57nxrCY08iyMRXru0jbpaH57Q3NCge/ypY7fOvgCr8tPyucKrGbVndKhjXE0IX0VfQ==",
+					"version": "8.0.10",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.10.tgz",
+					"integrity": "sha512-jPLPKQjBmDLK5r1BdyDyNKBytmkv2AsDWm2CxHJh+fqhSmC9Pmb7RQxwOq8xQig9+AWIS49+51k4f6vDQ3VnrQ==",
 					"dev": true,
 					"requires": {
 						"agentkeepalive": "^4.1.0",
@@ -6851,12 +6943,12 @@
 					"dev": true
 				},
 				"npm-package-arg": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.1.tgz",
-					"integrity": "sha512-/h5Fm6a/exByzFSTm7jAyHbgOqErl9qSNJDQF32Si/ZzgwT2TERVxRxn3Jurw1wflgyVVAxnFR4fRHPM7y1ClQ==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
+					"integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.2",
+						"hosted-git-info": "^3.0.6",
 						"semver": "^7.0.0",
 						"validate-npm-package-name": "^3.0.0"
 					}
@@ -6996,12 +7088,11 @@
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -7237,15 +7328,37 @@
 			}
 		},
 		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+			"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.0",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -7496,9 +7609,9 @@
 					}
 				},
 				"hosted-git-info": {
-					"version": "3.0.5",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-					"integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+					"integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -7539,12 +7652,12 @@
 					"dev": true
 				},
 				"npm-package-arg": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.1.tgz",
-					"integrity": "sha512-/h5Fm6a/exByzFSTm7jAyHbgOqErl9qSNJDQF32Si/ZzgwT2TERVxRxn3Jurw1wflgyVVAxnFR4fRHPM7y1ClQ==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
+					"integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.2",
+						"hosted-git-info": "^3.0.6",
 						"semver": "^7.0.0",
 						"validate-npm-package-name": "^3.0.0"
 					}
@@ -7951,12 +8064,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				}
 			}
@@ -8341,9 +8454,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-			"integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+			"integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -8737,9 +8850,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
 			"dev": true
 		},
 		"split": {
@@ -9137,9 +9250,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"tslint": {
@@ -9223,9 +9336,9 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
-			"integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.2.tgz",
+			"integrity": "sha512-G440NU6fewtnQftSgqRV1r2A5ChKbU1gqFCJ7I8S7MPpY/eZZfLGefaY6gUZYiWebMaO+txgiQ1ZyLDuNWJulg==",
 			"dev": true,
 			"optional": true
 		},
@@ -9342,9 +9455,9 @@
 			"dev": true
 		},
 		"update-notifier": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.1.tgz",
-			"integrity": "sha512-9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
+			"integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
 			"dev": true,
 			"requires": {
 				"boxen": "^4.2.0",
@@ -9363,12 +9476,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -9404,9 +9516,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -9415,9 +9527,9 @@
 			}
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -58,9 +58,8 @@
     "@feathersjs/feathers": "^5.0.0-pre.0",
     "debug": "^4.1.1",
     "express-session": "^1.17.1",
-    "grant": "^4.7.0",
-    "grant-profile": "^0.0.11",
-    "lodash": "^4.17.20"
+    "grant": "^5.2.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -59,7 +59,7 @@
     "debug": "^4.1.1",
     "express-session": "^1.17.1",
     "grant": "^5.2.0",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -28,7 +28,7 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   const { strategyNames } = service;
 
   // Set up all the defaults
-  const { path = '/oauth' } = oauth.defaults || {};
+  const { prefix = '/oauth' } = oauth.defaults || {};
   const port = app.get('port');
   let host = app.get('host');
   let protocol = 'https';
@@ -43,16 +43,16 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
 
   const grant = merge({
     defaults: {
-      path,
-      host,
-      protocol,
-      transport: 'session'
+      prefix,
+      origin: `${protocol}://${host}`,
+      transport: 'session',
+      response: ['tokens', 'raw', 'profile']
     }
   }, omit(oauth, 'redirect'));
 
   const getUrl = (url: string) => {
     const { defaults } = grant;
-    return `${defaults.protocol}://${defaults.host}${path}/${url}`;
+    return `${defaults.origin}${prefix}/${url}`;
   };
 
   each(grant, (value, name) => {

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -45,6 +45,10 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     };
   }
 
+  async getProfile (data: AuthenticationRequest, _params: Params) {
+    return data.profile
+  }
+
   async getCurrentEntity (params: Params) {
     const { authentication } = params;
     const { entity } = this.configuration;
@@ -137,7 +141,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
   async authenticate (authentication: AuthenticationRequest, originalParams: Params) {
     const entity: string = this.configuration.entity;
     const { provider, ...params } = originalParams;
-    const { profile } = authentication;
+    const profile = await this.getProfile(authentication, params);
     const existingEntity = await this.findEntity(profile, params)
       || await this.getCurrentEntity(params);
 

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -1,5 +1,4 @@
 // @ts-ignore
-import getProfile from 'grant-profile/lib/client';
 import querystring from 'querystring';
 import Debug from 'debug';
 import {
@@ -44,16 +43,6 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     return {
       [`${this.name}Id`]: profile.sub || profile.id
     };
-  }
-
-  /* istanbul ignore next */
-  async getProfile (data: AuthenticationRequest, _params: Params) {
-    const config = this.app.get('grant');
-    const provider = config[data.strategy];
-
-    debug('getProfile of oAuth profile from grant-profile with', data);
-
-    return getProfile(provider, data);
   }
 
   async getCurrentEntity (params: Params) {
@@ -148,7 +137,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
   async authenticate (authentication: AuthenticationRequest, originalParams: Params) {
     const entity: string = this.configuration.entity;
     const { provider, ...params } = originalParams;
-    const profile = await this.getProfile(authentication, params);
+    const { profile } = authentication;
     const existingEntity = await this.findEntity(profile, params)
       || await this.getCurrentEntity(params);
 

--- a/packages/authentication-oauth/test/express.test.ts
+++ b/packages/authentication-oauth/test/express.test.ts
@@ -15,15 +15,23 @@ describe('@feathersjs/authentication-oauth/express', () => {
   after(() => server.close());
 
   it('oauth/test', async () => {
-    axios.get('http://localhost:9876/oauth//test?feathers_token=testing');
+    try {
+      await axios.get('http://localhost:9876/oauth/test?feathers_token=testing', { maxRedirects: 0 });
+    } catch (error) {
+      assert.equal(error.response.status, 302)
+    }
   });
 
   it('oauth/test with query', async () => {
-    axios.get('http://localhost:9876/oauth//test?other=test');
+    try {
+      await axios.get('http://localhost:9876/oauth/test?other=test', { maxRedirects: 0 });
+    } catch (error) {
+      assert.equal(error.response.status, 302)
+    }
   });
 
   it('oauth/test/authenticate', async () => {
-    const { data } = await axios.get('http://localhost:9876/oauth//test/authenticate?id=expressTest');
+    const { data } = await axios.get('http://localhost:9876/oauth/test/authenticate?profile[sub]=expressTest');
 
     assert.ok(data.accessToken);
     assert.equal(data.user.testId, 'expressTest');
@@ -38,14 +46,6 @@ describe('@feathersjs/authentication-oauth/express', () => {
     } catch (error) {
       assert.ok(/Cannot GET/.test(error.response.data));
       delete app.get('authentication').oauth.redirect;
-    }
-  });
-
-  it('oauth/test/authenticate with error', async () => {
-    try {
-      await axios.get('http://localhost:9876/oauth/test/authenticate');
-    } catch (error) {
-      assert.equal(error.response.data.message, 'Data needs an id');
     }
   });
 });

--- a/packages/authentication-oauth/test/fixture.ts
+++ b/packages/authentication-oauth/test/fixture.ts
@@ -5,14 +5,6 @@ import { AuthenticationService, JWTStrategy, AuthenticationRequest } from '@feat
 import { express as oauth, OAuthStrategy } from '../src';
 
 export class TestOAuthStrategy extends OAuthStrategy {
-  async getProfile (data: AuthenticationRequest, _params: Params) {
-    if (!data.id) {
-      throw new Error('Data needs an id');
-    }
-
-    return data;
-  }
-
   async authenticate (data: AuthenticationRequest, params: Params) {
     const { fromMiddleware } = params;
     const authResult = await super.authenticate(data, params);
@@ -27,7 +19,7 @@ export class TestOAuthStrategy extends OAuthStrategy {
 
 export const app = express(feathers());
 
-const port = 3000;
+const port = 9876;
 const auth = new AuthenticationService(app);
 
 auth.register('jwt', new JWTStrategy());
@@ -43,7 +35,7 @@ app.set('authentication', {
   authStrategies: [ 'jwt' ],
   oauth: {
     defaults: {
-      transport: 'query'
+      transport: 'querystring'
     },
     test: {
       key: 'some-key',

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -51,18 +51,13 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
     assert.equal(redirect, '/#dashboard?access_token=testing');
   });
 
-  it('getProfile', async () => {
-    const data = { id: 'getProfileTest' };
-    const profile = await strategy.getProfile(data, {});
-
-    assert.deepEqual(profile, data);
-  });
-
   describe('authenticate', () => {
     it('with new user', async () => {
       const authResult = await strategy.authenticate({
         strategy: 'test',
-        id: 'newEntity'
+        profile: {
+          id: 'newEntity'
+        }
       }, {});
 
       assert.deepEqual(authResult, {
@@ -78,7 +73,9 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
       });
       const authResult = await strategy.authenticate({
         strategy: 'test',
-        id: 'existingEntity'
+        profile: {
+          id: 'existingEntity'
+        }
       }, {});
 
       assert.deepEqual(authResult, {
@@ -97,7 +94,9 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
 
       const authResult = await strategy.authenticate({
         strategy: 'test',
-        id: 'linkedEntity'
+        profile: {
+          id: 'linkedEntity'
+        }
       }, {
         authentication: {
           strategy: 'jwt',


### PR DESCRIPTION
This updates `@feathersjs/authentication-oauth` to use the new version of grant (5.x). (#1961)

Among other stuff, the new grant version offers the possibility to pass options to the underlying http client, which is used for the request for `profile_url`. In my project I need to add proxy settings to this request.

This should go together with a corresponding PR for the docs, as some things have changed with grant. This still needs to be done.

Unfortunately I was not able to test those changes in a real project. I tried installing the `@feathersjs/authentication-oauth` package from my own git repo instead of npm, but this didn't work out well, because of the monorepo structure.
Because the unit tests don't implement a full oauth flow, I guess this should still be tested somehow. Especially the "getting the profile" part, because that was not tested but mocked before already and has completely changed now.
Any ideas on that, how to proceed here?