### PR TITLE
fix: clean script in client package causing test to fail

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,7 @@
     "*.js"
   ],
   "scripts": {
-    "clean": "../../node_modules/.bin/shx rm -rf dist/ && ../../node_modules/.bin/shx mkdir -p dist",
+    "clean": "shx rm -rf dist/ && shx mkdir -p dist",
     "version": "npm run build",
     "mocha": "mocha --config ../../.mocharc.json test/ --recursive",
     "test": "npm run build && npm run mocha",


### PR DESCRIPTION
Current `clean` script in `client/package.json` is causing test to fail