### PR TITLE
fix: Resolve some type problems

### DIFF
--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -6,13 +6,14 @@ import {
 } from '@feathersjs/feathers';
 
 interface ExpressUseHandler<T, ServiceTypes> {
-  <L extends keyof ServiceTypes> (
-    path: ServiceTypes[L] extends never ? string|RegExp : L,
+  <L extends keyof ServiceTypes & string> (
+    path: L,
     ...middlewareOrService: (
       Express|express.RequestHandler|
-      (ServiceTypes[L] extends never ? ServiceInterface<any> : ServiceTypes[L])
+      (keyof any extends keyof ServiceTypes ? ServiceInterface<any> : ServiceTypes[L])
     )[]
   ): T;
+  (path: RegExp, ...expressHandlers: express.RequestHandler[]): T;
   (...expressHandlers: express.RequestHandler[]): T;
   (handler: Express|express.ErrorRequestHandler): T;
 }

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -21,7 +21,7 @@ export * from './declarations';
 
 const debug = Debug('@feathersjs/express');
 
-export default function feathersExpress<S = any, C = any> (feathersApp?: FeathersApplication, expressApp: Express = express()): Application<S, C> {
+export default function feathersExpress<S = any, C = any> (feathersApp?: FeathersApplication<S, C>, expressApp: Express = express()): Application<S, C> {
   if (!feathersApp) {
     return expressApp as any;
   }
@@ -62,7 +62,7 @@ export default function feathersExpress<S = any, C = any> (feathersApp?: Feather
 
       debug('Registering service with middleware', middleware);
       // Since this is a service, call Feathers `.use`
-      feathersApp.use.call(this, location, service, { middleware });
+      (feathersApp as FeathersApplication).use.call(this, location, service, { middleware });
 
       return this;
     },

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -75,7 +75,7 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
 
   use<L extends keyof ServiceTypes & string> (
     path: L,
-    service: (keyof any extends keyof ServiceTypes ? ServiceInterface<any> : ServiceTypes[L]) | Application,
+    service: keyof any extends keyof ServiceTypes ? ServiceInterface<any> | Application : ServiceTypes[L],
     options?: ServiceOptions
   ): this {
     if (typeof path !== 'string') {
@@ -83,7 +83,7 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     }
 
     const location = (stripSlashes(path) || '/') as L;
-    const subApp = service as FeathersApplication;
+    const subApp = service as Application;
     const isSubApp = typeof subApp.service === 'function' && subApp.services;
 
     if (isSubApp) {
@@ -113,7 +113,7 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     return this;
   }
 
-  hooks (hookMap: HookOptions<Application<ServiceTypes, AppSettings>, any>) {
+  hooks (hookMap: HookOptions<this, any>) {
     const legacyMap = hookMap as LegacyHookMap<this, any>;
 
     if (legacyMap.before || legacyMap.after || legacyMap.error) {
@@ -121,7 +121,7 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     }
 
     if (Array.isArray(hookMap)) {
-      this.appHooks[HOOKS].push(...hookMap);
+      this.appHooks[HOOKS].push(...hookMap as any);
     } else {
       const methodHookMap = hookMap as HookMap<Application<ServiceTypes, AppSettings>, any>;
 

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -183,7 +183,7 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
    */
   use<L extends keyof ServiceTypes & string> (
     path: L,
-    service: (keyof any extends keyof ServiceTypes ? ServiceInterface<any> : ServiceTypes[L]) | Application,
+    service: keyof any extends keyof ServiceTypes ? ServiceInterface<any> | Application : ServiceTypes[L],
     options?: ServiceOptions
   ): this;
 
@@ -205,7 +205,7 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
    *
    * @param map The application hook settings.
    */
-  hooks (map: HookOptions<Application<ServiceTypes, AppSettings>, any>): this;
+  hooks (map: HookOptions<this, any>): this;
 }
 
 // This needs to be an interface instead of a type
@@ -309,7 +309,7 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
 
 // Legacy hook typings
 export type LegacyHookFunction<A = Application, S = Service<any, any>> =
-  (this: S, context: HookContext<A, S>) => (Promise<HookContext<A, S> | void> | HookContext<A, S> | void);
+  (this: S, context: HookContext<A, S>) => (Promise<HookContext<Application, S> | void> | HookContext<Application, S> | void);
 
 type LegacyHookMethodMap<A, S> =
   { [L in keyof S]?: SelfOrArray<LegacyHookFunction<A, S>>; } &


### PR DESCRIPTION
Continues #1566.

Don't know why types started to fail only after my changes, but i found and fixed reason for failures:

In [`LegacyHookFunction`](https://github.com/feathersjs/feathers/blob/2fb4cfa19b35f54ed5ff372233aeb50ca6c65dfe/packages/feathers/src/declarations.ts#L311) `app` property on potentially returned context was required to be of the same type as on passed in context. And because of this it was creating variance problems between simple feathers app and express wrapped app, through such forbidden chain:

```ts
(expressApp as FeathersApp).service('some').hooks({after: (context) => ({app: feathersApp, ...otherStuff})});
```

Since we don't care about returned context, simply relaxed type there. In turn such relaxation allowed to improve type of options in `hooks` method of app itself (and not on service through which the problem was exposed).

Other bonus small changes:

- Updated `ExpressUseHandler` as you mentioned. I missed that one, but it was not a cause for the failings. Also created separate overload for when `path` is a regexp.
 
- Keep `ServiceTypes` and `AppSettings` from feathers app during express wrapping.

 - In `app.use` `| Application` should be inside ternary expression, not outside.