### PR TITLE
docs(typescript): fix misleading parameter name

### DIFF
--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -54,7 +54,7 @@ declare namespace createApplication {
     }
 
     // tslint:disable-next-line void-return
-    type Hook<T = any, S = Service<T>> = (hook: HookContext<T, S>) => (Promise<HookContext<T, S> | void> | HookContext<T, S> | void);
+    type Hook<T = any, S = Service<T>> = (context: HookContext<T, S>) => (Promise<HookContext<T, S> | void> | HookContext<T, S> | void);
 
     interface HookContext<T = any, S = Service<T>> {
         /**

--- a/packages/transport-commons/src/channels/mixins.ts
+++ b/packages/transport-commons/src/channels/mixins.ts
@@ -62,7 +62,7 @@ export function channelMixin () {
 
 export type Event = string|(typeof ALL_EVENTS);
 
-export type Publisher<T = any> = (data: T, hook: HookContext<T>) => Channel | Channel[] | void | Promise<Channel | Channel[] | void>;
+export type Publisher<T = any> = (data: T, context: HookContext<T>) => Channel | Channel[] | void | Promise<Channel | Channel[] | void>;
 
 export interface PublishMixin<T = any> {
   [PUBLISHERS]: { [ALL_EVENTS]?: Publisher<T>, [key: string]: Publisher<T> };


### PR DESCRIPTION
For IDEs with autocompletion, this argument name is slightly misleading. `context` makes more sense and is in line with the rest of the hooks documentation.