### PR TITLE
feat(core): Public custom service methods

### DIFF
--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -33,7 +33,7 @@ export type Application<ServiceTypes = any, AppSettings = any> =
 
 declare module '@feathersjs/feathers/lib/declarations' {
   export interface ServiceOptions {
-    middleware: {
+    middleware?: {
       before: express.RequestHandler[],
       after: express.RequestHandler[]
     }

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -35,12 +35,15 @@ export default function feathersExpress<S = any, C = any> (feathersApp?: Feather
   const mixin: any = {
     use (location: string, ...rest: any[]) {
       let service: any;
-      const middleware = Array.from(arguments).slice(1)
-        .reduce(function (middleware, arg) {
+      let options = {};
+
+      const middleware = rest.reduce(function (middleware, arg) {
           if (typeof arg === 'function' || Array.isArray(arg)) {
             middleware[service ? 'after' : 'before'].push(arg);
           } else if (!service) {
             service = arg;
+          } else if (arg.methods || arg.events) {
+            options = arg;
           } else {
             throw new Error('Invalid options passed to app.use');
           }
@@ -62,7 +65,10 @@ export default function feathersExpress<S = any, C = any> (feathersApp?: Feather
 
       debug('Registering service with middleware', middleware);
       // Since this is a service, call Feathers `.use`
-      (feathersApp as FeathersApplication).use.call(this, location, service, { middleware });
+      (feathersApp as FeathersApplication).use.call(this, location, service, {
+        ...options,
+        middleware
+      });
 
       return this;
     },

--- a/packages/express/src/rest.ts
+++ b/packages/express/src/rest.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import { MethodNotAllowed } from '@feathersjs/errors';
 import { HookContext } from '@feathersjs/hooks';
-import { createContext, getServiceOptions, NullableId, Params } from '@feathersjs/feathers';
+import { createContext, defaultServiceMethods, getServiceOptions, NullableId, Params } from '@feathersjs/feathers';
 import { Request, Response, NextFunction, RequestHandler, Router } from 'express';
 
 import { parseAuthentication } from './authentication';
@@ -94,14 +94,13 @@ export const serviceMiddleware = (callback: ServiceCallback) =>
   }
 
 export const serviceMethodHandler = (
-  service: any, methodName: string, getArgs: (opts: ServiceParams) => any[], header?: string
+  service: any, methodName: string, getArgs: (opts: ServiceParams) => any[], headerOverride?: string
 ) => serviceMiddleware(async (req, res, options) => {
-  const method = (typeof header === 'string' && req.headers[header])
-    ? req.headers[header] as string
-    : methodName
+  const methodOverride = typeof headerOverride === 'string' && (req.headers[headerOverride] as string);
+  const method = methodOverride ? methodOverride : methodName
   const { methods } = getServiceOptions(service);
 
-  if (!methods.includes(method)) {
+  if (!methods.includes(method) || defaultServiceMethods.includes(methodOverride)) {
     res.status(statusCodes.methodNotAllowed);
 
     throw new MethodNotAllowed(`Method \`${method}\` is not supported by this endpoint.`);

--- a/packages/express/test/authentication.test.ts
+++ b/packages/express/test/authentication.test.ts
@@ -174,19 +174,20 @@ describe('@feathersjs/express/authentication', () => {
       });
     });
 
-    it.skip('protected endpoint fails with invalid Authorization header', () => {
-      return axios.get('/protected', {
-        headers: {
-          Authorization: 'Bearer: something wrong'
-        }
-      }).then(() => {
+    it.skip('protected endpoint fails with invalid Authorization header', async () => {
+      try {
+        await axios.get('/protected', {
+          headers: {
+            Authorization: 'Bearer: something wrong'
+          }
+        });
         assert.fail('Should never get here');
-      }).catch(error => {
+      } catch (error) {
         const { data } = error.response;
 
         assert.strictEqual(data.name, 'NotAuthenticated');
         assert.strictEqual(data.message, 'Not authenticated');
-      });
+      }
     });
 
     it('can request protected endpoint with JWT present', () => {

--- a/packages/express/test/rest.test.ts
+++ b/packages/express/test/rest.test.ts
@@ -3,15 +3,18 @@ import { strict as assert } from 'assert';
 import axios, { AxiosRequestConfig } from 'axios';
 
 import { Server } from 'http';
+import { Request, Response, NextFunction } from 'express';
 import { feathers, HookContext, Id, Params } from '@feathersjs/feathers';
 import { Service, restTests } from '@feathersjs/tests';
+import { BadRequest } from '@feathersjs/errors';
 
 import * as express from '../src'
-import { Request, Response, NextFunction } from 'express';
-import { BadRequest } from '@feathersjs/errors/lib';
 
 const expressify = express.default;
 const { rest } = express;
+const errorHandler = express.errorHandler({
+  logger: false
+});
 
 describe('@feathersjs/express/rest provider', () => {
   describe('base functionality', () => {
@@ -526,7 +529,7 @@ describe('@feathersjs/express/rest provider', () => {
             };
           }
         })
-        .use(express.errorHandler());
+        .use(errorHandler);
 
       server = await app.listen(6880);
     });
@@ -575,9 +578,9 @@ describe('@feathersjs/express/rest provider', () => {
         .configure(rest())
         .use(express.json())
         .use('/todo', new Service(), {
-          methods: ['customMethod']
+          methods: ['find', 'customMethod']
         })
-        .use(express.errorHandler());
+        .use(errorHandler);
 
       server = await app.listen(4781);
     });
@@ -599,7 +602,7 @@ describe('@feathersjs/express/rest provider', () => {
       });
     });
 
-    it('throws MethodNotImplement for setup and methods not passed as options', async () => {
+    it('throws MethodNotImplement for .setup, non option and default methods', async () => {
       const options: AxiosRequestConfig = {
         method: 'POST',
         url: 'http://localhost:4781/todo',
@@ -618,7 +621,7 @@ describe('@feathersjs/express/rest provider', () => {
             code: 405,
             className: 'method-not-allowed'
           });
-  
+
           return true;
         });
       }
@@ -626,6 +629,8 @@ describe('@feathersjs/express/rest provider', () => {
       await testMethod('setup');
       await testMethod('internalMethod');
       await testMethod('nonExisting');
+      await testMethod('create');
+      await testMethod('find');
     });
   });
 });

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -101,7 +101,7 @@ export type FeathersService<A = FeathersApplication, S = Service<any>> =
   S & ServiceAddons<A, S> & OptionalPick<ServiceHookOverloads<S>, keyof S>;
 
 export type CustomMethod<Methods extends string> = {
-  [k in Methods]: (data: any, params?: Params) => Promise<any>;
+  [k in Methods]: <X = any> (data: any, params?: Params) => Promise<X>;
 }
 
 export type ServiceMixin<A> = (service: FeathersService<A>, path: string, options?: ServiceOptions) => void;

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -100,6 +100,10 @@ export interface ServiceHookOverloads<S> {
 export type FeathersService<A = FeathersApplication, S = Service<any>> =
   S & ServiceAddons<A, S> & OptionalPick<ServiceHookOverloads<S>, keyof S>;
 
+export type CustomMethod<Methods extends string> = {
+  [k in Methods]: (data: any, params?: Params) => Promise<any>;
+}
+
 export type ServiceMixin<A> = (service: FeathersService<A>, path: string, options?: ServiceOptions) => void;
 
 export type ServiceGenericType<S> = S extends ServiceInterface<infer T> ? T : any;

--- a/packages/feathers/src/service.ts
+++ b/packages/feathers/src/service.ts
@@ -13,7 +13,7 @@ export const defaultServiceArguments = {
   remove: [ 'id', 'params' ]
 }
 
-export const defaultServiceMethods = Object.keys(defaultServiceArguments).concat('setup');
+export const defaultServiceMethods = Object.keys(defaultServiceArguments);
 
 export const defaultEventMap = {
   create: 'created',
@@ -60,7 +60,7 @@ export function wrapService (
   const protoService = Object.create(service);
   const serviceOptions = getServiceOptions(service, options);
 
-  if (Object.keys(serviceOptions.methods).length === 0) {
+  if (Object.keys(serviceOptions.methods).length === 0 && typeof service.setup !== 'function') {
     throw new Error(`Invalid service object passed for path \`${location}\``);
   }
 

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -64,7 +64,6 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.14.35",
     "axios": "^0.21.1",
-    "body-parser": "^1.19.0",
     "mocha": "^8.3.2",
     "node-fetch": "^2.6.1",
     "rxjs": "^6.6.6",

--- a/packages/rest-client/src/fetch.ts
+++ b/packages/rest-client/src/fetch.ts
@@ -14,9 +14,7 @@ export class FetchClient extends Base {
       fetchOptions.body = JSON.stringify(options.body);
     }
 
-    const fetch = this.connection;
-
-    return fetch(options.url, fetchOptions)
+    return this.connection(options.url, fetchOptions)
       .then(this.checkStatus)
       .then((response: any) => {
         if (response.status === 204) {

--- a/packages/rest-client/src/index.ts
+++ b/packages/rest-client/src/index.ts
@@ -36,6 +36,8 @@ export interface Transport {
   axios: Handler;
 }
 
+export type RestService<T = any, D = Partial<any>> = Base<T, D>;
+
 export default function restClient (base = '') {
   const result: any = { Base };
 

--- a/packages/rest-client/test/axios.test.ts
+++ b/packages/rest-client/test/axios.test.ts
@@ -8,13 +8,17 @@ import { NotAcceptable } from '@feathersjs/errors';
 
 import createServer from './server';
 import rest from '../src';
+import { ServiceTypes } from './declarations';
+
 
 describe('Axios REST connector', function () {
   const url = 'http://localhost:8889';
   const setup = rest(url).axios(axios);
-  const app = feathers().configure(setup);
+  const app = feathers<ServiceTypes>().configure(setup);
   const service = app.service('todos');
   let server: Server;
+
+  service.methods('customMethod');
 
   before(async () => {
     server = await createServer().listen(8889);
@@ -112,6 +116,16 @@ describe('Axios REST connector', function () {
       assert.strictEqual(err.message, 'connect ECONNREFUSED 127.0.0.1:60000');
       assert.ok(e.data.config);
     }
+  });
+
+  it('works with custom method .customMethod', async () => {
+    const result = await service.customMethod({ message: 'hi' });
+
+    assert.deepEqual(result, {
+      data: { message: 'hi' },
+      provider: 'rest',
+      type: 'customMethod'
+    });
   });
 
   clientTests(service, 'todos');

--- a/packages/rest-client/test/declarations.ts
+++ b/packages/rest-client/test/declarations.ts
@@ -1,0 +1,6 @@
+import { CustomMethod } from '@feathersjs/feathers';
+import { RestService } from '../src';
+
+export type ServiceTypes = {
+  todos: RestService & CustomMethod<'customMethod'>
+}

--- a/packages/rest-client/test/fetch.test.ts
+++ b/packages/rest-client/test/fetch.test.ts
@@ -4,17 +4,20 @@ import { feathers } from '@feathersjs/feathers';
 import { clientTests } from '@feathersjs/tests';
 import { NotAcceptable } from '@feathersjs/errors';
 import fetch from 'node-fetch';
-
-import createServer from './server';
-import rest from '../src';
 import { Server } from 'http';
+
+import rest from '../src';
+import createServer from './server';
+import { ServiceTypes } from './declarations';
 
 describe('fetch REST connector', function () {
   const url = 'http://localhost:8889';
   const setup = rest(url).fetch(fetch);
-  const app = feathers().configure(setup);
+  const app = feathers<ServiceTypes>().configure(setup);
   const service = app.service('todos');
   let server: Server;
+
+  service.methods('customMethod');
 
   before(async () => {
     server = await createServer().listen(8889);
@@ -114,6 +117,16 @@ describe('fetch REST connector', function () {
     });
 
     assert.strictEqual(response, null)
+  });
+
+  it('works with custom method .customMethod', async () => {
+    const result = await service.customMethod({ message: 'hi' });
+
+    assert.deepEqual(result, {
+      data: { message: 'hi' },
+      provider: 'rest',
+      type: 'customMethod'
+    });
   });
 
   clientTests(service, 'todos');

--- a/packages/rest-client/test/server.ts
+++ b/packages/rest-client/test/server.ts
@@ -1,6 +1,5 @@
-import bodyParser from 'body-parser';
 import { feathers, Id, NullableId, Params } from '@feathersjs/feathers';
-import expressify, { rest } from '@feathersjs/express';
+import expressify, { rest, urlencoded, json } from '@feathersjs/express';
 import { Service } from '@feathersjs/adapter-memory';
 import { FeathersError, NotAcceptable } from '@feathersjs/errors';
 
@@ -59,12 +58,20 @@ class TodoService extends Service {
         id, text: 'deleted many'
       });
     }
-    
+
     if (params.query.noContent) {
       return Promise.resolve();
     }
 
     return super.remove(id, params);
+  }
+
+  async customMethod (data: any, { provider }: Params) {
+    return {
+      data,
+      provider,
+      type: 'customMethod'
+    }
   }
 }
 
@@ -92,10 +99,14 @@ export default (configurer?: any) => {
       next();
     })
     // Parse HTTP bodies
-    .use(bodyParser.json())
-    .use(bodyParser.urlencoded({ extended: true }))
+    .use(json())
+    .use(urlencoded({ extended: true }))
     // Host our Todos service on the /todos path
-    .use('/todos', new TodoService())
+    .use('/todos', new TodoService(), {
+      methods: [
+        'find', 'get', 'create', 'patch', 'update', 'remove', 'customMethod'
+      ]
+    })
     .use(errorHandler);
 
   if (typeof configurer === 'function') {

--- a/packages/rest-client/test/superagent.test.ts
+++ b/packages/rest-client/test/superagent.test.ts
@@ -6,16 +6,19 @@ import { feathers } from '@feathersjs/feathers';
 import { clientTests } from '@feathersjs/tests';
 import { NotAcceptable } from '@feathersjs/errors';
 
-import createServer from './server';
 import rest from '../src';
+import createServer from './server';
+import { ServiceTypes } from './declarations';
 
 describe('Superagent REST connector', function () {
   let server: Server;
 
   const url = 'http://localhost:8889';
   const setup = rest(url).superagent(superagent);
-  const app = feathers().configure(setup);
+  const app = feathers<ServiceTypes>().configure(setup);
   const service = app.service('todos');
+  
+  service.methods('customMethod');
 
   before(async () => {
     server = await createServer().listen(8889);
@@ -95,6 +98,16 @@ describe('Superagent REST connector', function () {
       assert.strictEqual(error.code, 406);
       assert.ok((error as any).response);
     }
+  });
+
+  it('works with custom method .customMethod', async () => {
+    const result = await service.customMethod({ message: 'hi' });
+
+    assert.deepEqual(result, {
+      data: { message: 'hi' },
+      provider: 'rest',
+      type: 'customMethod'
+    });
   });
 
   clientTests(service, 'todos');

--- a/packages/socketio-client/src/index.ts
+++ b/packages/socketio-client/src/index.ts
@@ -1,12 +1,10 @@
-import { Service } from '@feathersjs/transport-commons/client';
+import { Service, SocketService } from '@feathersjs/transport-commons/client';
 import { Socket } from 'socket.io-client';
 import { defaultEventMap } from '@feathersjs/feathers';
 
-interface SocketIOClientOptions {
-    timeout?: number;
-}
+export { SocketService };
 
-function socketioClient (connection: Socket, options?: SocketIOClientOptions) {
+export default function socketioClient (connection: Socket, options?: any) {
   if (!connection) {
     throw new Error('Socket.io connection needs to be provided');
   }
@@ -38,4 +36,6 @@ function socketioClient (connection: Socket, options?: SocketIOClientOptions) {
   return initialize;
 }
 
-export = socketioClient;
+if (typeof module !== 'undefined') {
+  module.exports = Object.assign(socketioClient, module.exports);
+}

--- a/packages/socketio-client/test/server.ts
+++ b/packages/socketio-client/test/server.ts
@@ -29,13 +29,25 @@ class TodoService extends Service {
 
     return Object.assign({ query: params.query }, data)
   }
+
+  async customMethod (data: any, { provider }: Params) {
+    return {
+      data,
+      provider,
+      type: 'customMethod'
+    }
+  }
 }
 
 export function createServer () {
   const app = feathers()
     .configure(socketio())
     .use('/', new TodoService())
-    .use('/todos', new TodoService());
+    .use('/todos', new TodoService(), {
+      methods: [
+        'find', 'get', 'create', 'update', 'patch', 'remove', 'customMethod'
+      ]
+    });
   const service = app.service('todos');
   const rootService = app.service('/');
   const publisher = () => app.channel('general');

--- a/packages/socketio/test/methods.ts
+++ b/packages/socketio/test/methods.ts
@@ -13,11 +13,11 @@ export default (name: string, options: any) => {
       );
     });
 
-  it('invalid arguments cause an error', () =>
-    call('find', 1, {}).catch(e =>
-      assert.strictEqual(e.message, 'Too many arguments for \'find\' method')
-    )
-  );
+  it('invalid arguments cause an error', async () => {
+    await assert.rejects(() => call('find', 1, {}), {
+      message: 'Too many arguments for \'find\' method'
+    });
+  });
 
   it('.find', () => async () => {
     await call('find', {}).then(data => verify.find(data));

--- a/packages/tests/src/fixture.ts
+++ b/packages/tests/src/fixture.ts
@@ -73,6 +73,18 @@ export class Service {
   async remove (id: any) {
     return { id };
   }
+
+  async customMethod (data: any, params: any) {
+    return {
+      data,
+      method: 'customMethod',
+      provider: params.provider
+    };
+  }
+
+  async internalMethod () {
+    throw new Error('Should never get here');
+  }
 }
 
 export const verify = {

--- a/packages/tests/src/rest.ts
+++ b/packages/tests/src/rest.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 import { verify } from './fixture';
 
-export function testRest (description: string, name: string, port: number) {
+export function restTests (description: string, name: string, port: number) {
   describe(description, () => {
     it('GET .find', () => {
       return axios.get(`http://localhost:${port}/${name}`)

--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -10,7 +10,7 @@ const debug = Debug('@feathersjs/transport-commons/channels');
 const { CHANNELS } = keys;
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  interface ServiceAddons<A, S> extends EventEmitter {
+  interface ServiceAddons<A, S> extends EventEmitter { // eslint-disable-line
     publish (publisher: Publisher<ServiceGenericType<S>>): this;
     publish (event: Event, publisher: Publisher<ServiceGenericType<S>>): this;
 

--- a/packages/transport-commons/src/socket/utils.ts
+++ b/packages/transport-commons/src/socket/utils.ts
@@ -1,6 +1,6 @@
 import Debug from 'debug';
 import isEqual from 'lodash/isEqual';
-import { NotFound, MethodNotAllowed } from '@feathersjs/errors';
+import { NotFound, MethodNotAllowed, BadRequest } from '@feathersjs/errors';
 import { HookContext, Application, createContext, getServiceOptions } from '@feathersjs/feathers';
 import { CombinedChannel } from '../channels/channel/combined';
 import { RealTimeConnection } from '../channels/channel/base';
@@ -94,6 +94,11 @@ export async function runMethod (app: Application, connection: RealTimeConnectio
     const query = methodArgs[position] || {};
     // `params` have to be re-mapped to the query and added with the route
     const params = Object.assign({ query, route, connection }, connection);
+
+    // `params` is always the last parameter. Error if we got more arguments.
+    if (methodArgs.length > (position + 1)) {
+      throw new BadRequest(`Too many arguments for '${method}' method`);
+    }
 
     methodArgs[position] = params;
 

--- a/packages/transport-commons/test/channels/index.test.ts
+++ b/packages/transport-commons/test/channels/index.test.ts
@@ -38,7 +38,7 @@ describe('feathers-channels', () => {
         }
       });
 
-    const service = app.service('test') as any;
+    const service: any = app.service('test') ;
 
     assert.ok(!service[keys.PUBLISHERS]);
   });

--- a/packages/transport-commons/test/client.test.ts
+++ b/packages/transport-commons/test/client.test.ts
@@ -1,14 +1,15 @@
 import assert from 'assert';
 import { EventEmitter } from 'events';
+import { CustomMethod } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
-import { Service } from '../src/client';
+import { Service, SocketService } from '../src/client';
 
 declare type DummyCallback = (err: any, data?: any) => void;
 
 describe('client', () => {
   let connection: any;
   let testData: any;
-  let service: Service & EventEmitter;
+  let service: SocketService & CustomMethod<'customMethod'> & EventEmitter;
 
   beforeEach(() => {
     connection = new EventEmitter();
@@ -18,7 +19,7 @@ describe('client', () => {
       name: 'todos',
       method: 'emit',
       connection
-    }) as Service & EventEmitter;
+    }) as any;
   });
 
   it('sets `events` property on service', () => {
@@ -73,78 +74,76 @@ describe('client', () => {
     connection.emit('todos thing', testData);
   });
 
-  it('sends all service methods with acknowledgement', () => {
+  it('sends all service and custom methods with acknowledgement', async () => {
     const idCb = (_path: any, id: any, _params: any, callback: DummyCallback) =>
       callback(null, { id });
     const idDataCb = (_path: any, _id: any, data: any, _params: any, callback: DummyCallback) =>
       callback(null, data);
-
-    connection.once('create', (_path: any, data: any, _params: any, callback: DummyCallback) => {
+    const dataCb = (_path: any, data: any, _params: any, callback: DummyCallback) => {
       data.created = true;
       callback(null, data);
+    };
+
+    connection.once('create', dataCb);
+    service.methods('customMethod');
+
+    let res = await service.create(testData);
+
+    assert.ok(res.created);
+
+    connection.once('get', idCb);
+    res = await service.get(1);
+    assert.deepStrictEqual(res, { id: 1 });
+
+    connection.once('remove', idCb);
+    res = await service.remove(12)
+    assert.deepStrictEqual(res, { id: 12 });
+
+    connection.once('update', idDataCb);
+    res = await service.update(12, testData);
+    assert.deepStrictEqual(res, testData);
+
+    connection.once('patch', idDataCb);
+    res = await service.patch(12, testData);
+    assert.deepStrictEqual(res, testData);
+
+    connection.once('customMethod', dataCb);
+    res = await service.customMethod({ message: 'test' });
+    assert.deepStrictEqual(res, {
+      created: true,
+      message: 'test'
     });
 
-    return service.create(testData)
-      .then((result: any) => assert.ok(result.created))
-      .then(() => {
-        connection.once('get', idCb);
+    connection.once('find', (_path: any, params: any, callback: DummyCallback) =>
+      callback(null, { params })
+    );
 
-        return service.get(1)
-          .then(res => assert.deepStrictEqual(res, { id: 1 }));
-      })
-      .then(() => {
-        connection.once('remove', idCb);
-
-        return service.remove(12)
-          .then(res => assert.deepStrictEqual(res, { id: 12 }));
-      })
-      .then(() => {
-        connection.once('update', idDataCb);
-
-        return service.update(12, testData)
-          .then(res => assert.deepStrictEqual(res, testData));
-      })
-      .then(() => {
-        connection.once('patch', idDataCb);
-
-        return service.patch(12, testData)
-          .then(res => assert.deepStrictEqual(res, testData));
-      })
-      .then(() => {
-        connection.once('find', (_path: any, params: any, callback: DummyCallback) =>
-          callback(null, { params })
-        );
-
-        return service.find({ query: { test: true } }).then((res: any) =>
-          assert.deepStrictEqual(res, {
-            params: { test: true }
-          })
-        );
-      });
+    res = await service.find({ query: { test: true } });
+    assert.deepStrictEqual(res, {
+      params: { test: true }
+    });
   });
 
-  it('converts to feathers-errors (#19)', () => {
+  it('converts to feathers-errors (#19)', async () => {
     connection.once('create', (_path: any, _data: any, _params: any, callback: DummyCallback) =>
       callback(new NotAuthenticated('Test', { hi: 'me' }).toJSON())
     );
 
-    return service.create(testData).catch(error => {
-      assert.ok(error instanceof NotAuthenticated);
-      assert.strictEqual(error.name, 'NotAuthenticated');
-      assert.strictEqual(error.message, 'Test');
-      assert.strictEqual(error.code, 401);
-      assert.deepStrictEqual(error.data, { hi: 'me' });
+    await assert.rejects(() => service.create(testData), {
+      name: 'NotAuthenticated',
+      message: 'Test',
+      code: 401,
+      data: { hi: 'me' }
     });
   });
 
-  it('converts other errors (#19)', () => {
+  it('converts other errors (#19)', async () => {
     connection.once('create', (_path: string, _data: any, _params: any, callback: (x: string) => void) =>
       callback('Something went wrong') // eslint-disable-line
     );
 
-    return service.create(testData).catch(error => {
-      assert.ok(error instanceof Error);
-      assert.strictEqual(error.message, 'Something went wrong');
+    await assert.rejects(() => service.create(testData), {
+      message: 'Something went wrong'
     });
   });
 


### PR DESCRIPTION
This pull request implements tests and client side functionality for custom service methods outlined in and closes #1976.

On the server a custom service method is added like this:

```js
class MyMessageService {
  async create (data, params) {}

  async findOne (data, params) {}

  async resendNotification (data, params) {}
}

app.use('/messages', new MyMessageService(), {
  methods: [ 'create', 'findOne', 'resendNotification' ]
});
```

It can be used via an HTTP and socket API directly as described in #1976.

On the Feathers client it is used like this:

```js
const feathers = require('@feathersjs/feathers');
const socketio = require('@feathersjs/socketio-client');
const io = require('socket.io-client');

const socket = io('http://api.feathersjs.com');
const app = feathers();

// Set up Socket.io client with the socket
app.configure(socketio(socket));

// Since there is no introspection, custom methods need to be initialized on a service
app.service('messages').methods('customMethod', 'findOne');

const message = await app.service('messages').findOne({ userId: 1 });
```

TypeScript has a CustomMethod and client interface:

```ts
import { feathers, CustomMethod } from '@feathersjs/feathers';
import socketio, { SocketClient } from '@feathersjs/socketio-client';
import io from 'socket.io-client';

type ServiceTypes = {
  messages: SocketClient & CustomMethod<'customMethod'|'findOne'>
}

const socket = io('http://api.feathersjs.com');
const app = feathers<ServiceTypes>();

// Set up Socket.io client with the socket
app.configure(socketio(socket));

// Since there is no introspection, custom methods need to be initialized on a service
app.service('messages').methods('customMethod', 'findOne');

const message = await app.service('messages').findOne({ userId: 1 });
```