### PR TITLE
fix(rest-client): Handle non-JSON errors with fetch adapter

### DIFF
--- a/packages/rest-client/lib/fetch.js
+++ b/packages/rest-client/lib/fetch.js
@@ -30,7 +30,11 @@ class FetchService extends Base {
       return response;
     }
 
-    return response.json().then(error => {
+    return response.json().catch(() => {
+      const ErrorClass = errors[response.status] || Error;
+      
+      return new ErrorClass('JSON parsing error');
+    }).then(error => {
       error.response = response;
       throw error;
     });


### PR DESCRIPTION
Closes https://github.com/feathersjs/feathers/issues/1940