### PR TITLE
(TypeDef) Add user property to the Params.

### DIFF
--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -42,7 +42,7 @@ declare namespace createApplication {
         provider?: string;
         route?: {[key: string]: string};
         headers?: {[key: string]: any};
-        user?: {[key: string]: string};
+        user?: {[key: string]: any};
 
         [key: string]: any; // (JL) not sure if we want this
     }

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -42,6 +42,7 @@ declare namespace createApplication {
         provider?: string;
         route?: {[key: string]: string};
         headers?: {[key: string]: any};
+        user?: {[key: string]: string};
 
         [key: string]: any; // (JL) not sure if we want this
     }


### PR DESCRIPTION
### Summary
I am using TypeScript. When I tried to access `context.params.user` property from the service hook the IntelliSense did not work. The reason is that the type of `context.params` is `Params`. But, `Params` does not contain the `user` field in it.

### Solution
Add `user` property in the `Params` interface.

### Checklist
- [x] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

