### PR TITLE
fix: Add fallback for breaking Socket.io change

### DIFF
--- a/packages/socketio/lib/index.js
+++ b/packages/socketio/lib/index.js
@@ -58,6 +58,9 @@ function configureSocketio (port, options, config) {
             // of event listeners (e.g. by registering 10 services).
             // So we set it to a higher number. 64 should be enough for everyone.
             io.sockets.setMaxListeners(64);
+            io.origins((_, callback) => {
+              callback(null, true);
+            });
           }
 
           if (typeof config === 'function') {


### PR DESCRIPTION
Related to https://github.com/feathersjs/feathers/issues/2128#issuecomment-755590395 this pull request adds the not-really recommended fallback because otherwise even reinstalling your packages will break clients from being able to reconnect.