### PR TITLE
fix(socketio-client): Throw an error and show a warning if someone tries to use socket.io-client v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,19 +13,19 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.12.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
-			"integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.7.tgz",
+			"integrity": "sha512-tRKx9B53kJe8NCGGIxEQb2Bkr0riUIEuN7Sc1fxhs5H8lKlCWUvQCSNMVIB0Meva7hcbCRJ76de15KoLltdoqw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.1",
+				"@babel/generator": "^7.12.5",
 				"@babel/helper-module-transforms": "^7.12.1",
-				"@babel/helpers": "^7.12.1",
-				"@babel/parser": "^7.12.3",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
+				"@babel/helpers": "^7.12.5",
+				"@babel/parser": "^7.12.7",
+				"@babel/template": "^7.12.7",
+				"@babel/traverse": "^7.12.7",
+				"@babel/types": "^7.12.7",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
@@ -37,9 +37,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -85,12 +85,12 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-			"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -120,12 +120,12 @@
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
+			"integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/helper-replace-supers": {
@@ -187,43 +187,43 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-			"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+			"integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
 			"dev": true
 		},
 		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-			"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.7.tgz",
+			"integrity": "sha512-nMWaqsQEeSvMNypswUDzjqQ+0rR6pqCtoQpsqGJC4/Khm9cISwPTSpai57F6/jDaOoEGz8yE/WxcO3PV6tKSmQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/generator": "^7.12.5",
 				"@babel/helper-function-name": "^7.10.4",
 				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.5",
-				"@babel/types": "^7.12.5",
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -232,9 +232,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.12.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-			"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+			"integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
@@ -1438,9 +1438,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.14.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-			"integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+			"version": "14.14.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.9.tgz",
+			"integrity": "sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -4570,12 +4570,6 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-negative-zero": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
-			"dev": true
-		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -4862,9 +4856,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -7364,67 +7358,23 @@
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
-			"integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+			"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				}
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
-			"integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+			"integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				}
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string_decoder": {
@@ -7757,9 +7707,9 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.11.5",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
-			"integrity": "sha512-btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.0.tgz",
+			"integrity": "sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA==",
 			"dev": true,
 			"optional": true
 		},

--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -65,7 +65,7 @@ export class AuthenticationClient {
 
     socket.on(disconnected, () => {
       const authPromise = new Promise(resolve =>
-        socket.once(connected, () => resolve())
+        socket.once(connected, (data: any) => resolve(data))
       )
       // Only reconnect when `reAuthenticate()` or `authenticate()`
       // has been called explicitly first

--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -104,7 +104,7 @@ export default (options: OauthSetupSettings) => {
           ...payload
         };
 
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
           if (!req.session.destroy) {
             req.session = null;
             resolve();

--- a/packages/authentication-oauth/test/express.test.ts
+++ b/packages/authentication-oauth/test/express.test.ts
@@ -9,7 +9,7 @@ describe('@feathersjs/authentication-oauth/express', () => {
   before(async () => {
     server = app.listen(9876);
 
-    await new Promise(resolve => server.once('listening', () => resolve()));
+    await new Promise<void>(resolve => server.once('listening', () => resolve()));
   });
 
   after(() => server.close());

--- a/packages/socketio-client/lib/index.js
+++ b/packages/socketio-client/lib/index.js
@@ -9,7 +9,7 @@ function socketioClient (connection, options) {
     connection.io.engine.transport && connection.io.engine.transport.query &&
     connection.io.engine.transport.query.EIO > 3
   ) {
-    // eslint-disable-next-line no-console
+    // tslint:disable-next-line
     console.error('You are trying to use the Socket.io client version 3 or later with Feathers v4 which only supports Socket.io version 2. Please use socket.io-client version 2 instead.');
     throw new Error('socket.io-client must be version 2.x');
   }

--- a/packages/socketio-client/lib/index.js
+++ b/packages/socketio-client/lib/index.js
@@ -5,6 +5,15 @@ function socketioClient (connection, options) {
     throw new Error('Socket.io connection needs to be provided');
   }
 
+  if (connection && connection.io && connection.io.engine &&
+    connection.io.engine.transport && connection.io.engine.transport.query &&
+    connection.io.engine.transport.query.EIO > 3
+  ) {
+    // eslint-disable-next-line no-console
+    console.error('You are trying to use the Socket.io client version 3 or later with Feathers v4 which only supports Socket.io version 2. Please use socket.io-client version 2 instead.');
+    throw new Error('socket.io-client must be version 2.x');
+  }
+
   const defaultService = function (name) {
     const events = Object.keys(this.eventMappings || {})
       .map(method => this.eventMappings[method]);

--- a/packages/transport-commons/test/channels/channel.test.ts
+++ b/packages/transport-commons/test/channels/channel.test.ts
@@ -104,7 +104,7 @@ describe('app.channel', () => {
       it('is an EventEmitter', () => {
         const channel = app.channel('emitchannel');
 
-        return new Promise((resolve) => {
+        return new Promise<void>((resolve) => {
           channel.once('message', data => {
             assert.strictEqual(data, 'hello');
             resolve();


### PR DESCRIPTION
Now that Socket.io is version three with many breaking changes is out and the client is installed separately, if you use incompatible versions, things will just hang and not connect. This is an attempt to throw an error and log a message with more information if you try to use incompatible versions. It's a little hacky but there doesn't seem to be a better way to figure out the Socket.io version based on the `socket` instance.