### PR TITLE
"fix(typescript): Revert add overload types for `find` service methods (#1972)

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -103,8 +103,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
       ...params,
       query
     });
-
-    const [ entity = null ] = Array.isArray(result) ? result : result.data
+    const [ entity = null ] = result.data ? result.data : result;
 
     debug('findEntity returning', entity);
 

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -211,22 +211,6 @@ declare namespace createApplication {
 
     interface ServiceOverloads<T> {
         /**
-         * Retrieve all resources from this service.
-         *
-         * @param params - Service call parameters {@link Params}
-         * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
-         */
-        find? (params: Params & { paginate: false}): Promise<T[]>
-
-        /**
-         * Retrieve all resources from this service.
-         *
-         * @param params - Service call parameters {@link Params}
-         * @see {@link https://docs.feathersjs.com/api/services.html#find-params|Feathers API Documentation: .find(params)}
-         */
-        find? (params?: Params): Promise<Paginated<T>>
-
-        /**
          * Create a new resource for this service.
          *
          * @param data - Data to insert into this service.


### PR DESCRIPTION
This pull request reverts #1972 which breaks some assumption for other adapters. It will be added in the adapter common types via https://github.com/feathersjs/databases/pull/9 instead.