### PR TITLE
feat(basic hooks) allow groups by method then type

### DIFF
--- a/deno/_feathers/application.ts
+++ b/deno/_feathers/application.ts
@@ -17,9 +17,9 @@ import {
   HookOptions,
   FeathersService,
   HookMap,
-  LegacyHookMap
+  BasicHookMap
 } from './declarations.ts';
-import { enableLegacyHooks } from './hooks/legacy.ts';
+import { enableBasicHooks } from './hooks/basic.ts';
 
 const debug = createDebug('@feathersjs/feathers');
 
@@ -33,11 +33,11 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     [HOOKS]: [ (eventHook as any) ]
   };
 
-  private legacyHooks: (this: any, allHooks: any) => any;
+  private basicHooks: (this: any, allHooks: any) => any;
 
   constructor () {
     super();
-    this.legacyHooks = enableLegacyHooks(this);
+    this.basicHooks = enableBasicHooks(this);
   }
 
   get<L extends keyof AppSettings & string> (name: L): AppSettings[L] {
@@ -114,10 +114,10 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
   }
 
   hooks (hookMap: HookOptions<this, any>) {
-    const legacyMap = hookMap as LegacyHookMap<this, any>;
+    const basicHookMap = hookMap as BasicHookMap<this, any>;
 
-    if (legacyMap.before || legacyMap.after || legacyMap.error) {
-      return this.legacyHooks(legacyMap);
+    if (basicHookMap.before || basicHookMap.after || basicHookMap.error) {
+      return this.basicHooks(basicHookMap);
     }
 
     if (Array.isArray(hookMap)) {
@@ -142,10 +142,10 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     for (const path of Object.keys(this.services)) {
       promise = promise.then(() => {
         const service: any = this.service(path as any);
-  
+
         if (typeof service.setup === 'function') {
           debug(`Setting up service for \`${path}\``);
-  
+
           return service.setup(this, path);
         }
       });

--- a/deno/_feathers/declarations.ts
+++ b/deno/_feathers/declarations.ts
@@ -312,23 +312,23 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
   event: string|null;
 }
 
-// Legacy hook typings
-export type LegacyHookFunction<A = Application, S = Service<any, any>> =
+// Basic hook typings
+export type BasicHookFunction<A = Application, S = Service<any, any>> =
   (this: S, context: HookContext<A, S>) => (Promise<HookContext<Application, S> | void> | HookContext<Application, S> | void);
 
-export type Hook<A = Application, S = Service<any, any>> = LegacyHookFunction<A, S>;
+export type Hook<A = Application, S = Service<any, any>> = BasicHookFunction<A, S>;
 
-type LegacyHookMethodMap<A, S> =
-  { [L in keyof S]?: SelfOrArray<LegacyHookFunction<A, S>>; } &
-  { all?: SelfOrArray<LegacyHookFunction<A, S>> };
+type BasicHookMethodMap<A, S> =
+  { [L in keyof S]?: SelfOrArray<BasicHookFunction<A, S>>; } &
+  { all?: SelfOrArray<BasicHookFunction<A, S>> };
 
-type LegacyHookTypeMap<A, S> =
-  SelfOrArray<LegacyHookFunction<A, S>> | LegacyHookMethodMap<A, S>;
+type BasicHookTypeMap<A, S> =
+  SelfOrArray<BasicHookFunction<A, S>> | BasicHookMethodMap<A, S>;
 
-export type LegacyHookMap<A, S> = {
-  before?: LegacyHookTypeMap<A, S>,
-  after?: LegacyHookTypeMap<A, S>,
-  error?: LegacyHookTypeMap<A, S>
+export type BasicHookMap<A, S> = {
+  before?: BasicHookTypeMap<A, S>,
+  after?: BasicHookTypeMap<A, S>,
+  error?: BasicHookTypeMap<A, S>
 }
 
 // New @feathersjs/hook typings
@@ -340,4 +340,4 @@ export type HookMap<A, S> = {
 };
 
 export type HookOptions<A, S> =
-  HookMap<A, S> | HookFunction<A, S>[] | LegacyHookMap<A, S>;
+  HookMap<A, S> | HookFunction<A, S>[] | BasicHookMap<A, S>;

--- a/deno/_feathers/hooks/basic.ts
+++ b/deno/_feathers/hooks/basic.ts
@@ -1,9 +1,11 @@
-import { _ } from '../dependencies';
-import { LegacyHookFunction } from '../declarations';
+// DO NOT MODIFY - generated from packages/feathers/src/hooks/basic.ts
+
+import { _ } from '../dependencies.ts';
+import { BasicHookFunction } from '../declarations.ts';
 
 const { each } = _;
 
-export function fromBeforeHook (hook: LegacyHookFunction) {
+export function fromBeforeHook (hook: BasicHookFunction) {
   return (context: any, next: any) => {
     context.type = 'before';
 
@@ -14,7 +16,7 @@ export function fromBeforeHook (hook: LegacyHookFunction) {
   };
 }
 
-export function fromAfterHook (hook: LegacyHookFunction) {
+export function fromAfterHook (hook: BasicHookFunction) {
   return (context: any, next: any) => {
     return next().then(() => {
       context.type = 'after';
@@ -25,7 +27,7 @@ export function fromAfterHook (hook: LegacyHookFunction) {
   }
 }
 
-export function fromErrorHooks (hooks: LegacyHookFunction[]) {
+export function fromErrorHooks (hooks: BasicHookFunction[]) {
   return (context: any, next: any) => {
     return next().catch((error: any) => {
       let promise: Promise<any> = Promise.resolve();
@@ -51,7 +53,7 @@ export function fromErrorHooks (hooks: LegacyHookFunction[]) {
   }
 }
 
-export function collectLegacyHooks (target: any, method: string) {
+export function collectBasicHooks (target: any, method: string) {
   const {
     before: { [method]: before = [] },
     after: { [method]: after = [] },
@@ -83,7 +85,7 @@ export function convertHookData (obj: any) {
 }
 
 // Add `.hooks` functionality to an object
-export function enableLegacyHooks (
+export function enableBasicHooks (
   obj: any,
   methods: string[] = ['find', 'get', 'create', 'update', 'patch', 'remove'],
   types: string[] = ['before', 'after', 'error']
@@ -102,7 +104,7 @@ export function enableLegacyHooks (
     writable: true
   });
 
-  return function legacyHooks (this: any, allHooks: any) {
+  return function basicHooks (this: any, allHooks: any) {
     each(allHooks, (current: any, type) => {
       if (!this.__hooks[type]) {
         throw new Error(`'${type}' is not a valid hook type`);

--- a/deno/_feathers/hooks/index.ts
+++ b/deno/_feathers/hooks/index.ts
@@ -8,12 +8,12 @@ import {
 } from '../declarations.ts';
 import { defaultServiceArguments, getHookMethods } from '../service.ts';
 import {
-  collectLegacyHooks,
-  enableLegacyHooks,
+  collectBasicHooks,
+  enableBasicHooks,
   fromAfterHook,
   fromBeforeHook,
   fromErrorHooks
-} from './legacy.ts';
+} from './basic.ts';
 
 export { fromAfterHook, fromBeforeHook, fromErrorHooks };
 
@@ -36,11 +36,11 @@ export class FeathersHookManager<A> extends HookManager {
   collectMiddleware (self: any, args: any[]): Middleware[] {
     const app = this.app as any as Application;
     const appHooks = app.appHooks[HOOKS].concat(app.appHooks[this.method] || []);
-    const legacyAppHooks = collectLegacyHooks(this.app, this.method);
+    const basicAppHooks = collectBasicHooks(this.app, this.method);
     const middleware = super.collectMiddleware(self, args);
-    const legacyHooks = collectLegacyHooks(self, this.method);
+    const basicHooks = collectBasicHooks(self, this.method);
 
-    return [...appHooks, ...legacyAppHooks, ...middleware, ...legacyHooks];
+    return [...appHooks, ...basicAppHooks, ...middleware, ...basicHooks];
   }
 
   initializeContext (self: any, args: any[], context: HookContext) {
@@ -81,7 +81,7 @@ export function hookMixin<A> (
 
     return res;
   }, {} as HookMap);
-  const handleLegacyHooks = enableLegacyHooks(service);
+  const handleLegacyHooks = enableBasicHooks(service);
 
   hooks(service, serviceMethodHooks);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "feathers",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.15.5",
@@ -3419,9 +3420,9 @@
 			}
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.14.173",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
-			"integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg=="
+			"version": "4.14.175",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+			"integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
 		},
 		"node_modules/@types/mime": {
 			"version": "1.3.2",
@@ -3455,9 +3456,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "16.9.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
-			"integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA=="
+			"version": "16.10.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+			"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "3.0.3",
@@ -4106,11 +4107,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/any-promise": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.2",
@@ -5054,12 +5050,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-			"integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+			"integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
 			"dependencies": {
 				"@babel/helper-define-polyfill-provider": "^0.2.2",
-				"core-js-compat": "^3.14.0"
+				"core-js-compat": "^3.16.2"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -5807,15 +5803,15 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"node_modules/browserslist": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-			"integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+			"integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001254",
-				"colorette": "^1.3.0",
-				"electron-to-chromium": "^1.3.830",
+				"caniuse-lite": "^1.0.30001259",
+				"electron-to-chromium": "^1.3.846",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.75"
+				"nanocolors": "^0.1.5",
+				"node-releases": "^1.1.76"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -6066,9 +6062,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001258",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-			"integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+			"version": "1.0.30001261",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
+			"integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/browserslist"
@@ -6711,9 +6707,9 @@
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"node_modules/cookiejar": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
 		},
 		"node_modules/cookies": {
 			"version": "0.8.0",
@@ -6748,11 +6744,11 @@
 			"hasInstallScript": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.0.tgz",
-			"integrity": "sha512-tRVjOJu4PxdXjRMEgbP7lqWy1TWJu9a01oBkn8d+dNrhgmBwdTkzhHZpVJnEmhISLdoJI1lX08rcBcHi3TZIWg==",
+			"version": "3.18.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.1.tgz",
+			"integrity": "sha512-XJMYx58zo4W0kLPmIingVZA10+7TuKrMLPt83+EzDmxFJQUMcTVVmQ+n5JP4r6Z14qSzhQBRi3NSWoeVyKKXUg==",
 			"dependencies": {
-				"browserslist": "^4.17.0",
+				"browserslist": "^4.17.1",
 				"semver": "7.0.0"
 			},
 			"funding": {
@@ -7209,9 +7205,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.843",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.843.tgz",
-			"integrity": "sha512-OWEwAbzaVd1Lk9MohVw8LxMXFlnYd9oYTYxfX8KS++kLLjDfbovLOcEEXwRhG612dqGQ6+44SZvim0GXuBRiKg=="
+			"version": "1.3.853",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.853.tgz",
+			"integrity": "sha512-W4U8n+U8I5/SUaFcqZgbKRmYZwcyEIQVBDf+j5QQK6xChjXnQD+wj248eGR9X4u+dDmDR//8vIfbu4PrdBBIoQ=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -7375,9 +7371,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-			"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -7473,9 +7469,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw=="
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.1.tgz",
+			"integrity": "sha512-17Ed9misDnpyNBJh63g1OhW3qUFecDgGOivI85JeZY/LGhDum8e+cltukbkSK8pcJnXXEkya56sp4vSS1nzoUw=="
 		},
 		"node_modules/es-to-primitive": {
 			"version": "1.2.1",
@@ -10678,9 +10674,9 @@
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "27.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
-			"integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
+			"version": "27.2.3",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.3.tgz",
+			"integrity": "sha512-ZwOvv4GCIPviL+Ie4pVguz4N5w/6IGbTaHBYOl3ZcsZZktaL7d8JOU0rmovoED7AJZKA8fvmLbBg8yg80u/tGA==",
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -11013,16 +11009,16 @@
 			}
 		},
 		"node_modules/koa": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/koa/-/koa-2.13.1.tgz",
-			"integrity": "sha512-Lb2Dloc72auj5vK4X4qqL7B5jyDPQaZucc9sR/71byg7ryoD1NCaCm63CShk9ID9quQvDEi1bGR/iGjCG7As3w==",
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/koa/-/koa-2.13.3.tgz",
+			"integrity": "sha512-XhXIoR+ylAwqG3HhXwnMPQAM/4xfywz52OvxZNmxmTWGGHsvmBv4NSIhURha6yMuvEex1WdtplUTHnxnKpQiGw==",
 			"dependencies": {
 				"accepts": "^1.3.5",
 				"cache-content-type": "^1.0.0",
 				"content-disposition": "~0.5.2",
 				"content-type": "^1.0.4",
 				"cookies": "~0.8.0",
-				"debug": "~3.1.0",
+				"debug": "^4.3.2",
 				"delegates": "^1.0.0",
 				"depd": "^2.0.0",
 				"destroy": "^1.0.4",
@@ -11033,7 +11029,7 @@
 				"http-errors": "^1.6.3",
 				"is-generator-function": "^1.0.7",
 				"koa-compose": "^4.1.0",
-				"koa-convert": "^1.2.0",
+				"koa-convert": "^2.0.0",
 				"on-finished": "^2.3.0",
 				"only": "~0.0.2",
 				"parseurl": "^1.3.2",
@@ -11063,23 +11059,15 @@
 			"integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
 		},
 		"node_modules/koa-convert": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
-			"integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+			"integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
 			"dependencies": {
 				"co": "^4.6.0",
-				"koa-compose": "^3.0.0"
+				"koa-compose": "^4.1.0"
 			},
 			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/koa-convert/node_modules/koa-compose": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
-			"integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
-			"dependencies": {
-				"any-promise": "^1.1.0"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/koa-qs": {
@@ -11094,14 +11082,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/koa/node_modules/debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
 		"node_modules/koa/node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -11109,11 +11089,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/koa/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"node_modules/lasso": {
 			"version": "2.11.24",
@@ -12703,15 +12678,15 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-			"integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+			"integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
 				"chokidar": "3.5.2",
-				"debug": "4.3.1",
+				"debug": "4.3.2",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
@@ -12722,12 +12697,11 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.23",
+				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"wide-align": "1.1.3",
 				"workerpool": "6.1.5",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
@@ -12987,27 +12961,6 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
-		"node_modules/mocha/node_modules/debug": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/mocha/node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
 		"node_modules/mocha/node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -13121,9 +13074,9 @@
 			}
 		},
 		"node_modules/mongodb-connection-string-url": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.0.0.tgz",
-			"integrity": "sha512-M0I1vyLoq5+HQTuPSJWbt+hIXsMCfE8sS1fS5mvP9R2DOMoi2ZD32yWqgBIITyu0dFu4qtS50erxKjvUeBiyog==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
+			"integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
 			"dependencies": {
 				"@types/whatwg-url": "^8.2.1",
 				"whatwg-url": "^9.1.0"
@@ -13180,10 +13133,15 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
+		"node_modules/nanocolors": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+			"integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
+		},
 		"node_modules/nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -13379,9 +13337,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.75",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
+			"version": "1.1.76",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+			"integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA=="
 		},
 		"node_modules/nopt": {
 			"version": "4.0.3",
@@ -16098,9 +16056,9 @@
 			}
 		},
 		"node_modules/sift": {
-			"version": "14.0.2",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-14.0.2.tgz",
-			"integrity": "sha512-+LNx7frhvN3wwwjgMKzDCphsZgemO7lirlB39Sn0oOBDEF8LAmv8pzCjpqyUC91+HZfCV9UX9ONzMbXSaoAHKg=="
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-14.0.3.tgz",
+			"integrity": "sha512-zsQnIcPs6yI8YSdJqPG9Cp2dGm3A1nNBVBn9Opg/ICskrdeEUVC/2AjjuD8DNdWMG2ujeMbB7xCKZO2OUU8bGQ=="
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.4",
@@ -16764,9 +16722,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
-			"integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
+			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
 			"dependencies": {
 				"commander": "^2.20.0",
 				"source-map": "~0.7.2",
@@ -17035,9 +16993,9 @@
 			}
 		},
 		"node_modules/ts-loader": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.5.tgz",
-			"integrity": "sha512-al/ATFEffybdRMUIr5zMEWQdVnCGMUA9d3fXJ8dBVvBlzytPvIszoG9kZoR+94k6/i293RnVOXwMaWbXhNy9pQ==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
+			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
 			"dependencies": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
@@ -17626,9 +17584,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.53.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
-			"integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+			"version": "5.55.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.55.0.tgz",
+			"integrity": "sha512-/1LyoAG+4+YRt+RLN3H2cz4dcw8+iO/GwKhL54GQDmqONCi0ZISXZF6aCCrCRDJFK685h+RGLCZd61Y+SEqdWQ==",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -17639,8 +17597,8 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.0",
-				"es-module-lexer": "^0.7.1",
+				"enhanced-resolve": "^5.8.3",
+				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -17879,6 +17837,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
 			"dependencies": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -17887,6 +17846,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -17895,6 +17855,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -17903,6 +17864,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"dependencies": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -17915,6 +17877,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^3.0.0"
 			},
@@ -20874,9 +20837,9 @@
 			}
 		},
 		"@types/lodash": {
-			"version": "4.14.173",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
-			"integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg=="
+			"version": "4.14.175",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+			"integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
 		},
 		"@types/mime": {
 			"version": "1.3.2",
@@ -20909,9 +20872,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "16.9.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
-			"integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA=="
+			"version": "16.10.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+			"integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
 		},
 		"@types/node-fetch": {
 			"version": "3.0.3",
@@ -21409,11 +21372,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"any-promise": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
 		},
 		"anymatch": {
 			"version": "3.1.2",
@@ -22225,12 +22183,12 @@
 			}
 		},
 		"babel-plugin-polyfill-corejs3": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-			"integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+			"integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
 			"requires": {
 				"@babel/helper-define-polyfill-provider": "^0.2.2",
-				"core-js-compat": "^3.14.0"
+				"core-js-compat": "^3.16.2"
 			}
 		},
 		"babel-plugin-polyfill-regenerator": {
@@ -22918,15 +22876,15 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"browserslist": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-			"integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+			"integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001254",
-				"colorette": "^1.3.0",
-				"electron-to-chromium": "^1.3.830",
+				"caniuse-lite": "^1.0.30001259",
+				"electron-to-chromium": "^1.3.846",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.75"
+				"nanocolors": "^0.1.5",
+				"node-releases": "^1.1.76"
 			}
 		},
 		"bson": {
@@ -23101,9 +23059,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001258",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-			"integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA=="
+			"version": "1.0.30001261",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
+			"integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -23611,9 +23569,9 @@
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"cookiejar": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
 		},
 		"cookies": {
 			"version": "0.8.0",
@@ -23642,11 +23600,11 @@
 			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
 		},
 		"core-js-compat": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.0.tgz",
-			"integrity": "sha512-tRVjOJu4PxdXjRMEgbP7lqWy1TWJu9a01oBkn8d+dNrhgmBwdTkzhHZpVJnEmhISLdoJI1lX08rcBcHi3TZIWg==",
+			"version": "3.18.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.1.tgz",
+			"integrity": "sha512-XJMYx58zo4W0kLPmIingVZA10+7TuKrMLPt83+EzDmxFJQUMcTVVmQ+n5JP4r6Z14qSzhQBRi3NSWoeVyKKXUg==",
 			"requires": {
-				"browserslist": "^4.17.0",
+				"browserslist": "^4.17.1",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -24011,9 +23969,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.843",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.843.tgz",
-			"integrity": "sha512-OWEwAbzaVd1Lk9MohVw8LxMXFlnYd9oYTYxfX8KS++kLLjDfbovLOcEEXwRhG612dqGQ6+44SZvim0GXuBRiKg=="
+			"version": "1.3.853",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.853.tgz",
+			"integrity": "sha512-W4U8n+U8I5/SUaFcqZgbKRmYZwcyEIQVBDf+j5QQK6xChjXnQD+wj248eGR9X4u+dDmDR//8vIfbu4PrdBBIoQ=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -24137,9 +24095,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-			"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
 			"requires": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -24214,9 +24172,9 @@
 			}
 		},
 		"es-module-lexer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw=="
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.1.tgz",
+			"integrity": "sha512-17Ed9misDnpyNBJh63g1OhW3qUFecDgGOivI85JeZY/LGhDum8e+cltukbkSK8pcJnXXEkya56sp4vSS1nzoUw=="
 		},
 		"es-to-primitive": {
 			"version": "1.2.1",
@@ -26647,9 +26605,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "27.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
-			"integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
+			"version": "27.2.3",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.3.tgz",
+			"integrity": "sha512-ZwOvv4GCIPviL+Ie4pVguz4N5w/6IGbTaHBYOl3ZcsZZktaL7d8JOU0rmovoED7AJZKA8fvmLbBg8yg80u/tGA==",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -26930,16 +26888,16 @@
 			"dev": true
 		},
 		"koa": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/koa/-/koa-2.13.1.tgz",
-			"integrity": "sha512-Lb2Dloc72auj5vK4X4qqL7B5jyDPQaZucc9sR/71byg7ryoD1NCaCm63CShk9ID9quQvDEi1bGR/iGjCG7As3w==",
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/koa/-/koa-2.13.3.tgz",
+			"integrity": "sha512-XhXIoR+ylAwqG3HhXwnMPQAM/4xfywz52OvxZNmxmTWGGHsvmBv4NSIhURha6yMuvEex1WdtplUTHnxnKpQiGw==",
 			"requires": {
 				"accepts": "^1.3.5",
 				"cache-content-type": "^1.0.0",
 				"content-disposition": "~0.5.2",
 				"content-type": "^1.0.4",
 				"cookies": "~0.8.0",
-				"debug": "~3.1.0",
+				"debug": "^4.3.2",
 				"delegates": "^1.0.0",
 				"depd": "^2.0.0",
 				"destroy": "^1.0.4",
@@ -26950,7 +26908,7 @@
 				"http-errors": "^1.6.3",
 				"is-generator-function": "^1.0.7",
 				"koa-compose": "^4.1.0",
-				"koa-convert": "^1.2.0",
+				"koa-convert": "^2.0.0",
 				"on-finished": "^2.3.0",
 				"only": "~0.0.2",
 				"parseurl": "^1.3.2",
@@ -26959,23 +26917,10 @@
 				"vary": "^1.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
 				"depd": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
 					"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -26994,22 +26939,12 @@
 			"integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
 		},
 		"koa-convert": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
-			"integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+			"integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
 			"requires": {
 				"co": "^4.6.0",
-				"koa-compose": "^3.0.0"
-			},
-			"dependencies": {
-				"koa-compose": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
-					"integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
-					"requires": {
-						"any-promise": "^1.1.0"
-					}
-				}
+				"koa-compose": "^4.1.0"
 			}
 		},
 		"koa-qs": {
@@ -28336,15 +28271,15 @@
 			}
 		},
 		"mocha": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-			"integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+			"integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
 				"chokidar": "3.5.2",
-				"debug": "4.3.1",
+				"debug": "4.3.2",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
@@ -28355,12 +28290,11 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.23",
+				"nanoid": "3.1.25",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"wide-align": "1.1.3",
 				"workerpool": "6.1.5",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
@@ -28371,21 +28305,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-						}
-					}
 				},
 				"find-up": {
 					"version": "5.0.0",
@@ -28658,9 +28577,9 @@
 			}
 		},
 		"mongodb-connection-string-url": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.0.0.tgz",
-			"integrity": "sha512-M0I1vyLoq5+HQTuPSJWbt+hIXsMCfE8sS1fS5mvP9R2DOMoi2ZD32yWqgBIITyu0dFu4qtS50erxKjvUeBiyog==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
+			"integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
 			"requires": {
 				"@types/whatwg-url": "^8.2.1",
 				"whatwg-url": "^9.1.0"
@@ -28709,10 +28628,15 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
+		"nanocolors": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+			"integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
+		},
 		"nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -28860,9 +28784,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.75",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
+			"version": "1.1.76",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+			"integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA=="
 		},
 		"nopt": {
 			"version": "4.0.3",
@@ -30987,9 +30911,9 @@
 			}
 		},
 		"sift": {
-			"version": "14.0.2",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-14.0.2.tgz",
-			"integrity": "sha512-+LNx7frhvN3wwwjgMKzDCphsZgemO7lirlB39Sn0oOBDEF8LAmv8pzCjpqyUC91+HZfCV9UX9ONzMbXSaoAHKg=="
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-14.0.3.tgz",
+			"integrity": "sha512-zsQnIcPs6yI8YSdJqPG9Cp2dGm3A1nNBVBn9Opg/ICskrdeEUVC/2AjjuD8DNdWMG2ujeMbB7xCKZO2OUU8bGQ=="
 		},
 		"signal-exit": {
 			"version": "3.0.4",
@@ -31502,9 +31426,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
-			"integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
+			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
 			"requires": {
 				"commander": "^2.20.0",
 				"source-map": "~0.7.2",
@@ -31694,9 +31618,9 @@
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"ts-loader": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.5.tgz",
-			"integrity": "sha512-al/ATFEffybdRMUIr5zMEWQdVnCGMUA9d3fXJ8dBVvBlzytPvIszoG9kZoR+94k6/i293RnVOXwMaWbXhNy9pQ==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
+			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
 			"requires": {
 				"chalk": "^4.1.0",
 				"enhanced-resolve": "^5.0.0",
@@ -32143,9 +32067,9 @@
 			"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
 		},
 		"webpack": {
-			"version": "5.53.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
-			"integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+			"version": "5.55.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.55.0.tgz",
+			"integrity": "sha512-/1LyoAG+4+YRt+RLN3H2cz4dcw8+iO/GwKhL54GQDmqONCi0ZISXZF6aCCrCRDJFK685h+RGLCZd61Y+SEqdWQ==",
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
 				"@types/estree": "^0.0.50",
@@ -32156,8 +32080,8 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.0",
-				"es-module-lexer": "^0.7.1",
+				"enhanced-resolve": "^5.8.3",
+				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -32314,6 +32238,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			},
@@ -32321,17 +32246,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -32341,6 +32269,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -15,9 +15,9 @@ import {
   HookOptions,
   FeathersService,
   HookMap,
-  LegacyHookMap
+  BasicHookMap
 } from './declarations';
-import { enableLegacyHooks } from './hooks/legacy';
+import { enableBasicHooks } from './hooks/basic';
 
 const debug = createDebug('@feathersjs/feathers');
 
@@ -31,11 +31,11 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     [HOOKS]: [ (eventHook as any) ]
   };
 
-  private legacyHooks: (this: any, allHooks: any) => any;
+  private basicHooks: (this: any, allHooks: any) => any;
 
   constructor () {
     super();
-    this.legacyHooks = enableLegacyHooks(this);
+    this.basicHooks = enableBasicHooks(this);
   }
 
   get<L extends keyof AppSettings & string> (name: L): AppSettings[L] {
@@ -118,10 +118,12 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
   }
 
   hooks (hookMap: HookOptions<this, any>) {
-    const legacyMap = hookMap as LegacyHookMap<this, any>;
+    const basicHookMap = hookMap as BasicHookMap<this, any>;
 
-    if (legacyMap.before || legacyMap.after || legacyMap.error) {
-      return this.legacyHooks(legacyMap);
+    // Registering basic hooks
+    const isGroupedByMethod = Object.values(basicHookMap).some((o: any) => o.before || o.after || o.error)
+    if (basicHookMap.before || basicHookMap.after || basicHookMap.error || isGroupedByMethod) {
+      return this.basicHooks(basicHookMap);
     }
 
     if (Array.isArray(hookMap)) {
@@ -146,10 +148,10 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     for (const path of Object.keys(this.services)) {
       promise = promise.then(() => {
         const service: any = this.service(path as any);
-  
+
         if (typeof service.setup === 'function') {
           debug(`Setting up service for \`${path}\``);
-  
+
           return service.setup(this, path);
         }
       });

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -318,22 +318,22 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
 }
 
 // Legacy hook typings
-export type LegacyHookFunction<A = Application, S = Service<any, any>> =
+export type BasicHookFunction<A = Application, S = Service<any, any>> =
   (this: S, context: HookContext<A, S>) => (Promise<HookContext<Application, S> | void> | HookContext<Application, S> | void);
 
-export type Hook<A = Application, S = Service<any, any>> = LegacyHookFunction<A, S>;
+export type Hook<A = Application, S = Service<any, any>> = BasicHookFunction<A, S>;
 
-type LegacyHookMethodMap<A, S> =
-  { [L in keyof S]?: SelfOrArray<LegacyHookFunction<A, S>>; } &
-  { all?: SelfOrArray<LegacyHookFunction<A, S>> };
+type BasicHookMethodMap<A, S> =
+  { [L in keyof S]?: SelfOrArray<BasicHookFunction<A, S>>; } &
+  { all?: SelfOrArray<BasicHookFunction<A, S>> };
 
-type LegacyHookTypeMap<A, S> =
-  SelfOrArray<LegacyHookFunction<A, S>> | LegacyHookMethodMap<A, S>;
+type BasicHookTypeMap<A, S> =
+  SelfOrArray<BasicHookFunction<A, S>> | BasicHookMethodMap<A, S>;
 
-export type LegacyHookMap<A, S> = {
-  before?: LegacyHookTypeMap<A, S>,
-  after?: LegacyHookTypeMap<A, S>,
-  error?: LegacyHookTypeMap<A, S>
+export type BasicHookMap<A, S> = {
+  before?: BasicHookTypeMap<A, S>,
+  after?: BasicHookTypeMap<A, S>,
+  error?: BasicHookTypeMap<A, S>
 }
 
 // New @feathersjs/hook typings
@@ -345,4 +345,4 @@ export type HookMap<A, S> = {
 };
 
 export type HookOptions<A, S> =
-  HookMap<A, S> | HookFunction<A, S>[] | LegacyHookMap<A, S>;
+  HookMap<A, S> | HookFunction<A, S>[] | BasicHookMap<A, S>;

--- a/packages/feathers/src/hooks/basic.ts
+++ b/packages/feathers/src/hooks/basic.ts
@@ -1,11 +1,9 @@
-// DO NOT MODIFY - generated from packages/feathers/src/hooks/legacy.ts
-
-import { _ } from '../dependencies.ts';
-import { LegacyHookFunction } from '../declarations.ts';
+import { _ } from '../dependencies';
+import { BasicHookFunction } from '../declarations';
 
 const { each } = _;
 
-export function fromBeforeHook (hook: LegacyHookFunction) {
+export function fromBeforeHook (hook: BasicHookFunction) {
   return (context: any, next: any) => {
     context.type = 'before';
 
@@ -16,7 +14,7 @@ export function fromBeforeHook (hook: LegacyHookFunction) {
   };
 }
 
-export function fromAfterHook (hook: LegacyHookFunction) {
+export function fromAfterHook (hook: BasicHookFunction) {
   return (context: any, next: any) => {
     return next().then(() => {
       context.type = 'after';
@@ -27,7 +25,7 @@ export function fromAfterHook (hook: LegacyHookFunction) {
   }
 }
 
-export function fromErrorHooks (hooks: LegacyHookFunction[]) {
+export function fromErrorHooks (hooks: BasicHookFunction[]) {
   return (context: any, next: any) => {
     return next().catch((error: any) => {
       let promise: Promise<any> = Promise.resolve();
@@ -53,7 +51,7 @@ export function fromErrorHooks (hooks: LegacyHookFunction[]) {
   }
 }
 
-export function collectLegacyHooks (target: any, method: string) {
+export function collectBasicHooks (target: any, method: string) {
   const {
     before: { [method]: before = [] },
     after: { [method]: after = [] },
@@ -84,8 +82,21 @@ export function convertHookData (obj: any) {
   return hook;
 }
 
+// Takes hooks grouped by method `find: { before: [] }` into grouped by type `before: { find: [] }`
+export function groupBasicHooksByType (hookOptions: any) {
+  return Object.keys(hookOptions).reduce((hookObj: any, method) => {
+    ['before', 'after', 'error'].forEach(type => {
+      hookObj[type] = hookObj[type] || {}
+      if (Array.isArray(hookOptions[method][type])) {
+        hookObj[type][method] = hookOptions[method][type]
+      }
+    })
+    return hookObj
+  }, {})
+}
+
 // Add `.hooks` functionality to an object
-export function enableLegacyHooks (
+export function enableBasicHooks (
   obj: any,
   methods: string[] = ['find', 'get', 'create', 'update', 'patch', 'remove'],
   types: string[] = ['before', 'after', 'error']
@@ -104,7 +115,7 @@ export function enableLegacyHooks (
     writable: true
   });
 
-  return function legacyHooks (this: any, allHooks: any) {
+  return function basicHooks (this: any, allHooks: any) {
     each(allHooks, (current: any, type) => {
       if (!this.__hooks[type]) {
         throw new Error(`'${type}' is not a valid hook type`);

--- a/packages/feathers/test/application.test.ts
+++ b/packages/feathers/test/application.test.ts
@@ -174,7 +174,7 @@ describe('Feathers application', () => {
       app1.service('testing').create({ message: 'Hi' });
     });
 
-    it('async hooks run before legacy hooks', async () => {
+    it('advanced hooks run before basic hooks', async () => {
       const app = feathers();
 
       app.use('/dummy', {
@@ -197,11 +197,11 @@ describe('Feathers application', () => {
         ctx.data.order = [ 'async' ];
         await next();
       }]);
-      
+
       const result = await dummy.create({
         message: 'hi'
       });
-      
+
       assert.deepStrictEqual(result, {
         message: 'hi',
         order: ['async', 'before']

--- a/packages/feathers/test/hooks/app.test.ts
+++ b/packages/feathers/test/hooks/app.test.ts
@@ -26,7 +26,7 @@ describe('app.hooks', () => {
   });
 
   describe('app.hooks([ async ])', () => {
-    it('basic app async hook', async () => {
+    it('basic app advanced hook', async () => {
       const service = app.service('todos');
 
       app.hooks([

--- a/packages/feathers/test/hooks/async.test.ts
+++ b/packages/feathers/test/hooks/async.test.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import { feathers } from '../../src';
 
-describe('`async` hooks', () => {
-  it('async hooks can set hook.result which will skip service method', async () => {
+describe('`advanced` hooks', () => {
+  it('advanced hooks can set hook.result which will skip service method', async () => {
     const app = feathers().use('/dummy', {
       async get () {
         assert.ok(false, 'This should never run');
@@ -169,7 +169,7 @@ describe('`async` hooks', () => {
     await service.create({ some: 'thing' });
   });
 
-  it('async hooks run in the correct order', async () => {
+  it('advanced hooks run in the correct order', async () => {
     const app = feathers().use('/dummy', {
       async get (id: any, params: any) {
         assert.deepStrictEqual(params.items, ['first', 'second', 'third']);
@@ -244,7 +244,7 @@ describe('`async` hooks', () => {
     await service.find();
   });
 
-  it('async hooks have service as context and keep it in service method (#17)', async () => {
+  it('advanced hooks have service as context and keep it in service method (#17)', async () => {
     class Dummy {
       number= 42;
 


### PR DESCRIPTION
### Summary

- Introduces the terminology of "Basic Hooks" and "Advanced Hooks"
   - Any reference of "Legacy Hooks" to "Basic Hooks".
   - Renames any reference of "Async Hooks" to "Advanced Hooks"
- Introduces support for registering basic hook objects  grouped by method.  To prevent a lot of code changes, it converts the new format to the old format, internally.

There are now two supported Basic Hook registration formats.  The new format prevents having to scoll past all other methods' hooks in order to see the after hooks.

```ts
const  newFormat = {
  find: {
    before: [hook1, hook2, hook3],
    after: [hook4, hook5, hook6],
    error: [error1, error2, error3]
  },
  get: {
    before: [hook1, hook2, hook3],
    after: [hook4, hook5, hook6],
    error: [error1, error2, error3]
  },
}
```

### Other Information

The majority of the changes in this PR are for renaming the hooks from `legacy` to `basic`.

The new hook format feature is added in `application.ts`, `hooks/basic.ts`, and the test file.
- The [`app.hooks()` method](https://github.com/feathersjs/feathers/pull/2456/files#diff-52e395dc6b28077aefd1ed36163fd5c50f7e23ca71dd56c8a8a08d393fd46684R123-R126) now checks for an object that has nested hook types.  Please double-check this.
- A new [`groupBasicHooksByType` private utility](https://github.com/feathersjs/feathers/pull/2456/files#diff-5ca7fe5525ed3155322fac494f81c2be465060933eb1b8030616e329a3a9eca9R85-R97) has been added.  It's "private" in the sense that it isn't exported from the main module, but just the basic hooks module.
- The [`service.hooks` method](https://github.com/feathersjs/feathers/pull/2456/files#diff-9dd442ca294f7dba145a85914271f3ff3b2ffbca851c4ef1eaeb63329bba30eaR87-R91) detects the new format and uses the above utility to convert the hooks.
- I added [two tests](https://github.com/feathersjs/feathers/pull/2456/files#diff-8a706c65373f4cc3169dcfb691543e66e6ecc78a568259801517018a23c8b44cR105-R200)
   - A unit test for the `groupBasicHooksByType` method.
   - A unit test for services to make sure hooks are registered and run correctly.

### Pending Work

- [ ] Update the Deno version.  Is this done by a build process or is it manual?
- [ ] Documentation
   - [ ] Clarify differences between Basic and Advanced Hooks
   - [ ] Show the new Basic Hook format.
- [ ] Maybe update the `BasicHookOptions` type to be the new format, since it makes more sense and doesn't introduce any negative effects or mental overhead.