### PR TITLE
fix(adapter-commons): Return missing overloads

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -171,6 +171,9 @@ export class AdapterService<T = any> implements ServiceMethods<T|Paginated<T>> {
     return callMethod(this, '_get', id, params);
   }
 
+  create (data: Partial<T>, params?: Params): Promise<T>;
+  create (data: Partial<T>[], params?: Params): Promise<T[]>;
+  create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]>;
   create (data: Partial<T> | Partial<T>[], params?: Params): Promise<T | T[]> {
     if (Array.isArray(data) && !this.allowsMulti('create')) {
       return Promise.reject(new MethodNotAllowed('Can not create multiple entries'));
@@ -189,6 +192,9 @@ export class AdapterService<T = any> implements ServiceMethods<T|Paginated<T>> {
     return callMethod(this, '_update', id, data, params);
   }
 
+  patch (id: Id, data: Partial<T>, params?: Params): Promise<T>;
+  patch (id: null, data: Partial<T>, params?: Params): Promise<T[]>;
+  patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]>;
   patch (id: NullableId, data: Partial<T>, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('patch')) {
       return Promise.reject(new MethodNotAllowed('Can not patch multiple entries'));
@@ -197,6 +203,9 @@ export class AdapterService<T = any> implements ServiceMethods<T|Paginated<T>> {
     return callMethod(this, '_patch', id, data, params);
   }
 
+  remove (id: Id, params?: Params): Promise<T>;
+  remove (id: null, params?: Params): Promise<T[]>;
+  remove (id: NullableId, params?: Params): Promise<T | T[]>;
   remove (id: NullableId, params?: Params): Promise<T | T[]> {
     if (id === null && !this.allowsMulti('remove')) {
       return Promise.reject(new MethodNotAllowed('Can not remove multiple entries'));


### PR DESCRIPTION
Same as before, were lost in transition back somehow.

Related PRs: #1567, #1717, #1838, [#4](https://github.com/feathersjs-ecosystem/databases/pull/4)


