### PR TITLE
feat(core): Remove Uberproto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,17 +216,17 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+			"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.10",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.10",
-				"@babel/types": "^7.12.10",
+				"@babel/code-frame": "^7.12.11",
+				"@babel/generator": "^7.12.11",
+				"@babel/helper-function-name": "^7.12.11",
+				"@babel/helper-split-export-declaration": "^7.12.11",
+				"@babel/parser": "^7.12.11",
+				"@babel/types": "^7.12.12",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
@@ -241,9 +241,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+			"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.12.11",
@@ -2035,28 +2035,28 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+			"integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.3",
+				"@nodelib/fs.stat": "2.0.4",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+			"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+			"integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.3",
+				"@nodelib/fs.scandir": "2.1.4",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -2509,9 +2509,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.14.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-			"integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+			"version": "14.14.20",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+			"integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -2521,186 +2521,70 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.1.tgz",
-			"integrity": "sha512-fABclAX2QIEDmTMk6Yd7Muv1CzFLwWM4505nETzRHpP3br6jfahD9UUJkhnJ/g2m7lwfz8IlswcwGGPGiq9exw==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.12.0.tgz",
+			"integrity": "sha512-wHKj6q8s70sO5i39H2g1gtpCXCvjVszzj6FFygneNFyIAxRvNSVz9GML7XpqrB9t7hNutXw+MHnLN/Ih6uyB8Q==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.11.1",
-				"@typescript-eslint/scope-manager": "4.11.1",
+				"@typescript-eslint/experimental-utils": "4.12.0",
+				"@typescript-eslint/scope-manager": "4.12.0",
 				"debug": "^4.1.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.0.0",
 				"semver": "^7.3.2",
 				"tsutils": "^3.17.1"
-			},
-			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz",
-					"integrity": "sha512-Al2P394dx+kXCl61fhrrZ1FTI7qsRDIUiVSuN6rTwss6lUn8uVO2+nnF4AvO0ug8vMsy3ShkbxLu/uWZdTtJMQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"@typescript-eslint/visitor-keys": "4.11.1"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.1.tgz",
-					"integrity": "sha512-5kvd38wZpqGY4yP/6W3qhYX6Hz0NwUbijVsX2rxczpY6OXaMxh0+5E5uLJKVFwaBM7PJe1wnMym85NfKYIh6CA==",
-					"dev": true
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz",
-					"integrity": "sha512-IrlBhD9bm4bdYcS8xpWarazkKXlE7iYb1HzRuyBP114mIaj5DJPo11Us1HgH60dTt41TCZXMaTCAW+OILIYPOg==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.1.tgz",
-			"integrity": "sha512-mAlWowT4A6h0TC9F+J5pdbEhjNiEMO+kqPKQ4sc3fVieKL71dEqfkKgtcFVSX3cjSBwYwhImaQ/mXQF0oaI38g==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.12.0.tgz",
+			"integrity": "sha512-MpXZXUAvHt99c9ScXijx7i061o5HEjXltO+sbYfZAAHxv3XankQkPaNi5myy0Yh0Tyea3Hdq1pi7Vsh0GJb0fA==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/scope-manager": "4.11.1",
-				"@typescript-eslint/types": "4.11.1",
-				"@typescript-eslint/typescript-estree": "4.11.1",
+				"@typescript-eslint/scope-manager": "4.12.0",
+				"@typescript-eslint/types": "4.12.0",
+				"@typescript-eslint/typescript-estree": "4.12.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
-			},
-			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz",
-					"integrity": "sha512-Al2P394dx+kXCl61fhrrZ1FTI7qsRDIUiVSuN6rTwss6lUn8uVO2+nnF4AvO0ug8vMsy3ShkbxLu/uWZdTtJMQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"@typescript-eslint/visitor-keys": "4.11.1"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.1.tgz",
-					"integrity": "sha512-5kvd38wZpqGY4yP/6W3qhYX6Hz0NwUbijVsX2rxczpY6OXaMxh0+5E5uLJKVFwaBM7PJe1wnMym85NfKYIh6CA==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.1.tgz",
-					"integrity": "sha512-tC7MKZIMRTYxQhrVAFoJq/DlRwv1bnqA4/S2r3+HuHibqvbrPcyf858lNzU7bFmy4mLeIHFYr34ar/1KumwyRw==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"@typescript-eslint/visitor-keys": "4.11.1",
-						"debug": "^4.1.1",
-						"globby": "^11.0.1",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^7.3.2",
-						"tsutils": "^3.17.1"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz",
-					"integrity": "sha512-IrlBhD9bm4bdYcS8xpWarazkKXlE7iYb1HzRuyBP114mIaj5DJPo11Us1HgH60dTt41TCZXMaTCAW+OILIYPOg==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.11.1.tgz",
-			"integrity": "sha512-BJ3jwPQu1jeynJ5BrjLuGfK/UJu6uwHxJ/di7sanqmUmxzmyIcd3vz58PMR7wpi8k3iWq2Q11KMYgZbUpRoIPw==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.12.0.tgz",
+			"integrity": "sha512-9XxVADAo9vlfjfoxnjboBTxYOiNY93/QuvcPgsiKvHxW6tOZx1W4TvkIQ2jB3k5M0pbFP5FlXihLK49TjZXhuQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.11.1",
-				"@typescript-eslint/types": "4.11.1",
-				"@typescript-eslint/typescript-estree": "4.11.1",
+				"@typescript-eslint/scope-manager": "4.12.0",
+				"@typescript-eslint/types": "4.12.0",
+				"@typescript-eslint/typescript-estree": "4.12.0",
 				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz",
-					"integrity": "sha512-Al2P394dx+kXCl61fhrrZ1FTI7qsRDIUiVSuN6rTwss6lUn8uVO2+nnF4AvO0ug8vMsy3ShkbxLu/uWZdTtJMQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"@typescript-eslint/visitor-keys": "4.11.1"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.1.tgz",
-					"integrity": "sha512-5kvd38wZpqGY4yP/6W3qhYX6Hz0NwUbijVsX2rxczpY6OXaMxh0+5E5uLJKVFwaBM7PJe1wnMym85NfKYIh6CA==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.1.tgz",
-					"integrity": "sha512-tC7MKZIMRTYxQhrVAFoJq/DlRwv1bnqA4/S2r3+HuHibqvbrPcyf858lNzU7bFmy4mLeIHFYr34ar/1KumwyRw==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"@typescript-eslint/visitor-keys": "4.11.1",
-						"debug": "^4.1.1",
-						"globby": "^11.0.1",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^7.3.2",
-						"tsutils": "^3.17.1"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz",
-					"integrity": "sha512-IrlBhD9bm4bdYcS8xpWarazkKXlE7iYb1HzRuyBP114mIaj5DJPo11Us1HgH60dTt41TCZXMaTCAW+OILIYPOg==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.11.1",
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz",
-			"integrity": "sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.12.0.tgz",
+			"integrity": "sha512-QVf9oCSVLte/8jvOsxmgBdOaoe2J0wtEmBr13Yz0rkBNkl5D8bfnf6G4Vhox9qqMIoG7QQoVwd2eG9DM/ge4Qg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.11.0",
-				"@typescript-eslint/visitor-keys": "4.11.0"
+				"@typescript-eslint/types": "4.12.0",
+				"@typescript-eslint/visitor-keys": "4.12.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.0.tgz",
-			"integrity": "sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.12.0.tgz",
+			"integrity": "sha512-N2RhGeheVLGtyy+CxRmxdsniB7sMSCfsnbh8K/+RUIXYYq3Ub5+sukRCjVE80QerrUBvuEvs4fDhz5AW/pcL6g==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz",
-			"integrity": "sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.12.0.tgz",
+			"integrity": "sha512-gZkFcmmp/CnzqD2RKMich2/FjBTsYopjiwJCroxqHZIY11IIoN0l5lKqcgoAPKHt33H2mAkSfvzj8i44Jm7F4w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.11.0",
-				"@typescript-eslint/visitor-keys": "4.11.0",
+				"@typescript-eslint/types": "4.12.0",
+				"@typescript-eslint/visitor-keys": "4.12.0",
 				"debug": "^4.1.1",
 				"globby": "^11.0.1",
 				"is-glob": "^4.0.1",
@@ -2710,12 +2594,12 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz",
-			"integrity": "sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.12.0.tgz",
+			"integrity": "sha512-hVpsLARbDh4B9TKYz5cLbcdMIOAoBYgFPCSP9FFS/liSF+b33gVNq8JHY3QGhHNVz85hObvL7BEYLlgx553WCw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.11.0",
+				"@typescript-eslint/types": "4.12.0",
 				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
@@ -4036,9 +3920,9 @@
 			"dev": true
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz",
-			"integrity": "sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+			"integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0",
@@ -4996,9 +4880,9 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "30.7.9",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.9.tgz",
-			"integrity": "sha512-qMM0fNx7/6OCnIh3jRpIrEBAhTG1THNXXbr3yfJ8yqLrDbzJR98xsstX25xt9GCPlrjNc/bBpTHfJQOvn7nVMA==",
+			"version": "30.7.13",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz",
+			"integrity": "sha512-YM4WIsmurrp0rHX6XiXQppqKB8Ne5ATiZLJe2+/fkp9l9ExXFr43BbAbjZaVrpCT+tuPYOZ8k1MICARHnURUNQ==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "^0.7.6",
@@ -7809,9 +7693,9 @@
 			}
 		},
 		"meow": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
-			"integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.0.tgz",
+			"integrity": "sha512-fNWkgM1UVMey2kf24yLiccxLihc5W+6zVus3/N0b+VfnJgxV99E9u04X6NAiKdg6ED7DAQBX5sy36NM0QJZkWA==",
 			"dev": true,
 			"requires": {
 				"@types/minimist": "^1.2.0",
@@ -8003,18 +7887,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.27",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"version": "2.1.28",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+			"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.44.0"
+				"mime-db": "1.45.0"
 			}
 		},
 		"mimic-fn": {
@@ -11219,9 +11103,9 @@
 			"dev": true
 		},
 		"tsutils": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.18.0.tgz",
+			"integrity": "sha512-D9Tu8nE3E7D1Bsf/V29oMHceMf+gnVO+pDguk/A5YRo1cLpkiQ48ZnbbS57pvvHeY+OIeNQx1vf4ASPlEtRpcA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -11279,9 +11163,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.12.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.3.tgz",
-			"integrity": "sha512-feZzR+kIcSVuLi3s/0x0b2Tx4Iokwqt+8PJM7yRHKuldg4MLdam4TCFeICv+lgDtuYiCtdmrtIP+uN9LWvDasw==",
+			"version": "3.12.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.4.tgz",
+			"integrity": "sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==",
 			"dev": true,
 			"optional": true
 		},

--- a/packages/adapter-tests/src/methods.ts
+++ b/packages/adapter-tests/src/methods.ts
@@ -539,7 +539,7 @@ export default (test: any, app: any, _errors: any, serviceName: string, idProp: 
       let throwing: any;
 
       before(() => {
-        throwing = app.service(serviceName).extend({
+        throwing = Object.assign(Object.create(app.service(serviceName)), {
           get store () {
             return app.service(serviceName).store;
           },

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -54,8 +54,7 @@
     "@types/express": "^4.17.9",
     "debug": "^4.3.1",
     "express": "^4.17.1",
-    "lodash": "^4.17.20",
-    "uberproto": "^2.0.6"
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@feathersjs/authentication": "^5.0.0-pre.1",

--- a/packages/express/src/rest/index.ts
+++ b/packages/express/src/rest/index.ts
@@ -9,16 +9,10 @@ const HTTP_METHOD = Symbol('@feathersjs/express/rest/HTTP_METHOD');
 
 export function httpMethod (verb: any, uris?: any) {
   return (method: any) => {
-    Object.defineProperty(method, HTTP_METHOD, {
-      enumerable: false,
-      configurable: true,
-      writable: false,
-      value: (Array.isArray(uris) ? uris : [uris])
-        .reduce(
-          (result, uri) => ([...result, { verb, uri }]),
-          method[HTTP_METHOD] || []
-        )
-    });
+    method[HTTP_METHOD] = (Array.isArray(uris) ? uris : [uris]).reduce(
+      (result, uri) => ([...result, { verb, uri }]),
+      method[HTTP_METHOD] || []
+    );
 
     return method;
   };

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -59,8 +59,7 @@
     "@feathersjs/commons": "^5.0.0-pre.1",
     "@feathersjs/hooks": "^0.6.1",
     "debug": "^4.3.1",
-    "events": "^3.2.0",
-    "uberproto": "^2.0.6"
+    "events": "^3.2.0"
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -47,7 +47,8 @@
     "version": "npm run write-version",
     "publish": "npm run reset-version",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
+    "test": "npm run compile && npm run mocha",
+    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "engines": {
     "node": ">= 12"

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -100,8 +100,9 @@ export default {
       throw new Error(`Invalid service object passed for path \`${location}\``);
     }
 
-    // Create a new object with the prototype pointing to the original service
-    const protoService = Object.create(service);
+    // User use existing service or create a new object with prototype pointing to original
+    const isFeathersService = typeof service.hooks === 'function' && (service as any)._serviceEvents;
+    const protoService = isFeathersService ? service : Object.create(service);
 
     debug(`Registering new service at \`${location}\``);
 

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -100,7 +100,7 @@ export default {
       throw new Error(`Invalid service object passed for path \`${location}\``);
     }
 
-    // User use existing service or create a new object with prototype pointing to original
+    // Use existing service or create a new object with prototype pointing to original
     const isFeathersService = typeof service.hooks === 'function' && (service as any)._serviceEvents;
     const protoService = isFeathersService ? service : Object.create(service);
 

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -1,18 +1,12 @@
 import Debug from 'debug';
 import { stripSlashes } from '@feathersjs/commons';
 
-// @ts-ignore
-import Uberproto from 'uberproto';
 import events from './events';
 import hooks from './hooks';
 import version from './version';
 import { BaseApplication, Service } from './declarations';
 
 const debug = Debug('feathers:application');
-
-const Proto = Uberproto.extend({
-  create: null
-});
 
 interface AppExtensions {
   _isSetup: boolean;
@@ -106,8 +100,8 @@ export default {
       throw new Error(`Invalid service object passed for path \`${location}\``);
     }
 
-    // If the service is already Uberproto'd use it directly
-    const protoService = Proto.isPrototypeOf(service) ? service : Proto.extend(service);
+    // Create a new object with the prototype pointing to the original service
+    const protoService = Object.create(service);
 
     debug(`Registering new service at \`${location}\``);
 

--- a/packages/feathers/src/events.ts
+++ b/packages/feathers/src/events.ts
@@ -30,7 +30,7 @@ export function eventMixin (this: Application, service: Service<any>) {
   const isEmitter = typeof service.on === 'function' &&
     typeof service.emit === 'function';
 
-  // If not, mix add EventEmitter functionality
+  // If not, add EventEmitter functionality
   if (!isEmitter) {
     Object.assign(service, EventEmitter.prototype);
   }

--- a/packages/feathers/src/events.ts
+++ b/packages/feathers/src/events.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Proto from 'uberproto';
 import { EventEmitter } from 'events';
 import { HookContext, Service, Application } from './declarations';
 
@@ -32,9 +30,9 @@ export function eventMixin (this: Application, service: Service<any>) {
   const isEmitter = typeof service.on === 'function' &&
     typeof service.emit === 'function';
 
-  // If not, mix it in (the service is always an Uberproto object that has a .mixin)
-  if (typeof service.mixin === 'function' && !isEmitter) {
-    service.mixin(EventEmitter.prototype);
+  // If not, mix add EventEmitter functionality
+  if (!isEmitter) {
+    Object.assign(service, EventEmitter.prototype);
   }
 
   // Define non-enumerable properties of
@@ -81,7 +79,7 @@ export default function () {
     app.hooks({ finally: eventHook() });
 
     // Make the app an event emitter
-    Proto.mixin(EventEmitter.prototype, app);
+    Object.assign(app, EventEmitter.prototype);
 
     app.mixins.push(eventMixin);
   };

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -89,25 +89,29 @@ function withHooks (app: Application, service: Service<any>, methods: string[]) 
   hooksDecorator(service, hookMap);
 }
 
-const mixinMethod = (_super: any) => function (this: any) {
-  const service = this;
-  const args = Array.from(arguments);
+const mixinMethod = (_super: any) => {
+  const result = function (this: any) {
+    const service = this;
+    const args = Array.from(arguments);
+  
+    const returnHook = args[args.length - 1] === true || args[args.length - 1] instanceof HookContext
+      ? args.pop() : false;
+  
+    const hookContext = returnHook instanceof HookContext ? returnHook : _super.createContext();
+  
+    return _super.call(service, ...args, hookContext)
+      .then(() => returnHook ? hookContext : hookContext.result)
+      // Handle errors
+      .catch(() => {
+        if (typeof hookContext.error !== 'undefined' && typeof hookContext.result === 'undefined') {
+          return Promise.reject(returnHook ? hookContext : hookContext.error);
+        } else {
+          return returnHook ? hookContext : hookContext.result;
+        }
+      });
+  };
 
-  const returnHook = args[args.length - 1] === true || args[args.length - 1] instanceof HookContext
-    ? args.pop() : false;
-
-  const hookContext = returnHook instanceof HookContext ? returnHook : _super.createContext();
-
-  return _super.call(service, ...args, hookContext)
-    .then(() => returnHook ? hookContext : hookContext.result)
-    // Handle errors
-    .catch(() => {
-      if (typeof hookContext.error !== 'undefined' && typeof hookContext.result === 'undefined') {
-        return Promise.reject(returnHook ? hookContext : hookContext.error);
-      } else {
-        return returnHook ? hookContext : hookContext.result;
-      }
-    });
+  return Object.assign(result, _super);
 }
 
 // A service mixin that adds `service.hooks()` method and functionality
@@ -116,7 +120,7 @@ const hookMixin = exports.hookMixin = function hookMixin (service: any) {
     return;
   }
 
-  service.methods = Object.getOwnPropertyNames(service)
+  service.methods = Object.getOwnPropertyNames(Object.getPrototypeOf(service))
     .filter(key => typeof service[key] === 'function' && service[key][ACTIVATE_HOOKS])
     .reduce((result, methodName) => {
       result[methodName] = service[methodName][ACTIVATE_HOOKS];

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -93,12 +93,12 @@ const mixinMethod = (_super: any) => {
   const result = function (this: any) {
     const service = this;
     const args = Array.from(arguments);
-  
+
     const returnHook = args[args.length - 1] === true || args[args.length - 1] instanceof HookContext
       ? args.pop() : false;
-  
+
     const hookContext = returnHook instanceof HookContext ? returnHook : _super.createContext();
-  
+
     return _super.call(service, ...args, hookContext)
       .then(() => returnHook ? hookContext : hookContext.result)
       // Handle errors

--- a/packages/feathers/src/index.ts
+++ b/packages/feathers/src/index.ts
@@ -1,16 +1,9 @@
-// @ts-ignore
-import Proto from 'uberproto';
 import Application from './application';
 import version from './version';
 import { Application as ApplicationType } from './declarations'
 
-const baseObject = Object.create(null);
-
 export default function feathers<ServiceTypes = {}> (): ApplicationType<ServiceTypes> {
-  const app = Object.create(baseObject);
-
-  // Mix in the base application
-  Proto.mixin(Application, app);
+  const app = Object.create(Application);
 
   app.init();
 

--- a/packages/feathers/src/index.ts
+++ b/packages/feathers/src/index.ts
@@ -3,11 +3,11 @@ import version from './version';
 import { Application as ApplicationType } from './declarations'
 
 export default function feathers<ServiceTypes = {}> (): ApplicationType<ServiceTypes> {
-  const app = Object.create(Application);
+  const app = Object.assign({}, Application);
 
   app.init();
 
-  return app;
+  return app as any as ApplicationType<ServiceTypes>;
 }
 
 export { version };

--- a/packages/feathers/test/application.test.ts
+++ b/packages/feathers/test/application.test.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Proto from 'uberproto';
 import assert from 'assert';
 import feathers, { Id, version } from '../src'
 import { HookContext } from '@feathersjs/hooks';
@@ -117,7 +115,7 @@ describe('Feathers application', () => {
       const app = feathers().use('/dummy', dummyService);
       const wrappedService = app.service('dummy');
 
-      assert.ok(Proto.isPrototypeOf(wrappedService), 'Service got wrapped as Uberproto object');
+      assert.strictEqual(Object.getPrototypeOf(wrappedService), dummyService, 'Object points to original service prototype');
 
       return wrappedService.create({
         message: 'Test message'

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -52,8 +52,7 @@
   "dependencies": {
     "@feathersjs/transport-commons": "^5.0.0-pre.1",
     "debug": "^4.3.1",
-    "socket.io": "^3.0.4",
-    "uberproto": "^2.0.6"
+    "socket.io": "^3.0.4"
   },
   "devDependencies": {
     "@feathersjs/adapter-memory": "^5.0.0-pre.1",


### PR DESCRIPTION
This pull request removes dependency on the dated [Uberproto](https://github.com/daffl/uberproto) library which is a utility for ES5 inheritance. Instead, built-in JavaScript functionality (`Object.create` and `Object.assign`) is now used together with the recommended ES6 classes.

Everything will continue to work as is except for the `service.mixin()` method, which will no longer be available (but can usually be replaced with a simple `Object.assign`).