### PR TITLE
fix oauth session.destroy is undefined when use cookie-session package

### DIFF
--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -96,7 +96,7 @@ export default (options: OauthSetupSettings) => {
         };
 
         await new Promise((resolve, reject) =>
-          req.session.destroy(err => err ? reject(err) : resolve())
+          req.session!.destroy(err => err ? reject(err) : resolve())
         );
 
         debug(`Calling ${authService}.create authentication with strategy ${name}`);

--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -95,9 +95,14 @@ export default (options: OauthSetupSettings) => {
           ...payload
         };
 
-        await new Promise((resolve, reject) =>
-          req.session!.destroy(err => err ? reject(err) : resolve())
-        );
+        await new Promise((resolve, reject) => {
+          if (!req.session.destroy) {
+            req.session = null;
+            resolve();
+          }
+
+          req.session.destroy(err => err ? reject(err) : resolve());
+        });
 
         debug(`Calling ${authService}.create authentication with strategy ${name}`);
 


### PR DESCRIPTION


Hi @daffl 
Oauth in our project suddenly broke, and it turned out that we use `cookie-session` for OAuth like so 
```
const cookieSession = require('cookie-session');

  app.configure(expressOauth({
    expressSession: cookieSession({
      name: 'session',
      keys: ['grant'],
      maxAge: 60 * 1000
    })
  }));
```
that fixes OAuth when scaling the app Kubernetes. So now when trying to authenticate, it throws an error because `cookie-session` doesn't have `destroy`.
The bug is in `authentication-oauth` repo. 

Thank you. 
