### PR TITLE
feat(authentication-client): Throw separate OauthError in authentication client

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -3,6 +3,12 @@ import { Application, Params } from '@feathersjs/feathers';
 import { AuthenticationRequest, AuthenticationResult } from '@feathersjs/authentication';
 import { Storage, StorageWrapper } from './storage';
 
+class OauthError extends FeathersError {
+  constructor (message: string, data?: any) {
+    super(message, 'OauthError', 401, 'oauth-error', data);
+  }
+}
+
 const getMatch = (location: Location, key: string): [ string, RegExp ] => {
   const regex = new RegExp(`(?:\&?)${key}=([^&]*)`);
   const match = location.hash ? location.hash.match(regex) : null;
@@ -90,7 +96,7 @@ export class AuthenticationClient {
     if (message !== null) {
       location.hash = location.hash.replace(errorRegex, '');
 
-      return Promise.reject(new NotAuthenticated(decodeURIComponent(message)));
+      return Promise.reject(new OauthError(decodeURIComponent(message)));
     }
 
     return Promise.resolve(null);

--- a/packages/authentication-client/test/index.test.ts
+++ b/packages/authentication-client/test/index.test.ts
@@ -91,7 +91,7 @@ describe('@feathersjs/authentication-client', () => {
       } as Location);
       assert.fail('Should never get here');
     } catch (error) {
-      assert.strictEqual(error.name, 'NotAuthenticated');
+      assert.strictEqual(error.name, 'OauthError');
       assert.strictEqual(error.message, 'Error Happened');
     }
   });


### PR DESCRIPTION
This pull request throws a new `OauthError` in the authentication client when an error has been passed in the URL through the oAuth flow.

Closes #1668