### PR TITLE
add whitelist to authenticate hook

### DIFF
--- a/packages/authentication/src/hooks/authenticate.ts
+++ b/packages/authentication/src/hooks/authenticate.ts
@@ -1,5 +1,6 @@
 import flatten from 'lodash/flatten';
 import omit from 'lodash/omit';
+import pick from 'lodash/pick';
 import { HookContext } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
 import Debug from 'debug';
@@ -22,8 +23,8 @@ export default (originalSettings: string | AuthenticateHookSettings, ...original
 
   return async (context: HookContext) => {
     const { app, params, type, path, service } = context;
-    const { strategies } = settings;
-    const { provider, authentication } = params;
+    const { strategies, whitelist } = settings;
+    const { provider, authentication, query } = params;
     const authService = app.defaultAuthentication(settings.service);
 
     debug(`Running authenticate hook on '${path}'`);
@@ -46,9 +47,10 @@ export default (originalSettings: string | AuthenticateHookSettings, ...original
     }
 
     if (authentication) {
-      const authParams = omit(params, 'provider', 'authentication', 'query');
+      const authQuery = pick(query, whitelist);
+      const authParams = Object.assign({}, omit(params, 'provider', 'authentication', 'query'), { query: authQuery });
 
-      debug('Authenticating with', authentication, strategies);
+      debug('Authenticating with', authentication, strategies, whitelist);
 
       const authResult = await authService.authenticate(authentication, authParams, ...strategies);
 

--- a/packages/authentication/src/hooks/authenticate.ts
+++ b/packages/authentication/src/hooks/authenticate.ts
@@ -10,6 +10,7 @@ const debug = Debug('@feathersjs/authentication/hooks/authenticate');
 export interface AuthenticateHookSettings {
   service?: string;
   strategies: string[];
+  whitelist?: string[];
 }
 
 export default (originalSettings: string | AuthenticateHookSettings, ...originalStrategies: string[]) => {

--- a/packages/authentication/test/hooks/authenticate.test.ts
+++ b/packages/authentication/test/hooks/authenticate.test.ts
@@ -170,7 +170,7 @@ describe('authentication/hooks/authenticate', () => {
 
     assert.deepStrictEqual(result, Object.assign({
       authentication: params.authentication,
-      params: { authenticated: true }
+      params: { authenticated: true, query: {} }
     }, Strategy2.result));
   });
 


### PR DESCRIPTION
This is related to #2007 adds whitelist option to authenticate hook, which allows query params to be passed to the user entity lookup.