### PR TITLE
fix(authentication): Include query params when authenticating via authenticate hook

### DIFF
--- a/packages/authentication/src/hooks/authenticate.ts
+++ b/packages/authentication/src/hooks/authenticate.ts
@@ -46,7 +46,7 @@ export default (originalSettings: string | AuthenticateHookSettings, ...original
     }
 
     if (authentication) {
-      const authParams = omit(params, 'provider', 'authentication', 'query');
+      const authParams = omit(params, 'provider', 'authentication');
 
       debug('Authenticating with', authentication, strategies);
 


### PR DESCRIPTION
Supersedes #2008 fixes #2007 