### PR TITLE
feat: consistent response return between local and jwt strategy

### DIFF
--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -115,7 +115,7 @@ export class AuthenticationService extends AuthenticationBase implements Partial
     const auth = {
       authentication: {
           accessToken,
-          payload: jsonwebtoken.decode(accessToken),
+          payload: jsonwebtoken.decode(accessToken)
       }
     };
 

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -5,6 +5,7 @@ import { AuthenticationBase, AuthenticationResult, AuthenticationRequest } from 
 import { connection, event } from './hooks';
 import '@feathersjs/transport-commons';
 import { Application, Params, ServiceMethods, ServiceAddons } from '@feathersjs/feathers';
+import jsonwebtoken from 'jsonwebtoken';
 
 const debug = Debug('@feathersjs/authentication/service');
 
@@ -111,8 +112,14 @@ export class AuthenticationService extends AuthenticationBase implements Partial
     debug('Creating JWT with', payload, jwtOptions);
 
     const accessToken = await this.createAccessToken(payload, jwtOptions, params.secret);
+    const auth = {
+      authentication: {
+          accessToken,
+          payload: jsonwebtoken.decode(accessToken),
+      }
+    };
 
-    return Object.assign({}, { accessToken }, authResult);
+    return merge({}, { accessToken }, authResult, auth);
   }
 
   /**

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -112,14 +112,13 @@ export class AuthenticationService extends AuthenticationBase implements Partial
     debug('Creating JWT with', payload, jwtOptions);
 
     const accessToken = await this.createAccessToken(payload, jwtOptions, params.secret);
-    const auth = {
+
+    return merge({ accessToken }, authResult, {
       authentication: {
           accessToken,
           payload: jsonwebtoken.decode(accessToken)
       }
-    };
-
-    return merge({}, { accessToken }, authResult, auth);
+    });
   }
 
   /**

--- a/packages/authentication/test/service.test.ts
+++ b/packages/authentication/test/service.test.ts
@@ -58,7 +58,8 @@ describe('authentication/service', () => {
       }
 
       assert.ok(result.accessToken);
-      assert.deepStrictEqual(omit(result, 'accessToken'), Strategy1.result);
+      assert.deepStrictEqual(omit(result, 'accessToken', 'authentication'), Strategy1.result);
+      assert.deepStrictEqual(result.authentication.payload, decoded);
       assert.ok(UUID.test(decoded.jti), 'Set `jti` to default UUID');
       assert.strictEqual(decoded.aud, settings.audience);
       assert.strictEqual(decoded.iss, settings.issuer);

--- a/packages/express/test/authentication.test.js
+++ b/packages/express/test/authentication.test.js
@@ -3,6 +3,7 @@ const _axios = require('axios');
 const feathers = require('@feathersjs/feathers');
 const getApp = require('@feathersjs/authentication-local/test/fixture');
 const { authenticate } = require('@feathersjs/authentication');
+const omit = require('lodash/omit');
 
 const expressify = require('../lib');
 const axios = _axios.create({
@@ -63,8 +64,9 @@ describe('@feathersjs/express/authentication', () => {
   describe('service authentication', () => {
     it('successful local authentication', () => {
       assert.ok(authResult.accessToken);
-      assert.deepStrictEqual(authResult.authentication, {
-        strategy: 'local'
+      assert.deepStrictEqual(omit(authResult.authentication, 'payload'), {
+        strategy: 'local',
+        accessToken: authResult.accessToken
       });
       assert.strictEqual(authResult.user.email, email);
       assert.strictEqual(authResult.user.password, undefined);


### PR DESCRIPTION
Currently, when /authentication service is trigger with `local` strategy, it is missing `authentication.accessToken` and `authentication.payload` field as compared to `jwt` strategy

This commit attempts to ensure consistency in both response

```json
// response from 'jwt' strategy
{
    "accessToken": "<token>",
    "authentication": {
        "strategy": "local",
        "accessToken": "<token>",
        "payload": {
            "iat": 1597565489,
            "exp": 1597651889,
            "aud": "https://yourdomain.com",
            "iss": "feathers",
            "sub": "5edb8a3f8a2e8936c429d5ba",
            "jti": "e64f9caa-e738-47da-9c27-fe8c026ab627"
        }
    },
    "user": {
        "_id": "123456",
        "email": "helloworld@gmail.com",
        "createdAt": "2020-06-06T12:21:19.167Z",
        "updatedAt": "2020-06-06T12:24:55.164Z",
        "__v": 0
    }
}

// response from 'local' strategy (before)
{
    "accessToken": "<token>",
    "authentication": {
        "strategy": "local"
    },
    "user": {
        "_id": "123456",
        "email": "helloworld@gmail.com",
        "createdAt": "2020-06-06T12:21:19.167Z",
        "updatedAt": "2020-06-06T12:24:55.164Z",
        "__v": 0
    }
}

// response from 'local' strategy (after)
{
    "accessToken": "<token>",
    "authentication": {
        "strategy": "local"
        "accessToken": "<token>",
        "payload": {
            "iat": 1597565489,
            "exp": 1597651889,
            "aud": "https://yourdomain.com",
            "iss": "feathers",
            "sub": "5edb8a3f8a2e8936c429d5ba",
            "jti": "e64f9caa-e738-47da-9c27-fe8c026ab627"
        }
    },
    "user": {
        "_id": "123456",
        "email": "helloworld@gmail.com",
        "createdAt": "2020-06-06T12:21:19.167Z",
        "updatedAt": "2020-06-06T12:24:55.164Z",
        "__v": 0
    }
}
```

---

I added in `authentication` package instead of `authentication-local` because `jsonwebtoken` is already available and it seem like the correct place to add