### PR TITLE
feat: Allow reAuthentication using specific strategy

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -132,7 +132,7 @@ export class AuthenticationClient {
     return Promise.reject(error);
   }
 
-  reAuthenticate (force: boolean = false): Promise<AuthenticationResult> {
+  reAuthenticate (force: boolean = false, strategy?: string): Promise<AuthenticationResult> {
     // Either returns the authentication state or
     // tries to re-authenticate with the stored JWT and strategy
     const authPromise = this.app.get('authentication');
@@ -144,7 +144,7 @@ export class AuthenticationClient {
         }
 
         return this.authenticate({
-          strategy: this.options.jwtStrategy,
+          strategy: strategy || this.options.jwtStrategy,
           accessToken
         });
       });

--- a/packages/authentication-client/test/index.test.ts
+++ b/packages/authentication-client/test/index.test.ts
@@ -202,5 +202,27 @@ describe('@feathersjs/authentication-client', () => {
           assert.ok(!app.get('authentication'));
         });
     });
+
+    it('reauthenticates using different strategy', async () => {
+      app.configure(client({ jwtStrategy: 'any' }));
+
+      const data = {
+        strategy: 'testing'
+      };
+
+      let result = await app.authenticate(data);
+      assert.deepStrictEqual(result, {
+        accessToken,
+        data,
+        user
+      });
+
+      result = await app.authentication.reAuthenticate(false, 'jwt');
+      assert.deepStrictEqual(result, {
+        accessToken,
+        data,
+        user
+      });
+    })
   });
 });


### PR DESCRIPTION
Allow reAuthentication using different strategy.

This use case arises if one were to implement an alternate JWT strategy with existing built-in Feathers JWT strategy