### PR TITLE
Adds error handling for undefined/null password field in authentication-local

### DIFF
--- a/packages/authentication-local/src/strategy.ts
+++ b/packages/authentication-local/src/strategy.ts
@@ -119,9 +119,14 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
   }
 
   async authenticate (data: AuthenticationRequest, params: Params) {
-    const { passwordField, usernameField, entity } = this.configuration;
+    const { passwordField, usernameField, entity, errorMessage } = this.configuration;
     const username = data[usernameField];
     const password = data[passwordField];
+
+    if (!password) { // exit early if there is no password
+      throw new NotAuthenticated(errorMessage);
+    }
+
     const result = await this.findEntity(username, omit(params, 'provider'));
 
     await this.comparePassword(result, password);

--- a/packages/authentication-local/test/strategy.test.ts
+++ b/packages/authentication-local/test/strategy.test.ts
@@ -97,6 +97,20 @@ describe('@feathersjs/authentication-local/strategy', () => {
     }
   });
 
+  it('fails when password is not provided', async () => {
+    const authService = app.service('authentication');
+    try {
+      await authService.create({
+        strategy: 'local',
+        email,
+      });
+      assert.fail('Should never get here');
+    } catch (error) {
+      assert.strictEqual(error.name, 'NotAuthenticated');
+      assert.strictEqual(error.message, 'Invalid login');
+    }
+  });
+
   it('fails when password field is not available', async () => {
     const userEmail = 'someuser@localtest.com';
     const authService = app.service('authentication');


### PR DESCRIPTION
### Steps to reproduce the issue

- [ ] Create a feathers app with authentication using CLI 
- [ ] Send a local auth request but without password field. 


### Expected behavior
Should throw `401: NotAuthenticated`

### Actual behavior
Following `500: GeneralError` gets thrown
```
error: Error: Illegal arguments: undefined, string                                                                                    
    at _async (/<root>/node_modules/bcryptjs/dist/bcrypt.js:286:46)
    at /<root>/node_modules/bcryptjs/dist/bcrypt.js:307:17                                                                                             
    at new Promise (<anonymous>)                                                       
    at Object.bcrypt.compare (/<root>/node_modules/bcryptjs/dist/bcrypt.js:306:20)                                                                     
    at LocalStrategy.<anonymous> (/<root>/node_modules/@feathersjs/authentication-local/lib/strategy.js:88:53)                                         
    at Generator.next (<anonymous>)                                                    
    at /<root>/node_modules/@feathersjs/authentication-local/lib/strategy.js:8:71                                                                      
    at new Promise (<anonymous>)                                                       
    at __awaiter (/<root>/node_modules/@feathersjs/authentication-local/lib/strategy.js:4:12)                                                          
    at LocalStrategy.comparePassword (/<root>/node_modules/@feathersjs/authentication-local/lib/strategy.js:78:16)
    at LocalStrategy.<anonymous> (/<root>/node_modules/@feathersjs/authentication-local/lib/strategy.js:106:24)                                        
    at Generator.next (<anonymous>)                                                    
    at fulfilled (/<root>/node_modules/@feathersjs/authentication-local/lib/strategy.js:5:58)                                                          
    at processTicksAndRejections (internal/process/task_queues.js:97:5)  
```
