### PR TITLE
fix(feathers): Always enable hooks on default service methods

### DIFF
--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -1,6 +1,6 @@
 import { getManager, HookContextData, HookManager, HookMap, HOOKS, hooks, Middleware } from '@feathersjs/hooks';
 import { Service, ServiceOptions, HookContext, FeathersService, Application } from '../declarations';
-import { defaultServiceArguments } from '../service';
+import { defaultServiceArguments, defaultServiceMethods } from '../service';
 import {
   collectLegacyHooks,
   enableLegacyHooks,
@@ -59,7 +59,11 @@ export function hookMixin<A> (
   }
 
   const app = this;
-  const serviceMethodHooks = options.methods.reduce((res, method) => {
+  const { methods } = options;
+  const serviceMethods = defaultServiceMethods.filter(m =>
+    typeof (service as any)[m] === 'function' && !methods.includes(m)
+  ).concat(methods);
+  const serviceMethodHooks = serviceMethods.reduce((res, method) => {
     const params = (defaultServiceArguments as any)[method] || [ 'data', 'params' ];
 
     res[method] = new FeathersHookManager<A>(app, method)

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -1,6 +1,6 @@
 import { getManager, HookContextData, HookManager, HookMap, HOOKS, hooks, Middleware } from '@feathersjs/hooks';
 import { Service, ServiceOptions, HookContext, FeathersService, Application } from '../declarations';
-import { defaultServiceArguments, defaultServiceMethods } from '../service';
+import { defaultServiceArguments, getHookMethods } from '../service';
 import {
   collectLegacyHooks,
   enableLegacyHooks,
@@ -59,11 +59,7 @@ export function hookMixin<A> (
   }
 
   const app = this;
-  const { methods } = options;
-  const serviceMethods = defaultServiceMethods.filter(m =>
-    typeof (service as any)[m] === 'function' && !methods.includes(m)
-  ).concat(methods);
-  const serviceMethodHooks = serviceMethods.reduce((res, method) => {
+  const serviceMethodHooks = getHookMethods(service, options).reduce((res, method) => {
     const params = (defaultServiceArguments as any)[method] || [ 'data', 'params' ];
 
     res[method] = new FeathersHookManager<A>(app, method)

--- a/packages/feathers/src/service.ts
+++ b/packages/feathers/src/service.ts
@@ -22,6 +22,14 @@ export const defaultEventMap = {
   remove: 'removed'
 }
 
+export function getHookMethods (service: any, options: ServiceOptions) {
+  const { methods } = options;
+  
+  return defaultServiceMethods.filter(m =>
+    typeof service[m] === 'function' && !methods.includes(m)
+  ).concat(methods);
+}
+
 export function getServiceOptions (
   service: any, options: ServiceOptions = {}
 ): ServiceOptions {

--- a/packages/feathers/test/hooks/hooks.test.ts
+++ b/packages/feathers/test/hooks/hooks.test.ts
@@ -303,10 +303,14 @@ describe('hooks basics', () => {
     });
   });
 
-  it('can register hooks on a custom method', async () => {
+  it('can register hooks on a custom method, still adds hooks to default methods', async () => {
     class Dummy {
       async get (id: Id) {
         return { id };
+      }
+
+      async create (data: any) {
+        return data;
       }
 
       async custom (data: any) {
@@ -322,9 +326,10 @@ describe('hooks basics', () => {
 
     app.service('dummy').hooks({
       custom: [async (context, next) => {
-        (context.data as any).fromHook = true;
+        context.data.fromHook = true;
         await next();
-      }]
+      }],
+      create: [async (_context, next) => next()]
     });
 
     assert.deepStrictEqual(await app.service('dummy').custom({


### PR DESCRIPTION
Follow up for #2270 - default service method should always be enabled for hooks even if they are not passed in the options as an external method.