### PR TITLE
chore: Update funding links and CI badges

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: [ daffl ]
 patreon: # Replace with a single Patreon username
-open_collective: feathers
+open_collective: #
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "bugs": {
     "url": "https://github.com/feathersjs/feathers/issues"

--- a/packages/authentication-client/README.md
+++ b/packages/authentication-client/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/authentication-client
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/authentication-client)](https://david-dm.org/feathersjs/feathers?path=packages/authentication-client)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/authentication-client.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/authentication-client)
 

--- a/packages/authentication-client/package.json
+++ b/packages/authentication-client/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/authentication-local/README.md
+++ b/packages/authentication-local/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/authentication-local
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/authentication-local)](https://david-dm.org/feathersjs/feathers?path=packages/authentication-local)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/authentication-local.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/authentication-local)
 

--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/authentication-oauth/README.md
+++ b/packages/authentication-oauth/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/authentication-oauth
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/authentication-oauth)](https://david-dm.org/feathersjs/feathers?path=packages/authentication-oauth)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/authentication-oauth.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/authentication-oauth)
 

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/authentication
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/authentication)](https://david-dm.org/feathersjs/feathers?path=packages/authentication)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/authentication.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/authentication)
 

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/client
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/client.svg?style=flat-square)](https://david-dm.org/feathersjs/client)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/client.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/client)
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,8 +8,8 @@
   },
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "bugs": {
     "url": "https://github.com/feathersjs/feathers/issues"

--- a/packages/commons/README.md
+++ b/packages/commons/README.md
@@ -1,6 +1,6 @@
 # Feathers Commons
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/commons)](https://david-dm.org/feathersjs/feathers?path=packages/commons)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/commons.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/commons)
 

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -8,8 +8,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/configuration/README.md
+++ b/packages/configuration/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/configuration
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/configuration)](https://david-dm.org/feathersjs/feathers?path=packages/configuration)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/configuration.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/configuration)
 

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/errors
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/errors)](https://david-dm.org/feathersjs/feathers?path=packages/errors)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/errors.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/errors)
 

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/express
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/express)](https://david-dm.org/feathersjs/feathers?path=packages/express)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/express.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/express)
 

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -22,8 +22,8 @@
   },
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "bugs": {
     "url": "https://github.com/feathersjs/feathers/issues"

--- a/packages/feathers/readme.md
+++ b/packages/feathers/readme.md
@@ -3,7 +3,7 @@
 ## A framework for real-time applications and REST APIs with JavaScript and TypeScript
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/feathersjs/feathers.svg)](https://greenkeeper.io/)
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Maintainability](https://api.codeclimate.com/v1/badges/cb5ec42a2d0cc1a47a02/maintainability)](https://codeclimate.com/github/feathersjs/feathers/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/cb5ec42a2d0cc1a47a02/test_coverage)](https://codeclimate.com/github/feathersjs/feathers/test_coverage)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/feathers.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/feathers)

--- a/packages/primus-client/README.md
+++ b/packages/primus-client/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/primus-client
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/primus-client)](https://david-dm.org/feathersjs/feathers?path=packages/primus-client)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/primus-client.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/primus-client)
 

--- a/packages/primus-client/package.json
+++ b/packages/primus-client/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/primus/README.md
+++ b/packages/primus/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/primus
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/primus)](https://david-dm.org/feathersjs/feathers?path=packages/primus)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/primus.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/primus)
 

--- a/packages/primus/package.json
+++ b/packages/primus/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/rest-client
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/rest-client)](https://david-dm.org/feathersjs/feathers?path=packages/rest-client)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/rest-client.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/rest-client)
 

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/socketio-client/README.md
+++ b/packages/socketio-client/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/socketio-client
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/socketio-client)](https://david-dm.org/feathersjs/feathers?path=packages/socketio-client)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/socketio-client.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/socketio-client)
 

--- a/packages/socketio-client/package.json
+++ b/packages/socketio-client/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/socketio/README.md
+++ b/packages/socketio/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/socketio
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/socketio)](https://david-dm.org/feathersjs/feathers?path=packages/socketio)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/socketio.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/socketio)
 

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/tests
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/express)](https://david-dm.org/feathersjs/feathers?path=packages/koa)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/tests.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/tests)
 

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -10,8 +10,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",

--- a/packages/transport-commons/README.md
+++ b/packages/transport-commons/README.md
@@ -1,6 +1,6 @@
 # @feathersjs/transport-commons
 
-[![CI](https://github.com/feathersjs/feathers/workflows/Node.js%20CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3A%22Node.js+CI%22)
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
 [![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/transport-commons)](https://david-dm.org/feathersjs/feathers?path=packages/transport-commons)
 [![Download Status](https://img.shields.io/npm/dm/@feathersjs/transport-commons.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/transport-commons)
 

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/feathers"
+    "type": "github",
+    "url": "https://github.com/sponsors/daffl"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am planning on retiring the OpenCollective and instead let people sponsor the developers they’d like to support on GitHub. Reasons:

- Dealing with OpenCollective Paypal payouts and tax forms has been a hassle
- I’ve been trying to make the process open and transparent and give others the opportunity to get paid for open source work but essentially I was the only one that ever used the collective for anything. This was either because contributors were not interested in getting paid or didn’t contribute frequently enough for it to make sense (by which I mean more than once).
- GitHub has the matching fund which will double any contribution. Regular contributors will be able to add GitHub sponsorship tiers that will give companies the option to get their logo added to the official Feathers page
- The remaining funds in the OpenCollective will be used for sponsoring developers of Feathers projects on GitHub, one more batch of swag and donations to open source related projects and initiatives