### PR TITLE
fix(configuration): Fix handling of config values that start with . or .. but are not relative paths

### DIFF
--- a/packages/configuration/src/index.ts
+++ b/packages/configuration/src/index.ts
@@ -25,7 +25,7 @@ export default function init () {
             if (process.env[value]) {
               value = process.env[value];
             }
-            if (value.indexOf('.') === 0 || value.indexOf('..') === 0) {
+            if (value.indexOf('./') === 0 || value.indexOf('../') === 0) {
               // Make relative paths absolute
               value = path.resolve(
                 path.join(config.util.getEnv('NODE_CONFIG_DIR')),

--- a/packages/configuration/test/config/default.json
+++ b/packages/configuration/test/config/default.json
@@ -2,6 +2,8 @@
   "port": 3030,
   "environment": "NODE_ENV",
   "path": "../something",
+  "notDotPath": ".dot",
+  "notDotDotPath": "..dotdot",
   "pathFromEnv": "PATH_ENV",
   "unescaped": "\\NODE_ENV",
   "from": "default",

--- a/packages/configuration/test/index.test.ts
+++ b/packages/configuration/test/index.test.ts
@@ -64,6 +64,14 @@ describe('@feathersjs/configuration', () => {
     assert.strictEqual(app.get('pathFromEnv'), join(__dirname, 'something'))
   );
 
+  it('does not normalize values that start with . but are not a relative path', () =>
+    assert.strictEqual(app.get('notDotPath'), '.dot')
+  );
+
+  it('does not normalize values that start with .. but are not a relative path', () =>
+    assert.strictEqual(app.get('notDotDotPath'), '..dotdot')
+  );
+
   it('converts environment variables recursively', () =>
     assert.strictEqual(app.get('deeply').nested.env, 'testing')
   );


### PR DESCRIPTION

### Summary

- [x] Tell us about the problem your pull request is solving.

This PR fixes the problem where a config value that is not a relative path gets normalized
to an absolute path when it shouldn't be. For example, values like ".foo" and "..bar" are
not relative paths.

- [ x] Are there any open issues that are related to this?

Not that I am aware of.

- [x ] Is this PR dependent on PRs in other repos?

Not that I am aware of.
