### PR TITLE
[dove/hygen-cli] Name temp dirs like feathers_ts_koa

### DIFF
--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -31,25 +31,22 @@ function combinate<O extends Record<string | number, any[]>> (obj: O) {
   }
   return combos;
 }
-const combinations = process.env.CI ? combinate(matrix) : [defaultCombination];
+// Github CI can't handle the matrix... GITHUB_REF is refs/heads/feature-branch-1
+const combinations = process.env.CI && !process.env.GITHUB_REF ? combinate(matrix) : [defaultCombination];
 
 describe('@feathersjs/cli', () => {
   const oldCwd = process.cwd();
-  let tmpDir: string;
-
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'feathers-'));
-    process.chdir(tmpDir);
-  });
 
   afterEach(() => process.chdir(oldCwd));
 
   for (const { language, framework } of combinations) {
     it(`generates ${language} ${framework} app and passes tests`, async () => {
+      const name = `feathers_${language}_${framework}`;
+      const tmpDir = await mkdtemp(path.join(os.tmpdir(), name + '-'));
       const appPrompts = {
         framework,
         language,
-        name: 'feathers-cli-test',
+        name: name,
         description: 'The Feathers CLI test app',
         lib: 'src',
         packager: 'npm',

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -31,8 +31,8 @@ function combinate<O extends Record<string | number, any[]>> (obj: O) {
   }
   return combos;
 }
-// Github CI can't handle the matrix... GITHUB_REF is refs/heads/feature-branch-1
-const combinations = process.env.CI && !process.env.GITHUB_REF ? combinate(matrix) : [defaultCombination];
+
+const combinations = process.env.CI ? combinate(matrix) : [defaultCombination];
 
 describe('@feathersjs/cli', () => {
   const oldCwd = process.cwd();


### PR DESCRIPTION
# Summary

Instead of test folders being named like this:
```
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:53 feathers-O7C15n
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:53 feathers-GGIGRy
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:52 feathers-cz5zXe
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:52 feathers-eQiVHK
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:49 feathers-ewzTXi
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:43 feathers-qRmKUw
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:41 feathers-HyM5uj
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:37 feathers-ZgnC7M
drwx------ 7 sandbox sandbox 4.0K Oct  5 20:31 feathers-IIUqZJ
```

Names them like this:
```
drwx------ 8 sandbox sandbox 4.0K Oct  5 21:09 feathers_ts_koa-fxVBjf
drwx------ 7 sandbox sandbox 4.0K Oct  5 21:07 feathers_ts_express-Nj0Nfm
drwx------ 7 sandbox sandbox 4.0K Oct  5 21:07 feathers_js_express-3A31J1
drwx------ 7 sandbox sandbox 4.0K Oct  5 21:06 feathers_js_koa-DPoCLs
```

**why the tests are failing**: 5 minute time out... in a project with thousands of tests

- [x] Tell us about the problem your pull request is solving.
    - Debugging and building off of the generator tests is hard with random names 
- [x] Are there any open issues that are related to this?
    - You're looking at it. 
- [x] Is this PR dependent on PRs in other repos?
    - Nope, it's an independent, strong, PR