### PR TITLE
chore: Updated typings

### DIFF
--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -147,7 +147,10 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     };
   }
 
-  async parse (req: IncomingMessage) {
+  async parse (req: IncomingMessage): Promise<{
+    strategy: string;
+    accessToken: string;
+  } | null> {
     const { header, schemes }: { header: string, schemes: string[] } = this.configuration;
     const headerValue = req.headers && req.headers[header.toLowerCase()];
 


### PR DESCRIPTION
### Summary

The current generated type definitions for `JwtStrategy` is as follows:

```ts
// jwt.d.ts
parse(req: IncomingMessage): Promise<{
  strategy: string;
  accessToken: string;
}>;
```

This backwards-compatible PR updates the type definition to:

```ts
 parse(req: IncomingMessage): Promise<{
    strategy: string;
    accessToken: string;
} | null>;
```

This is to allow other projects with [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) to sub-class `JwtStrategy` and able to compile without any errors.

```txt
node_modules/feathers-authentication-oidc/lib/OidcStrategy.d.ts:9:5 - error TS2416: Property 'parse' in type 'OidcStrategy' is not assignable to the same property in base type 'JWTStrategy'.
  Type '(req: IncomingMessage) => Promise<{ strategy: string; accessToken: string; } | null>' is not assignable to type '(req: IncomingMessage) => Promise<{ strategy: string; accessToken: string; }>'.
    Type 'Promise<{ strategy: string; accessToken: string; } | null>' is not assignable to type 'Promise<{ strategy: string; accessToken: string; }>'.
      Type '{ strategy: string; accessToken: string; } | null' is not assignable to type '{ strategy: string; accessToken: string; }'.
        Type 'null' is not assignable to type '{ strategy: string; accessToken: string; }'.

9     parse(req: IncomingMessage): Promise<{
```

