### PR TITLE
Some of the published packages include coverage

### DIFF
--- a/packages/authentication-client/.npmignore
+++ b/packages/authentication-client/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/

--- a/packages/authentication-local/.npmignore
+++ b/packages/authentication-local/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/

--- a/packages/authentication-oauth/.npmignore
+++ b/packages/authentication-oauth/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/

--- a/packages/authentication/.npmignore
+++ b/packages/authentication/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/

--- a/packages/client/.npmignore
+++ b/packages/client/.npmignore
@@ -1,4 +1,4 @@
 src/
 test/
 browser/
-!dist/
+!dist/coverage/

--- a/packages/commons/.npmignore
+++ b/packages/commons/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/

--- a/packages/configuration/.npmignore
+++ b/packages/configuration/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/

--- a/packages/errors/.npmignore
+++ b/packages/errors/.npmignore
@@ -1,1 +1,2 @@
 test/
+coverage/

--- a/packages/express/.npmignore
+++ b/packages/express/.npmignore
@@ -1,1 +1,2 @@
 test/
+coverage/

--- a/packages/feathers/.npmignore
+++ b/packages/feathers/.npmignore
@@ -1,1 +1,1 @@
-test/
+test/coverage/

--- a/packages/primus-client/.npmignore
+++ b/packages/primus-client/.npmignore
@@ -1,1 +1,2 @@
 test/
+coverage/

--- a/packages/primus/.npmignore
+++ b/packages/primus/.npmignore
@@ -1,1 +1,2 @@
 test/
+coverage/

--- a/packages/rest-client/.npmignore
+++ b/packages/rest-client/.npmignore
@@ -1,1 +1,2 @@
 test/
+coverage/

--- a/packages/socketio-client/.npmignore
+++ b/packages/socketio-client/.npmignore
@@ -1,1 +1,2 @@
 test/
+coverage/

--- a/packages/socketio/.npmignore
+++ b/packages/socketio/.npmignore
@@ -1,1 +1,2 @@
 test/
+coverage/

--- a/packages/tests/.npmignore
+++ b/packages/tests/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/

--- a/packages/transport-commons/.npmignore
+++ b/packages/transport-commons/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+coverage/


### PR DESCRIPTION
I'm guessing you probably didn't intend to publish the coverage data as
part of these packages.  This PR just adds `coverage/` to all of your
`.npmignore` files, but in general I would recommend using the files
field in package.json to specify what should be published, rather than
depending on your `.npmignore` to include everything that shouldn't be
published..

[files]: https://docs.npmjs.com/files/package.json#files

```
$ du -ksh node_modules/@feathers*/coverage
356K	authentication-local/coverage
612K	authentication/coverage
348K	express/coverage
560K	transport-commons/coverage
```