### PR TITLE
Fix additional query parameters causing issues

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -109,7 +109,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
     debug('createEntity with data', data);
 
-    return this.entityService.create(data, params);
+    return this.entityService.create(data, omit(params, 'query'));
   }
 
   async updateEntity (entity: any, profile: OAuthProfile, params: Params) {
@@ -134,7 +134,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     }
 
     return entityService.get(result[entityId], {
-      ...params,
+      ...omit(params, 'query'),
       [entity]: result
     });
   }

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -6,7 +6,7 @@ import {
 } from '@feathersjs/authentication';
 import { Params } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
-import { createDebug } from '@feathersjs/commons';
+import { createDebug, omit } from '@feathersjs/commons';
 
 const debug = createDebug('@feathersjs/authentication-oauth/strategy');
 
@@ -118,7 +118,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
     debug(`updateEntity with id ${id} and data`, data);
 
-    return this.entityService.patch(id, data, params);
+    return this.entityService.patch(id, data, omit(params, 'query'));
   }
 
   async getEntity (result: any, params: Params) {

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -6,7 +6,7 @@ import {
 } from '@feathersjs/authentication';
 import { Params } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
-import { createDebug, omit } from '@feathersjs/commons';
+import { createDebug, _ } from '@feathersjs/commons';
 
 const debug = createDebug('@feathersjs/authentication-oauth/strategy');
 
@@ -109,7 +109,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
     debug('createEntity with data', data);
 
-    return this.entityService.create(data, omit(params, 'query'));
+    return this.entityService.create(data, _.omit(params, 'query'));
   }
 
   async updateEntity (entity: any, profile: OAuthProfile, params: Params) {
@@ -118,7 +118,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
     debug(`updateEntity with id ${id} and data`, data);
 
-    return this.entityService.patch(id, data, omit(params, 'query'));
+    return this.entityService.patch(id, data, _.omit(params, 'query'));
   }
 
   async getEntity (result: any, params: Params) {
@@ -134,7 +134,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     }
 
     return entityService.get(result[entityId], {
-      ...omit(params, 'query'),
+      ..._.omit(params, 'query'),
       [entity]: result
     });
   }


### PR DESCRIPTION
### Summary

the expressOauth code allows passing through more parameters than `redirect`, which all get lumped into an object called `query`, this then gets put into the params object on the other end of the oauth flow for convenience.

e.g. `https://mybackend.com/oauth/google?redirect=/checkout&cartId=1234`
results in the following in params being available `{ redirect: '/checkout', query: { cartId: 1234 } }`

The issue is that these params are passed directly into the patch/get/create service method calls in the strategy, so then the query is used to filter the patch request and an error is returned where the id is not found.

Omitting the query from the params fixes this issue.