### PR TITLE
Fix #1999

### DIFF
--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -130,7 +130,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     }
 
     const entityId = await this.getEntityId(result, params);
-    const value = await this.getEntity(entityId, params);
+    const value = await this.getEntity(entityId, omit(params, 'provider'));
 
     return {
       ...result,


### PR DESCRIPTION
This fixes #1999 - missed the prize for the 2000th issue by 1! 😀

Proposal:
The entity loaded into hook.params.[entity] should bypass any redaction hooks on [entity].find as this is an internal call. I recommend calling getEntity here without the provider as this is an internal call.

I would appreciate alternative solutions if this causes other issues.