### PR TITLE
chore(dependencies): Add improved dependency update action

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,31 @@
+name: Update dependencies
+
+on:  
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '15.x'
+    - run: npm ci
+    - run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "hello@feathersjs.com"
+        git checkout -b update-dependencies-$GITHUB_RUN_ID
+    - run: |
+        npm run update-dependencies
+        npm install
+    - run: |
+        git commit -am "chore(dependencies): Update dependencies"
+        git push origin update-dependencies-$GITHUB_RUN_ID
+    - run: |
+        gh pr create --title "chore(dependencies): Update all dependencies" --body ""
+      env:
+        GITHUB_TOKEN: ${{secrets.CI_ACCESS_TOKEN}}
+        


### PR DESCRIPTION
This pull request adds a GitHub action that runs once a month (or can be triggered manually) that updates all dependencies in the default branch and create a new pull request for it. This is less noisy than the Dependabot and does only relies on GitHub actions and the `gh` GitHub CLI.