### PR TITLE
Update index.d.ts

### DIFF
--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -130,7 +130,7 @@ declare namespace createApplication {
         event?: null;
     }
 
-    interface HookMap<T = any, S = any, A = any> {
+    interface HookMap<T = any, S = Service<T>, A = Application> {
         all: Hook<T, S, A> | Hook<T, S, A>[];
         find: Hook<T, S, A> | Hook<T, S, A>[];
         get: Hook<T, S, A> | Hook<T, S, A>[];
@@ -140,11 +140,11 @@ declare namespace createApplication {
         remove: Hook<T, S, A> | Hook<T, S, A>[];
     }
 
-    interface HooksObject<T = any, S = any, A = any> {
-        before: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
-        after: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
-        error: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
-        finally?: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
+    interface HooksObject<T = any, A = Application> {
+        before: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        after: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        error: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        finally?: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
     }
 
     interface SetupMethod {

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -55,14 +55,14 @@ declare namespace createApplication {
     }
 
     // tslint:disable-next-line void-return
-    type Hook<T = any, S = Service<T>> = (context: HookContext<T, S>) => (Promise<HookContext<T, S> | void> | HookContext<T, S> | void);
+    type Hook<T = any, S = Service<T>, A = Application> = (context: HookContext<T, S, A>) => (Promise<HookContext<T, S> | void> | HookContext<T, S> | void);
 
-    interface HookContext<T = any, S = Service<T>> {
+    interface HookContext<T = any, S = Service<T>, A = Application> {
         /**
          * A read only property that contains the Feathers application object. This can be used to
          * retrieve other services (via context.app.service('name')) or configuration values.
          */
-        readonly app: Application;
+        readonly app: A;
         /**
          * A writeable property containing the data of a create, update and patch service
          * method call.
@@ -130,21 +130,21 @@ declare namespace createApplication {
         event?: null;
     }
 
-    interface HookMap<T = any> {
-        all: Hook<T> | Hook<T>[];
-        find: Hook<T> | Hook<T>[];
-        get: Hook<T> | Hook<T>[];
-        create: Hook<T> | Hook<T>[];
-        update: Hook<T> | Hook<T>[];
-        patch: Hook<T> | Hook<T>[];
-        remove: Hook<T> | Hook<T>[];
+    interface HookMap<T = any, S = any, A = any> {
+        all: Hook<T, S, A> | Hook<T, S, A>[];
+        find: Hook<T, S, A> | Hook<T, S, A>[];
+        get: Hook<T, S, A> | Hook<T, S, A>[];
+        create: Hook<T, S, A> | Hook<T, S, A>[];
+        update: Hook<T, S, A> | Hook<T, S, A>[];
+        patch: Hook<T, S, A> | Hook<T, S, A>[];
+        remove: Hook<T, S, A> | Hook<T, S, A>[];
     }
 
-    interface HooksObject<T = any> {
-        before: Partial<HookMap<T>> | Hook<T> | Hook<T>[];
-        after: Partial<HookMap<T>> | Hook<T> | Hook<T>[];
-        error: Partial<HookMap<T>> | Hook<T> | Hook<T>[];
-        finally?: Partial<HookMap<T>> | Hook<T> | Hook<T>[];
+    interface HooksObject<T = any, S = any, A = any> {
+        before: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
+        after: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
+        error: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
+        finally?: Partial<HookMap<T, S, A>> | Hook<T, S, A> | Hook<T, S, A>[];
     }
 
     interface SetupMethod {

--- a/packages/feathers/index.d.ts
+++ b/packages/feathers/index.d.ts
@@ -55,9 +55,9 @@ declare namespace createApplication {
     }
 
     // tslint:disable-next-line void-return
-    type Hook<T = any, S = Service<T>, A = Application> = (context: HookContext<T, S, A>) => (Promise<HookContext<T, S> | void> | HookContext<T, S> | void);
+    type Hook<T = any, S = Service<T>, A extends Application = Application> = (context: HookContext<T, S, A>) => (Promise<HookContext<T, S, A> | void> | HookContext<T, S, A> | void);
 
-    interface HookContext<T = any, S = Service<T>, A = Application> {
+    interface HookContext<T = any, S = Service<T>, A extends Application = any> {
         /**
          * A read only property that contains the Feathers application object. This can be used to
          * retrieve other services (via context.app.service('name')) or configuration values.
@@ -130,21 +130,21 @@ declare namespace createApplication {
         event?: null;
     }
 
-    interface HookMap<T = any, S = Service<T>, A = Application> {
-        all: Hook<T, S, A> | Hook<T, S, A>[];
-        find: Hook<T, S, A> | Hook<T, S, A>[];
-        get: Hook<T, S, A> | Hook<T, S, A>[];
-        create: Hook<T, S, A> | Hook<T, S, A>[];
-        update: Hook<T, S, A> | Hook<T, S, A>[];
-        patch: Hook<T, S, A> | Hook<T, S, A>[];
-        remove: Hook<T, S, A> | Hook<T, S, A>[];
+    interface HookMap<T = any, A extends Application = Application> {
+        all: Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        find: Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        get: Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        create: Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        update: Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        patch: Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+        remove: Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
     }
 
-    interface HooksObject<T = any, A = Application> {
-        before: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
-        after: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
-        error: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
-        finally?: Partial<HookMap<T, Service<T>, A>> | Hook<T, Service<T>, A> | Hook<T, Service<T>, A>[];
+    interface HooksObject<T = any, A extends Application = Application> {
+        before: Partial<HookMap<T, A>> | Hook<T, A> | Hook<T, Service<T>, A>[];
+        after: Partial<HookMap<T, A>> | Hook<T, A> | Hook<T, Service<T>, A>[];
+        error: Partial<HookMap<T, A>> | Hook<T, A> | Hook<T, Service<T>, A>[];
+        finally?: Partial<HookMap<T, A>> | Hook<T, A> | Hook<T, Service<T>, A>[];
     }
 
     interface SetupMethod {
@@ -288,11 +288,11 @@ declare namespace createApplication {
         remove? (id: null, params?: Params): Promise<T[]>;
     }
 
-    interface ServiceAddons<T> extends EventEmitter {
+    interface ServiceAddons<T, A extends Application = Application> extends EventEmitter {
         id?: any;
         _serviceEvents: string[];
         methods: {[method: string]: string[]};
-        hooks (hooks: Partial<HooksObject>): this;
+        hooks<A extends Application = Application> (hooks: Partial<HooksObject<T, A>>): this;
     }
 
     type Service<T> = ServiceOverloads<T> & ServiceAddons<T> & ServiceMethods<T>;


### PR DESCRIPTION
Allow application generic on hooks.

### Summary

This allows you to set up a `HooksObject` with a custom Application interface so you don't need to manually set the typings in each hook.

Before:
```ts
import { Application } from '../../declarations';

const hooks: HooksObject<Data> = {
  before: {
    all: [
      (context) => {
        // need to set the typing to get intellisense for your current application
        (context as { app: Application }).app.service('service').create...
      }
    ]
  }
}
```

After:
```ts
const hooks: HooksObject<Data, Application> = {
  before: {
    all: [
      (context) => {
        // application has services intellisense on the app.service() method
        context.app.service('service').create...
      }
    ]
  }
}
```

### Other Information

This only affects TypeScript users, just a minor change that doesn't have any breaking changes. 