### PR TITLE
Add JWT getEntityQuery

### DIFF
--- a/packages/authentication-local/src/strategy.ts
+++ b/packages/authentication-local/src/strategy.ts
@@ -45,7 +45,7 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
   }
 
   async findEntity (username: string, params: Params) {
-    const { entityUsernameField, service, errorMessage } = this.configuration;
+    const { entityUsernameField, errorMessage } = this.configuration;
     if (!username) { // don't query for users without any condition set.
       throw new NotAuthenticated(errorMessage);
     }
@@ -55,7 +55,7 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
     }, params);
 
     const findParams = Object.assign({}, params, { query });
-    const entityService = this.app.service(service);
+    const entityService = this.entityService;
 
     debug('Finding entity with query', params.query);
 
@@ -74,7 +74,7 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
   }
 
   async getEntity (result: any, params: Params) {
-    const { entityService } = this;
+    const entityService = this.entityService;
     const { entityId = entityService.id, entity } = this.configuration;
 
     if (!entityId || result[entityId] === undefined) {

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -104,14 +104,14 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
       [entityId]: id
     }, params);
 
-    const getParams = Object.assign({}, omit(params, 'provider', 'query'), { query });
+    const getParams = Object.assign({}, omit(params, 'provider'), { query });
     const result = await entityService.get(id, getParams);
 
     if (!params.provider) {
       return result;
     }
 
-    return entityService.get(id, { ...params, { query }, [entity]: result });
+    return entityService.get(id, { ...params, [entity]: result });
   }
 
   async getEntityId (authResult: AuthenticationResult, _params: Params) {

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -67,7 +67,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
   }
 
   verifyConfiguration () {
-    const allowedKeys = [ 'entity', 'service', 'header', 'schemes' ];
+    const allowedKeys = [ 'entity', 'entityId', 'service', 'header', 'schemes' ];
 
     for (const key of Object.keys(this.configuration)) {
       if (!allowedKeys.includes(key)) {

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -93,7 +93,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
    */
   async getEntity (id: string, params: Params) {
     const entityService = this.entityService;
-    const { entityId = entityService.id, entity } = this.configuration;
+    const { entity } = this.configuration;
 
     debug('Getting entity', id);
 
@@ -101,9 +101,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
       throw new NotAuthenticated(`Could not find entity service`);
     }
 
-    const query = await this.getEntityQuery({
-      [entityId]: id
-    }, params);
+    const query = await this.getEntityQuery({}, params);
 
     const getParams = Object.assign({}, omit(params, 'provider'), { query });
     const result = await entityService.get(id, getParams);

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -20,8 +20,9 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     const config = super.configuration;
 
     return {
-      entity: authConfig.entity,
       service: authConfig.service,
+      entity: authConfig.entity,
+      entityId: authConfig.entityId,
       header: 'Authorization',
       schemes: [ 'Bearer', 'JWT' ],
       ...config

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import omit from 'lodash/omit';
 import { IncomingMessage } from 'http';
 import { NotAuthenticated } from '@feathersjs/errors';
-import { Query, Params } from '@feathersjs/feathers';
+import { Params } from '@feathersjs/feathers';
 // @ts-ignore
 import lt from 'long-timeout';
 
@@ -80,7 +80,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     }
   }
 
-  async getEntityQuery (params: Params) {
+  async getEntityQuery (_params: Params) {
     return {};
   }
 

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -80,10 +80,8 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     }
   }
 
-  async getEntityQuery (query: Query, _params: Params) {
-    return {
-      ...query
-    };
+  async getEntityQuery (params: Params) {
+    return {};
   }
 
   /**
@@ -101,8 +99,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
       throw new NotAuthenticated(`Could not find entity service`);
     }
 
-    const query = await this.getEntityQuery({}, params);
-
+    const query = await this.getEntityQuery(params);
     const getParams = Object.assign({}, omit(params, 'provider'), { query });
     const result = await entityService.get(id, getParams);
 

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -75,7 +75,7 @@ describe('authentication/jwt', () => {
     app.setup();
   });
 
-  it('getEntity (and params.query)', async () => {
+  it('getEntity', async () => {
     const [ strategy ] = app.service('authentication').getStrategies('jwt') as JWTStrategy[];
 
     let entity = await strategy.getEntity(user.id, {


### PR DESCRIPTION
Brings both local-strategy and jwt-strategy into alignment.

Added getEntityQuery to JWT strategy, allows extending JWT class to include additional query parameters in entity lookup.

Closes https://github.com/feathersjs/feathers/issues/2007