### PR TITLE
feat(memory): Move feathers-memory into @feathersjs/adapter-memory

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -15,7 +15,9 @@
     "**/test/*",
     "**/dist/*",
     "**/*.dist.js",
-    "**/templates/*"
+    "**/templates/*",
+    "**/tests/*",
+    "**/adapter-tests/*"
   ],
   "print": "detail",
   "reporter": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2770,9 +2770,9 @@
 			}
 		},
 		"commander": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-			"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"dev": true
 		},
 		"commondir": {

--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -48,9 +48,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/commons": "^4.5.11",
-    "@feathersjs/errors": "^4.5.11",
-    "@feathersjs/feathers": "^4.5.11"
+    "@feathersjs/commons": "^5.0.0-pre.0",
+    "@feathersjs/errors": "^5.0.0-pre.0",
+    "@feathersjs/feathers": "^5.0.0-pre.0"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.4",

--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathersjs/adapter-commons",
-  "version": "4.5.11",
+  "version": "5.0.0-pre.0",
   "description": "Shared database adapter utility functions",
   "homepage": "https://feathersjs.com",
   "keywords": [

--- a/packages/adapter-memory/CHANGELOG.md
+++ b/packages/adapter-memory/CHANGELOG.md
@@ -1,0 +1,368 @@
+# Change Log
+
+## [v4.1.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v4.1.0) (2019-10-07)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v4.0.1...v4.1.0)
+
+**Merged pull requests:**
+
+- Update all dependencies [\#104](https://github.com/feathersjs-ecosystem/feathers-memory/pull/104) ([daffl](https://github.com/daffl))
+
+## [v4.0.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v4.0.1) (2019-09-29)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v4.0.0...v4.0.1)
+
+**Closed issues:**
+
+- An in-range update of @types/node is breaking the build 🚨 [\#101](https://github.com/feathersjs-ecosystem/feathers-memory/issues/101)
+- An in-range update of webpack is breaking the build 🚨 [\#98](https://github.com/feathersjs-ecosystem/feathers-memory/issues/98)
+
+**Merged pull requests:**
+
+- Pass entity type to AdapterService\<T\> [\#103](https://github.com/feathersjs-ecosystem/feathers-memory/pull/103) ([daffl](https://github.com/daffl))
+- Update semistandard to the latest version 🚀 [\#102](https://github.com/feathersjs-ecosystem/feathers-memory/pull/102) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update dtslint to the latest version 🚀 [\#100](https://github.com/feathersjs-ecosystem/feathers-memory/pull/100) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Greenkeeper/webpack 4.36.1 [\#99](https://github.com/feathersjs-ecosystem/feathers-memory/pull/99) ([daffl](https://github.com/daffl))
+
+## [v4.0.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v4.0.0) (2019-07-05)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v3.0.2...v4.0.0)
+
+**Merged pull requests:**
+
+- Add TypeScript definitions and upgrade to Feathers 4 [\#97](https://github.com/feathersjs-ecosystem/feathers-memory/pull/97) ([daffl](https://github.com/daffl))
+- Update mocha to the latest version 🚀 [\#94](https://github.com/feathersjs-ecosystem/feathers-memory/pull/94) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v3.0.2](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v3.0.2) (2019-01-24)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v3.0.1...v3.0.2)
+
+**Closed issues:**
+
+- Multiple patch records [\#92](https://github.com/feathersjs-ecosystem/feathers-memory/issues/92)
+
+**Merged pull requests:**
+
+- Allow patch to update prop that is within the query [\#93](https://github.com/feathersjs-ecosystem/feathers-memory/pull/93) ([Mattchewone](https://github.com/Mattchewone))
+- Add new tests [\#91](https://github.com/feathersjs-ecosystem/feathers-memory/pull/91) ([daffl](https://github.com/daffl))
+- Update @feathersjs/adapter-commons to the latest version 🚀 [\#90](https://github.com/feathersjs-ecosystem/feathers-memory/pull/90) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v3.0.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v3.0.1) (2018-12-29)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v3.0.0...v3.0.1)
+
+**Merged pull requests:**
+
+- Add default params to hook-less methods [\#89](https://github.com/feathersjs-ecosystem/feathers-memory/pull/89) ([daffl](https://github.com/daffl))
+
+## [v3.0.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v3.0.0) (2018-12-17)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v2.2.0...v3.0.0)
+
+**Closed issues:**
+
+- An in-range update of webpack is breaking the build 🚨 [\#84](https://github.com/feathersjs-ecosystem/feathers-memory/issues/84)
+- An in-range update of @feathersjs/errors is breaking the build 🚨 [\#83](https://github.com/feathersjs-ecosystem/feathers-memory/issues/83)
+
+**Merged pull requests:**
+
+- Update to @feathersjs/adapter-commons and drop Node 6 [\#88](https://github.com/feathersjs-ecosystem/feathers-memory/pull/88) ([daffl](https://github.com/daffl))
+- Update semistandard to the latest version 🚀 [\#87](https://github.com/feathersjs-ecosystem/feathers-memory/pull/87) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update all dependencies and Webpack build [\#85](https://github.com/feathersjs-ecosystem/feathers-memory/pull/85) ([daffl](https://github.com/daffl))
+- Update babel-loader to the latest version 🚀 [\#81](https://github.com/feathersjs-ecosystem/feathers-memory/pull/81) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v2.2.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v2.2.0) (2018-08-26)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v2.1.3...v2.2.0)
+
+**Closed issues:**
+
+- Previously functional batch service no longer works when creating in-memory service [\#77](https://github.com/feathersjs-ecosystem/feathers-memory/issues/77)
+
+**Merged pull requests:**
+
+- Remove cloneDeep dependency [\#80](https://github.com/feathersjs-ecosystem/feathers-memory/pull/80) ([daffl](https://github.com/daffl))
+- Fix cloning of instances [\#79](https://github.com/feathersjs-ecosystem/feathers-memory/pull/79) ([homerjam](https://github.com/homerjam))
+- Update sift to the latest version 🚀 [\#76](https://github.com/feathersjs-ecosystem/feathers-memory/pull/76) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v2.1.3](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v2.1.3) (2018-06-11)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v2.1.2...v2.1.3)
+
+**Closed issues:**
+
+- Use with create-react-app [\#74](https://github.com/feathersjs-ecosystem/feathers-memory/issues/74)
+
+**Merged pull requests:**
+
+- Transpile all Feathers modules for distributable [\#75](https://github.com/feathersjs-ecosystem/feathers-memory/pull/75) ([saiichihashimoto](https://github.com/saiichihashimoto))
+- Update shx to the latest version 🚀 [\#73](https://github.com/feathersjs-ecosystem/feathers-memory/pull/73) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v2.1.2](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v2.1.2) (2018-06-03)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v2.1.1...v2.1.2)
+
+**Merged pull requests:**
+
+- Update uberproto to the latest version 🚀 [\#72](https://github.com/feathersjs-ecosystem/feathers-memory/pull/72) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update clone-deep to the latest version 🚀 [\#70](https://github.com/feathersjs-ecosystem/feathers-memory/pull/70) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v2.1.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v2.1.1) (2018-03-07)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v2.1.0...v2.1.1)
+
+**Closed issues:**
+
+- Why are all the data deleted after the server is rebooted? [\#68](https://github.com/feathersjs-ecosystem/feathers-memory/issues/68)
+
+**Merged pull requests:**
+
+- Update webpack to the latest version 🚀 [\#69](https://github.com/feathersjs-ecosystem/feathers-memory/pull/69) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update clone-deep to the latest version 🚀 [\#67](https://github.com/feathersjs-ecosystem/feathers-memory/pull/67) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update mocha to the latest version 🚀 [\#66](https://github.com/feathersjs-ecosystem/feathers-memory/pull/66) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update semistandard to the latest version 🚀 [\#65](https://github.com/feathersjs-ecosystem/feathers-memory/pull/65) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v2.1.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v2.1.0) (2017-12-03)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v2.0.0...v2.1.0)
+
+**Merged pull requests:**
+
+- Use namespaced module name for exporting [\#64](https://github.com/feathersjs-ecosystem/feathers-memory/pull/64) ([daffl](https://github.com/daffl))
+
+## [v2.0.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v2.0.0) (2017-12-03)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v1.3.1...v2.0.0)
+
+**Merged pull requests:**
+
+- Client build [\#63](https://github.com/feathersjs-ecosystem/feathers-memory/pull/63) ([daffl](https://github.com/daffl))
+- Upgrade to Feathers Buzzard \(v3\) [\#62](https://github.com/feathersjs-ecosystem/feathers-memory/pull/62) ([daffl](https://github.com/daffl))
+- Update to new plugin infrastructure [\#61](https://github.com/feathersjs-ecosystem/feathers-memory/pull/61) ([daffl](https://github.com/daffl))
+- Update clone-deep to the latest version 🚀 [\#60](https://github.com/feathersjs-ecosystem/feathers-memory/pull/60) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v1.3.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v1.3.1) (2017-10-20)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v1.3.0...v1.3.1)
+
+**Closed issues:**
+
+- Custom $select returning `id` [\#58](https://github.com/feathersjs-ecosystem/feathers-memory/issues/58)
+- Best practice for $search [\#51](https://github.com/feathersjs-ecosystem/feathers-memory/issues/51)
+
+**Merged pull requests:**
+
+- Do not select the id by default [\#59](https://github.com/feathersjs-ecosystem/feathers-memory/pull/59) ([daffl](https://github.com/daffl))
+
+## [v1.3.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v1.3.0) (2017-10-19)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v1.2.1...v1.3.0)
+
+**Merged pull requests:**
+
+- Modified matcher to use new sift package [\#57](https://github.com/feathersjs-ecosystem/feathers-memory/pull/57) ([Mattchewone](https://github.com/Mattchewone))
+- Update mocha to the latest version 🚀 [\#56](https://github.com/feathersjs-ecosystem/feathers-memory/pull/56) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v1.2.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v1.2.1) (2017-09-13)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v1.2.0...v1.2.1)
+
+## [v1.2.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v1.2.0) (2017-09-13)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v1.1.0...v1.2.0)
+
+**Closed issues:**
+
+- \[RFE\] An option to set the type of the id field to String [\#54](https://github.com/feathersjs-ecosystem/feathers-memory/issues/54)
+
+**Merged pull requests:**
+
+- Deep clone objects before returning [\#55](https://github.com/feathersjs-ecosystem/feathers-memory/pull/55) ([daffl](https://github.com/daffl))
+- Update feathers-socketio to the latest version 🚀 [\#52](https://github.com/feathersjs-ecosystem/feathers-memory/pull/52) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update feathers-service-tests to the latest version 🚀 [\#50](https://github.com/feathersjs-ecosystem/feathers-memory/pull/50) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update semistandard to the latest version 🚀 [\#49](https://github.com/feathersjs-ecosystem/feathers-memory/pull/49) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update dependencies to enable Greenkeeper 🌴 [\#48](https://github.com/feathersjs-ecosystem/feathers-memory/pull/48) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v1.1.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v1.1.0) (2017-01-31)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v1.0.1...v1.1.0)
+
+**Merged pull requests:**
+
+- Allow to pass a custom matcher and sorter in the options [\#47](https://github.com/feathersjs-ecosystem/feathers-memory/pull/47) ([daffl](https://github.com/daffl))
+- Change `var` to `const`, fix a mistake with `feathers-memory` requiring [\#46](https://github.com/feathersjs-ecosystem/feathers-memory/pull/46) ([osenvosem](https://github.com/osenvosem))
+
+## [v1.0.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v1.0.1) (2016-11-15)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v1.0.0...v1.0.1)
+
+**Merged pull requests:**
+
+- feathers-service-tests@0.9.1 breaks build 🚨 [\#45](https://github.com/feathersjs-ecosystem/feathers-memory/pull/45) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
+## [v1.0.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v1.0.0) (2016-11-11)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.8.1...v1.0.0)
+
+**Closed issues:**
+
+- Support $select for gets [\#35](https://github.com/feathersjs-ecosystem/feathers-memory/issues/35)
+
+**Merged pull requests:**
+
+- Update feathers-service-tests to version 0.9.0 🚀 [\#44](https://github.com/feathersjs-ecosystem/feathers-memory/pull/44) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Update feathers-commons to version 0.8.0 🚀 [\#43](https://github.com/feathersjs-ecosystem/feathers-memory/pull/43) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
+## [v0.8.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.8.1) (2016-11-02)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.8.0...v0.8.1)
+
+**Merged pull requests:**
+
+- fix $select with more than one field [\#42](https://github.com/feathersjs-ecosystem/feathers-memory/pull/42) ([t2t2](https://github.com/t2t2))
+- babel-preset-es2015@6.18.0 breaks build 🚨 [\#41](https://github.com/feathersjs-ecosystem/feathers-memory/pull/41) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Two tweaks for clean build and tests on Windows [\#38](https://github.com/feathersjs-ecosystem/feathers-memory/pull/38) ([ghost](https://github.com/ghost))
+- jshint —\> semistandard [\#37](https://github.com/feathersjs-ecosystem/feathers-memory/pull/37) ([marshallswain](https://github.com/marshallswain))
+- adding code coverage reporting [\#36](https://github.com/feathersjs-ecosystem/feathers-memory/pull/36) ([ekryski](https://github.com/ekryski))
+- Update feathers-service-tests to version 0.8.0 🚀 [\#32](https://github.com/feathersjs-ecosystem/feathers-memory/pull/32) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
+## [v0.8.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.8.0) (2016-09-08)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.7.5...v0.8.0)
+
+**Closed issues:**
+
+- Remove object from memory once sent? [\#30](https://github.com/feathersjs-ecosystem/feathers-memory/issues/30)
+
+**Merged pull requests:**
+
+- Update service tests, id and events option [\#31](https://github.com/feathersjs-ecosystem/feathers-memory/pull/31) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Update mocha to version 3.0.0 🚀 [\#29](https://github.com/feathersjs-ecosystem/feathers-memory/pull/29) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
+## [v0.7.5](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.7.5) (2016-07-25)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.7.4...v0.7.5)
+
+## [v0.7.4](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.7.4) (2016-07-21)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.7.3...v0.7.4)
+
+**Merged pull requests:**
+
+- Update feathers-query-filters to version 2.0.0 🚀 [\#28](https://github.com/feathersjs-ecosystem/feathers-memory/pull/28) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
+## [v0.7.3](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.7.3) (2016-06-16)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.7.2...v0.7.3)
+
+**Merged pull requests:**
+
+- Update feathers-service-tests to version 0.6.0 🚀 [\#27](https://github.com/feathersjs-ecosystem/feathers-memory/pull/27) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
+## [v0.7.2](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.7.2) (2016-06-14)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.7.1...v0.7.2)
+
+**Closed issues:**
+
+- Support $search [\#14](https://github.com/feathersjs-ecosystem/feathers-memory/issues/14)
+
+**Merged pull requests:**
+
+- Use the original id if it can be coerced [\#26](https://github.com/feathersjs-ecosystem/feathers-memory/pull/26) ([daffl](https://github.com/daffl))
+- mocha@2.5.0 breaks build 🚨 [\#25](https://github.com/feathersjs-ecosystem/feathers-memory/pull/25) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Update babel-plugin-add-module-exports to version 0.2.0 🚀 [\#24](https://github.com/feathersjs-ecosystem/feathers-memory/pull/24) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
+## [v0.7.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.7.1) (2016-04-05)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.7.0...v0.7.1)
+
+## [v0.7.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.7.0) (2016-04-04)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.6.3...v0.7.0)
+
+**Merged pull requests:**
+
+- Move to feathers-commons utilities [\#20](https://github.com/feathersjs-ecosystem/feathers-memory/pull/20) ([daffl](https://github.com/daffl))
+
+## [v0.6.3](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.6.3) (2016-02-25)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.6.2...v0.6.3)
+
+**Closed issues:**
+
+- Upgrade to lodash 4 [\#17](https://github.com/feathersjs-ecosystem/feathers-memory/issues/17)
+
+**Merged pull requests:**
+
+- Use individual Lodash methods [\#19](https://github.com/feathersjs-ecosystem/feathers-memory/pull/19) ([daffl](https://github.com/daffl))
+
+## [v0.6.2](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.6.2) (2016-02-24)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.6.1...v0.6.2)
+
+**Merged pull requests:**
+
+- bumping feathers-errors version [\#16](https://github.com/feathersjs-ecosystem/feathers-memory/pull/16) ([ekryski](https://github.com/ekryski))
+
+## [v0.6.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.6.1) (2016-02-22)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.6.0...v0.6.1)
+
+**Merged pull requests:**
+
+- Exmaple update [\#15](https://github.com/feathersjs-ecosystem/feathers-memory/pull/15) ([ekryski](https://github.com/ekryski))
+
+## [v0.6.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.6.0) (2016-01-30)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.5.3...v0.6.0)
+
+**Merged pull requests:**
+
+- Use internal methods instead of service methods directly [\#13](https://github.com/feathersjs-ecosystem/feathers-memory/pull/13) ([daffl](https://github.com/daffl))
+
+## [v0.5.3](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.5.3) (2016-01-23)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.5.2...v0.5.3)
+
+## [v0.5.2](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.5.2) (2016-01-23)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.5.1...v0.5.2)
+
+**Merged pull requests:**
+
+- Adding nsp check [\#12](https://github.com/feathersjs-ecosystem/feathers-memory/pull/12) ([marshallswain](https://github.com/marshallswain))
+
+## [v0.5.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.5.1) (2015-12-19)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.5.0...v0.5.1)
+
+## [v0.5.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.5.0) (2015-12-03)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.4.1...v0.5.0)
+
+## [v0.4.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.4.1) (2015-12-03)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/v0.4.0...v0.4.1)
+
+**Merged pull requests:**
+
+- Use ES6 classes, Promises and support pagination [\#11](https://github.com/feathersjs-ecosystem/feathers-memory/pull/11) ([daffl](https://github.com/daffl))
+
+## [v0.4.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/v0.4.0) (2015-11-07)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.3.4...v0.4.0)
+
+**Closed issues:**
+
+- How properly append values to an existing memory element [\#9](https://github.com/feathersjs-ecosystem/feathers-memory/issues/9)
+- how to initialize memory on app startup [\#8](https://github.com/feathersjs-ecosystem/feathers-memory/issues/8)
+- Add query-filter support [\#7](https://github.com/feathersjs-ecosystem/feathers-memory/issues/7)
+- Remove sorting and other processing from core service [\#4](https://github.com/feathersjs-ecosystem/feathers-memory/issues/4)
+
+**Merged pull requests:**
+
+- Migrate to ES6 plugin infrastructure and shared feathers-service-tests [\#10](https://github.com/feathersjs-ecosystem/feathers-memory/pull/10) ([daffl](https://github.com/daffl))
+- Added support for simple query in find [\#6](https://github.com/feathersjs-ecosystem/feathers-memory/pull/6) ([ruimgoncalves](https://github.com/ruimgoncalves))
+
+## [0.3.4](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.3.4) (2014-09-25)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.3.3...0.3.4)
+
+**Closed issues:**
+
+- Query and persisting Data [\#5](https://github.com/feathersjs-ecosystem/feathers-memory/issues/5)
+
+## [0.3.3](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.3.3) (2014-06-13)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.3.2...0.3.3)
+
+## [0.3.2](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.3.2) (2014-06-13)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.3.1...0.3.2)
+
+## [0.3.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.3.1) (2014-06-13)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.3.0...0.3.1)
+
+**Closed issues:**
+
+- Fix peer dependency [\#3](https://github.com/feathersjs-ecosystem/feathers-memory/issues/3)
+- Should support `patch` service method [\#2](https://github.com/feathersjs-ecosystem/feathers-memory/issues/2)
+- Need to return proper errors [\#1](https://github.com/feathersjs-ecosystem/feathers-memory/issues/1)
+
+## [0.3.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.3.0) (2014-06-05)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.2.1...0.3.0)
+
+## [0.2.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.2.1) (2014-06-04)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.2.0...0.2.1)
+
+## [0.2.0](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.2.0) (2014-04-22)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.1.2...0.2.0)
+
+## [0.1.2](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.1.2) (2014-04-11)
+[Full Changelog](https://github.com/feathersjs-ecosystem/feathers-memory/compare/0.1.1...0.1.2)
+
+## [0.1.1](https://github.com/feathersjs-ecosystem/feathers-memory/tree/0.1.1) (2014-04-11)
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/packages/adapter-memory/LICENSE
+++ b/packages/adapter-memory/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Feathers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/adapter-memory/README.md
+++ b/packages/adapter-memory/README.md
@@ -1,0 +1,96 @@
+# @feathersjs/adapter-memory
+
+[![CI](https://github.com/feathersjs/feathers/workflows/CI/badge.svg)](https://github.com/feathersjs/feathers/actions?query=workflow%3ACI)
+[![Dependency Status](https://img.shields.io/david/feathersjs/feathers.svg?style=flat-square&path=packages/memory)](https://david-dm.org/feathersjs/feathers?path=packages/memory)
+[![Download Status](https://img.shields.io/npm/dm/@feathersjs/adapter-memory.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/adapter-memory)
+
+A [Feathers](https://feathersjs.com) service adapter for in-memory data storage that works on all platforms.
+
+```bash
+$ npm install --save @feathersjs/adapter-memory
+```
+
+> __Important:__ `@feathersjs/adapter-memory` implements the [Feathers Common database adapter API](https://docs.feathersjs.com/api/databases/common.html) and [querying syntax](https://docs.feathersjs.com/api/databases/querying.html).
+
+
+## API
+
+### `service([options])`
+
+Returns a new service instance initialized with the given options.
+
+```js
+const service = require('@feathersjs/adapter-memory');
+
+app.use('/messages', service());
+app.use('/messages', service({ id, startId, store, events, paginate }));
+```
+
+__Options:__
+
+- `id` (*optional*, default: `'id'`) - The name of the id field property.
+- `startId` (*optional*, default: `0`) - An id number to start with that will be incremented for every new record (unless it is already set).
+- `store` (*optional*) - An object with id to item assignments to pre-initialize the data store
+- `events` (*optional*) - A list of [custom service events](https://docs.feathersjs.com/api/events.html#custom-events) sent by this service
+- `paginate` (*optional*) - A [pagination object](https://docs.feathersjs.com/api/databases/common.html#pagination) containing a `default` and `max` page size
+- `whitelist` (*optional*) - A list of additional query parameters to allow
+- `multi` (*optional*) - Allow `create` with arrays and `update` and `remove` with `id` `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
+
+## Example
+
+Here is an example of a Feathers server with a `messages` in-memory service that supports pagination:
+
+```
+$ npm install @feathersjs/feathers @feathersjs/express @feathersjs/socketio @feathersjs/errors @feathersjs/adapter-memory
+```
+
+In `app.js`:
+
+```js
+const feathers = require('@feathersjs/feathers');
+const express = require('@feathersjs/express');
+const socketio = require('@feathersjs/socketio');
+
+const memory = require('@feathersjs/adapter-memory');
+
+// Create an Express compatible Feathers application instance.
+const app = express(feathers());
+// Turn on JSON parser for REST services
+app.use(express.json());
+// Turn on URL-encoded parser for REST services
+app.use(express.urlencoded({ extended: true }));
+// Enable REST services
+app.configure(express.rest());
+// Enable REST services
+app.configure(socketio());
+// Create an in-memory Feathers service with a default page size of 2 items
+// and a maximum size of 4
+app.use('/messages', memory({
+  paginate: {
+    default: 2,
+    max: 4
+  }
+}));
+// Set up default error handler
+app.use(express.errorHandler());
+
+// Create a dummy Message
+app.service('messages').create({
+  text: 'Message created on server'
+}).then(message => console.log('Created message', message));
+
+// Start the server.
+const port = 3030;
+
+app.listen(port, () => {
+  console.log(`Feathers server listening on port ${port}`)
+});
+```
+
+Run the example with `node app` and go to [localhost:3030/messages](http://localhost:3030/messages).
+
+## License
+
+Copyright (c) 2017
+
+Licensed under the [MIT license](LICENSE).

--- a/packages/adapter-memory/package.json
+++ b/packages/adapter-memory/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "feathers-memory",
+  "description": "An in memory service store",
+  "version": "5.0.0-pre.0",
+  "homepage": "https://github.com/feathersjs/databases",
+  "main": "lib/",
+  "keywords": [
+    "feathers",
+    "feathers-plugin"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/feathersjs/databases.git"
+  },
+  "author": {
+    "name": "Feathers contributors",
+    "email": "hello@feathersjs.com",
+    "url": "https://feathersjs.com"
+  },
+  "contributors": [],
+  "bugs": {
+    "url": "https://github.com/feathersjs/databases/issues"
+  },
+  "engines": {
+    "node": ">= 12"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md",
+    "src/**",
+    "lib/**",
+    "*.js"
+  ],
+  "scripts": {
+    "prepublish": "npm run compile",
+    "compile": "shx rm -rf lib/ && tsc",
+    "test": "npm run compile && npm run mocha",
+    "mocha": "mocha --config ../../.mocharc.ts.json --recursive test/**.test.ts test/**/*.test.ts"
+  },
+  "directories": {
+    "lib": "lib"
+  },
+  "dependencies": {
+    "@feathersjs/adapter-commons": "^5.0.0-pre.0",
+    "@feathersjs/commons": "^5.0.0-pre.0",
+    "@feathersjs/errors": "^5.0.0-pre.0",
+    "sift": "^12.0.0"
+  },
+  "devDependencies": {
+    "@feathersjs/adapter-tests": "^5.0.0-pre.0",
+    "@types/mocha": "^8.0.4",
+    "@types/node": "^14.14.10",
+    "mocha": "^8.2.1",
+    "shx": "^0.3.3",
+    "ts-node": "^9.1.0",
+    "typescript": "^4.1.2"
+  }
+}

--- a/packages/adapter-memory/src/index.ts
+++ b/packages/adapter-memory/src/index.ts
@@ -1,0 +1,156 @@
+import { NotFound } from '@feathersjs/errors';
+import { _ } from '@feathersjs/commons';
+import { sorter, select, AdapterService, ServiceOptions, InternalServiceMethods } from '@feathersjs/adapter-commons';
+import sift from 'sift';
+import { Params, NullableId, Id } from '@feathersjs/feathers';
+
+export interface MemoryServiceStore<T> {
+  [key: string]: T;
+}
+
+export interface MemoryServiceOptions<T = any> extends ServiceOptions {
+  store: MemoryServiceStore<T>;
+  startId: number;
+  matcher?: (query: any) => any;
+  sorter?: (sort: any) => any;
+}
+
+const _select = (data: any, params: any, ...args: any[]) => {
+  const base = select(params, ...args);
+
+  return base(JSON.parse(JSON.stringify(data)));
+};
+
+export class MemoryService<T = any> extends AdapterService<T> implements InternalServiceMethods<T> {
+  options: MemoryServiceOptions;
+  store: MemoryServiceStore<T>;
+  _uId: number;
+
+  constructor (options: Partial<MemoryServiceOptions<T>> = {}) {
+    super(_.extend({
+      id: 'id',
+      matcher: sift,
+      sorter
+    }, options));
+    this._uId = options.startId || 0;
+    this.store = options.store || {};
+  }
+
+  async getEntries (params = {}) {
+    const { query } = this.filterQuery(params);
+
+    return this._find(Object.assign({}, params, {
+      paginate: false,
+      query
+    }) as any) as Promise<T[]>;
+  }
+
+  async _find (params: Params = {}) {
+    const { query, filters, paginate } = this.filterQuery(params);
+    let values = _.values(this.store).filter(this.options.matcher(query));
+    const total = values.length;
+
+    if (filters.$sort !== undefined) {
+      values.sort(this.options.sorter(filters.$sort));
+    }
+
+    if (filters.$skip !== undefined) {
+      values = values.slice(filters.$skip);
+    }
+
+    if (filters.$limit !== undefined) {
+      values = values.slice(0, filters.$limit);
+    }
+
+    const result = {
+      total,
+      limit: filters.$limit,
+      skip: filters.$skip || 0,
+      data: values.map(value => _select(value, params))
+    };
+
+    if (!(paginate && (paginate as any).default)) {
+      return result.data;
+    }
+
+    return result;
+  }
+
+  async _get (id: Id, params: Params = {}) {
+    if (id in this.store) {
+      const { query } = this.filterQuery(params);
+      const value = this.store[id];
+
+      if (this.options.matcher(query)(value)) {
+        return _select(value, params, this.id);
+      }
+    }
+
+    throw new NotFound(`No record found for id '${id}'`);
+  }
+
+  // Create without hooks and mixins that can be used internally
+  async _create (data: Partial<T> | Partial<T>[], params: Params = {}): Promise<T | T[]> {
+    if (Array.isArray(data)) {
+      return Promise.all(data.map(current => this._create(current, params) as Promise<T>));
+    }
+
+    const id = (data as any)[this.id] || this._uId++;
+    const current = _.extend({}, data, { [this.id]: id });
+    const result = (this.store[id] = current);
+
+    return _select(result, params, this.id);
+  }
+
+  async _update (id: NullableId, data: T, params: Params = {}) {
+    const oldEntry = await this._get(id);
+    // We don't want our id to change type if it can be coerced
+    const oldId = oldEntry[this.id];
+
+    // tslint:disable-next-line
+    id = oldId == id ? oldId : id; 
+
+    this.store[id] = _.extend({}, data, { [this.id]: id });
+
+    return this._get(id, params);
+  }
+
+  async _patch (id: NullableId, data: Partial<T>, params: Params = {}) {
+    const patchEntry = (entry: T) => {
+      const currentId = (entry as any)[this.id];
+
+      this.store[currentId] = _.extend(this.store[currentId], _.omit(data, this.id));
+
+      return _select(this.store[currentId], params, this.id);
+    };
+
+    if (id === null) {
+      const entries = await this.getEntries(params);
+
+      return entries.map(patchEntry);
+    }
+
+    return patchEntry(await this._get(id, params)); // Will throw an error if not found
+  }
+
+  // Remove without hooks and mixins that can be used internally
+  async _remove (id: NullableId, params: Params = {}): Promise<T|T[]> {
+    if (id === null) {
+      const entries = await this.getEntries(params);
+
+      return Promise.all(entries.map(current =>
+        this._remove((current as any)[this.id], params) as Promise<T>
+      ));
+    }
+
+    const entry = await this._get(id, params);
+
+    delete this.store[id];
+
+    return entry;
+  }
+}
+
+export function memory (options: Partial<MemoryServiceOptions> = {}) {
+  return new MemoryService(options);
+}

--- a/packages/adapter-memory/test/index.test.ts
+++ b/packages/adapter-memory/test/index.test.ts
@@ -1,0 +1,188 @@
+import assert from 'assert';
+import adapterTests from '@feathersjs/adapter-tests';
+import errors from '@feathersjs/errors';
+import feathers from '@feathersjs/feathers';
+
+import { memory } from '../src';
+
+const testSuite = adapterTests([
+  '.options',
+  '.events',
+  '._get',
+  '._find',
+  '._create',
+  '._update',
+  '._patch',
+  '._remove',
+  '.get',
+  '.get + $select',
+  '.get + id + query',
+  '.get + NotFound',
+  '.get + id + query id',
+  '.find',
+  '.remove',
+  '.remove + $select',
+  '.remove + id + query',
+  '.remove + multi',
+  '.remove + id + query id',
+  '.update',
+  '.update + $select',
+  '.update + id + query',
+  '.update + NotFound',
+  '.update + id + query id',
+  '.patch',
+  '.patch + $select',
+  '.patch + id + query',
+  '.patch multiple',
+  '.patch multi query',
+  '.patch + NotFound',
+  '.patch + id + query id',
+  '.create',
+  '.create + $select',
+  '.create multi',
+  'internal .find',
+  'internal .get',
+  'internal .create',
+  'internal .update',
+  'internal .patch',
+  'internal .remove',
+  '.find + equal',
+  '.find + equal multiple',
+  '.find + $sort',
+  '.find + $sort + string',
+  '.find + $limit',
+  '.find + $limit 0',
+  '.find + $skip',
+  '.find + $select',
+  '.find + $or',
+  '.find + $in',
+  '.find + $nin',
+  '.find + $lt',
+  '.find + $lte',
+  '.find + $gt',
+  '.find + $gte',
+  '.find + $ne',
+  '.find + $gt + $lt + $sort',
+  '.find + $or nested + $sort',
+  '.find + paginate',
+  '.find + paginate + $limit + $skip',
+  '.find + paginate + $limit 0',
+  '.find + paginate + params'
+]);
+
+describe('Feathers Memory Service', () => {
+  const events = [ 'testing' ];
+  const app = feathers()
+    .use('/people', memory({ events }))
+    .use('/people-customid', memory({
+      id: 'customid', events
+    }));
+
+  it('update with string id works', async () => {
+    const people = app.service('people');
+    const person = await people.create({
+      name: 'Tester',
+      age: 33
+    });
+
+    const updatedPerson = await people.update(person.id.toString(), person);
+
+    assert.strictEqual(typeof updatedPerson.id, 'number');
+
+    await people.remove(person.id.toString());
+  });
+
+  it('patch record with prop also in query', async () => {
+    app.use('/animals', memory({ multi: true }));
+    const animals = app.service('animals');
+    await animals.create([{
+      type: 'cat',
+      age: 30
+    }, {
+      type: 'dog',
+      age: 10
+    }]);
+
+    const [updated] = await animals.patch(null, { age: 40 }, { query: { age: 30 } });
+
+    assert.strictEqual(updated.age, 40);
+
+    await animals.remove(null, {});
+  });
+
+  it('allows to pass custom find and sort matcher', async () => {
+    let sorterCalled = false;
+    let matcherCalled = false;
+
+    app.use('/matcher', memory({
+      matcher () {
+        matcherCalled = true;
+        return function () {
+          return true;
+        };
+      },
+
+      sorter () {
+        sorterCalled = true;
+        return function () {
+          return 0;
+        };
+      }
+    }));
+
+    await app.service('matcher').find({
+      query: { $sort: { something: 1 } }
+    });
+
+    assert.ok(sorterCalled, 'sorter called');
+    assert.ok(matcherCalled, 'matcher called');
+  });
+
+  it('does not modify the original data', async () => {
+    const people = app.service('people');
+
+    const person = await people.create({
+      name: 'Delete tester',
+      age: 33
+    });
+
+    delete person.age;
+
+    const otherPerson = await people.get(person.id);
+
+    assert.strictEqual(otherPerson.age, 33);
+
+    await people.remove(person.id);
+  });
+
+  it('does not $select the id', async () => {
+    const people = app.service('people');
+    const person = await people.create({
+      name: 'Tester'
+    });
+    const results = await people.find({
+      query: {
+        name: 'Tester',
+        $select: ['name']
+      }
+    });
+
+    assert.deepStrictEqual(results[0], { name: 'Tester' },
+      'deepEquals the same'
+    );
+
+    await people.remove(person.id);
+  });
+
+  it('update with null throws error', async () => {
+    try {
+      await app.service('people').update(null, {});
+      throw new Error('Should never get here');
+    } catch (error) {
+      assert.strictEqual(error.message, `You can not replace multiple instances. Did you mean 'patch'?`);
+    }
+  });
+
+  testSuite(app, errors, 'people');
+  testSuite(app, errors, 'people-customid', 'customid');
+});

--- a/packages/adapter-memory/tsconfig.json
+++ b/packages/adapter-memory/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "outDir": "lib"    
+  }
+}

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathersjs/adapter-tests",
-  "version": "4.5.11",
+  "version": "5.0.0-pre.0",
   "description": "Feathers shared database adapter test suite",
   "homepage": "https://feathersjs.com",
   "keywords": [


### PR DESCRIPTION
This pull request moves [feathers-memory](https://github.com/feathersjs-ecosystem/feathers-memory) into `@feathersjs/adapter-memory`. Now that the `feathersjs/databases` repository has been archived this reference implementation should be a part of the main repo so that the common test suite is actually covered in the automated tests.