### PR TITLE
perf(authentication-local): migrate to higher performance bcrypt implement

### DIFF
--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -55,12 +55,11 @@
     "@feathersjs/authentication": "^4.5.8",
     "@feathersjs/errors": "^4.5.8",
     "@feathersjs/feathers": "^4.5.8",
-    "bcryptjs": "^2.4.3",
+    "@node-rs/bcrypt": "^0.5.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.19"
   },
   "devDependencies": {
-    "@types/bcryptjs": "^2.4.2",
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.14.158",
     "@types/mocha": "^8.0.0",

--- a/packages/authentication-local/src/strategy.ts
+++ b/packages/authentication-local/src/strategy.ts
@@ -1,4 +1,4 @@
-import bcrypt from 'bcryptjs';
+import { verify, hash } from '@node-rs/bcrypt';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
 import Debug from 'debug';
@@ -104,7 +104,7 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
 
     debug('Verifying password');
 
-    const result = await bcrypt.compare(password, hash);
+    const result = await verify(password, hash);
 
     if (result) {
       return entity;
@@ -114,7 +114,7 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
   }
 
   async hashPassword (password: string, _params: Params) {
-    return bcrypt.hash(password, this.configuration.hashSize);
+    return hash(password, this.configuration.hashSize);
   }
 
   async authenticate (data: AuthenticationRequest, params: Params) {


### PR DESCRIPTION
[@node-rs/bcrypt](https://www.npmjs.com/package/@node-rs/bcrypt) is `4~8x` faster than `bcryptjs`.

And compare to [node bcrypt](https://www.npmjs.com/package/bcrypt), `@node-rs/bcrypt` has no `postinstall` download scripts nor `node-gyp`.


Benchmark:

- [@node-rs/bcrypt](https://www.npmjs.com/package/@node-rs/bcrypt)
- [node bcrypt](https://www.npmjs.com/package/bcrypt)
- [bcryptjs](https://www.npmjs.com/package/bcryptjs)

```
@node-rs/bcrypt x 70.38 ops/sec ±1.40% (32 runs sampled)
node bcrypt x 63.88 ops/sec ±0.95% (30 runs sampled)
bcryptjs x 12.23 ops/sec ±4.90% (10 runs sampled)
Async hash round 10 bench suite: Fastest is @node-rs/bcrypt
@node-rs/bcrypt x 16.55 ops/sec ±2.33% (11 runs sampled)
node bcrypt x 14.62 ops/sec ±1.48% (11 runs sampled)
bcryptjs x 3.12 ops/sec ±1.60% (6 runs sampled)
Async hash round 12 bench suite: Fastest is @node-rs/bcrypt
@node-rs/bcrypt x 3.65 ops/sec ±5.08% (6 runs sampled)
node bcrypt x 3.50 ops/sec ±2.14% (6 runs sampled)
bcryptjs x 0.84 ops/sec ±12.31% (5 runs sampled)
Async hash round 14 bench suite: Fastest is @node-rs/bcrypt
@node-rs/bcrypt x 18.78 ops/sec ±0.86% (12 runs sampled)
node bcrypt x 16.28 ops/sec ±3.55% (11 runs sampled)
bcryptjs x 3.70 ops/sec ±2.64% (6 runs sampled)
Async verify bench suite: Fastest is @node-rs/bcrypt
```