### PR TITLE
[dove/hygen-cli] Fix capitalized Yarn command issue

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -54,8 +54,13 @@ export async function getHelpers (pkg: PackageJSON, self: PackageJSON, _logger: 
           ? `${name}@${self.devDependencies[name]}`
           : name
       );
-      const { packager } = pkg.feathers;
-      const command = `${packager} install ${deps.join(' ')} --${dev ? 'save-dev' : 'save'}`;
+      const packagerName = pkg.feathers.packager
+      const packagerCmd = packagerName.toLowerCase()
+      const isYarn = packagerName === 'Yarn'
+      const installCmd = isYarn ? 'add' : 'install'
+      const devArg = isYarn ? '--dev' : '--save-dev'
+      const cmdArgs = dev ? ' ' + devArg : ''
+      const command = `${packagerCmd} ${installCmd} ${deps.join(' ')}${cmdArgs}`
 
       return command;
     },


### PR DESCRIPTION
# Bug fix for

hygen generator won't run when Yarn is selected...

![Screenshot 2021-10-04 14 23 59](https://user-images.githubusercontent.com/876076/135918759-6721da9d-99a8-4489-b1e5-04d18af80382.png)

when using these settings:
![Screenshot 2021-10-04 14 23 28](https://user-images.githubusercontent.com/876076/135918763-bb32df57-911f-40a3-b633-4a4d1c39e6ad.png)

# Details

## Why the tests are failing

The time out after 5 minutes, on CI tools it takes 3m30s just to get through lerna bootstrap... leaving almost no time for tests to run in CI=true env's. Solution could be to remove the automatic full monorepo boot... and only boot say, CLI with `lerna bootstrap --ignore-scripts --scope "@feathersjs/cli" --include-dependencies`

## Why I had to mess with the semicolon

Which if we only fixed the capitalization would yield:

```
/home/sandbox/.nvm/versions/node/v16.8.0/bin/node /home/sandbox/.nvm/versions/node/v16.8.0/bin/yarn add @feathersjs/feathers@^5.0.0-pre.6 @feathersjs/errors@^5.0.0-pre.6 @feathersjs/configuration@^5.0.0-pre.6 @feathersjs/authentication@^5.0.0-pre.6 @feathersjs/transport-commons@^5.0.0-pre.6 winston@^3.3.3 @feathersjs/socketio@^5.0.0-pre.6 @feathersjs/koa@^5.0.0-pre.6 koa-static@^5.0.0 ; yarn add nodemon@^2.0.12 axios@^0.21.4 mocha@^9.1.1 @types/mocha@^9.0.0 @types/koa-static @types/node@^16.9.4 ts-node-dev typescript@^4.4.3 shx@^0.3.3 --dev
```

and `Error: https://registry.yarnpkg.com/;: Not found`.

Hygen prefers the fail deadly approach of `&&` which we could employ by swapping the semicolon in `packages/cli/_templates/app/base/js/package.json.t` line 4

`sh: "<%= h.install(...dependencies) %>; <%= h.installDev(...devDependencies) %>"`


# Guru meditation:

Upon further testing, I see no benefit to having the generator use Yarn, it's not appreciably faster than NPM 7 for anything the generator would install. The generator runs in about 15 seconds on a shared CSB container with NPM... I'm in favor of dropping the whole choose your packager shenanigans. You can still use Yarn or PNPM after generating with minimal effort.

Also I'm in favor of running a yearly doodle to set defaults, Typescript should really be the first choice. And feathers-memory or [@seald-io/nedb](https://www.npmjs.com/package/@seald-io/nedb) for the database adapter, there is currently no DB adapter option that doesn't require spinning up a goliath.

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/crow/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
- [x] Is this PR dependent on PRs in other repos?
