### PR TITLE
Fix `data` property definition in @feathersjs/errors

### DIFF
--- a/packages/errors/index.d.ts
+++ b/packages/errors/index.d.ts
@@ -3,14 +3,14 @@ export interface FeathersErrorJSON {
   readonly message: string;
   readonly code: number;
   readonly className: string;
-  readonly data: any;
+  readonly data?: any;
   readonly errors: any;
 }
 
 export class FeathersError extends Error {
   readonly code: number;
   readonly className: string;
-  readonly data: any;
+  readonly data?: unknown;
   readonly errors: any;
   constructor (msg: string | Error, name: string, code: number, className: string, data: any);
   toJSON (): FeathersErrorJSON;


### PR DESCRIPTION
`data` is described in TypeScript definitions as always defined property, while from [the actual implementation](https://github.com/feathersjs/feathers/blob/c838d8bc4b8a78cb90a2d299bfe4f7b6b8d8c2f8/packages/errors/lib/index.js#L8) it can be undefined. As result direct assignment to and `error.data.boo` were not catched by TypeScript.

This PR fixes that definition to be according to actual code.
