### PR TITLE
chore: Remove sponsors from readme and update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/adapter-commons/LICENSE
+++ b/packages/adapter-commons/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/adapter-memory/LICENSE
+++ b/packages/adapter-memory/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/adapter-tests/LICENSE
+++ b/packages/adapter-tests/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication-client/LICENSE
+++ b/packages/authentication-client/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication-local/LICENSE
+++ b/packages/authentication-local/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication-oauth/LICENSE
+++ b/packages/authentication-oauth/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication/LICENSE
+++ b/packages/authentication/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/commons/LICENSE
+++ b/packages/commons/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/configuration/LICENSE
+++ b/packages/configuration/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/errors/LICENSE
+++ b/packages/errors/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/express/LICENSE
+++ b/packages/express/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/feathers/LICENSE
+++ b/packages/feathers/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/rest-client/LICENSE
+++ b/packages/rest-client/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/socketio-client/LICENSE
+++ b/packages/socketio-client/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/socketio-client/README.md
+++ b/packages/socketio-client/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers SocketIO API documentation](https://docs.feathersjs.com/a
 
 ## License
 
-Copyright (c) 2020 [Feathers contributors](https://github.com/feathersjs/client/graphs/contributors)
+Copyright (c) 2021 [Feathers contributors](https://github.com/feathersjs/client/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/socketio/LICENSE
+++ b/packages/socketio/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/tests/LICENSE
+++ b/packages/tests/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/transport-commons/LICENSE
+++ b/packages/transport-commons/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Feathers
+Copyright (c) 2021 Feathers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/readme.md
+++ b/readme.md
@@ -28,84 +28,12 @@ $ npm start
 
 To learn more about Feathers visit the website at [feathersjs.com](http://feathersjs.com) or jump right into [the Feathers guides](http://docs.feathersjs.com/guides).
 
-## Support
-
-### Sponsors
-
-Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/feathers#sponsor)]
-
-<a href="https://opencollective.com/feathers/sponsor/0/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/0/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/1/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/1/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/2/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/2/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/3/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/3/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/4/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/4/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/5/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/5/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/6/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/6/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/7/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/7/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/8/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/9/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/9/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/10/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/10/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/11/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/11/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/12/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/12/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/13/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/13/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/14/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/14/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/15/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/15/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/16/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/16/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/17/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/17/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/18/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/18/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/19/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/19/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/20/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/20/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/21/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/21/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/22/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/22/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/23/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/23/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/24/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/24/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/25/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/25/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/26/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/26/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/27/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/27/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/28/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/28/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/sponsor/29/website" target="_blank"><img src="https://opencollective.com/feathers/sponsor/29/avatar.svg"></a>
-
-### Backers
-
-Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/feathers#backer)]
-
-<a href="https://opencollective.com/feathers/backer/0/website" target="_blank"><img src="https://opencollective.com/feathers/backer/0/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/1/website" target="_blank"><img src="https://opencollective.com/feathers/backer/1/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/2/website" target="_blank"><img src="https://opencollective.com/feathers/backer/2/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/3/website" target="_blank"><img src="https://opencollective.com/feathers/backer/3/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/4/website" target="_blank"><img src="https://opencollective.com/feathers/backer/4/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/5/website" target="_blank"><img src="https://opencollective.com/feathers/backer/5/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/6/website" target="_blank"><img src="https://opencollective.com/feathers/backer/6/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/7/website" target="_blank"><img src="https://opencollective.com/feathers/backer/7/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/8/website" target="_blank"><img src="https://opencollective.com/feathers/backer/8/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/9/website" target="_blank"><img src="https://opencollective.com/feathers/backer/9/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/10/website" target="_blank"><img src="https://opencollective.com/feathers/backer/10/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/11/website" target="_blank"><img src="https://opencollective.com/feathers/backer/11/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/12/website" target="_blank"><img src="https://opencollective.com/feathers/backer/12/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/13/website" target="_blank"><img src="https://opencollective.com/feathers/backer/13/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/14/website" target="_blank"><img src="https://opencollective.com/feathers/backer/14/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/15/website" target="_blank"><img src="https://opencollective.com/feathers/backer/15/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/16/website" target="_blank"><img src="https://opencollective.com/feathers/backer/16/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/17/website" target="_blank"><img src="https://opencollective.com/feathers/backer/17/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/18/website" target="_blank"><img src="https://opencollective.com/feathers/backer/18/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/19/website" target="_blank"><img src="https://opencollective.com/feathers/backer/19/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/20/website" target="_blank"><img src="https://opencollective.com/feathers/backer/20/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/21/website" target="_blank"><img src="https://opencollective.com/feathers/backer/21/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/22/website" target="_blank"><img src="https://opencollective.com/feathers/backer/22/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/23/website" target="_blank"><img src="https://opencollective.com/feathers/backer/23/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/24/website" target="_blank"><img src="https://opencollective.com/feathers/backer/24/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/25/website" target="_blank"><img src="https://opencollective.com/feathers/backer/25/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/26/website" target="_blank"><img src="https://opencollective.com/feathers/backer/26/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/27/website" target="_blank"><img src="https://opencollective.com/feathers/backer/27/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/28/website" target="_blank"><img src="https://opencollective.com/feathers/backer/28/avatar.svg"></a>
-<a href="https://opencollective.com/feathers/backer/29/website" target="_blank"><img src="https://opencollective.com/feathers/backer/29/avatar.svg"></a>
-
 ## Documentation
 
 The [Feathers docs](http://docs.feathersjs.com) are loaded with awesome stuff and tell you every thing you need to know about using and configuring Feathers.
 
 ## License
 
-Copyright (c) 2019 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2021 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
This pull request removes the backer list from the discontinued OpenCollective. I might bring back a list from my [personal sponsorships](https://github.com/sponsors/daffl) but at the moment there are no subscribers to tiers that officially include having your logo on the readme or homepage.