### PR TITLE
fix(core): Allow to return a new hook context in basic hooks

### DIFF
--- a/packages/feathers/src/hooks/legacy.ts
+++ b/packages/feathers/src/hooks/legacy.ts
@@ -2,16 +2,20 @@ import { _ } from '../dependencies';
 import { LegacyHookFunction } from '../declarations';
 
 const { each } = _;
+const mergeContext = (context: any) => (res: any) => {
+  if (res && res !== context) {
+    Object.assign(context, res);
+  }
+  return res;
+}
 
 export function fromBeforeHook (hook: LegacyHookFunction) {
   return (context: any, next: any) => {
     context.type = 'before';
 
     return Promise.resolve(hook.call(context.self, context))
-      .then(ctx => {
-        if (ctx && ctx !== context) {
-          Object.assign(context, ctx);
-        }
+      .then(mergeContext(context))
+      .then(() => {
         context.type = null;
         return next();
       });
@@ -20,15 +24,15 @@ export function fromBeforeHook (hook: LegacyHookFunction) {
 
 export function fromAfterHook (hook: LegacyHookFunction) {
   return (context: any, next: any) => {
-    return next().then(() => {
-      context.type = 'after';
-      return hook.call(context.self, context)
-    }).then((ctx: any) => {
-      if (ctx && ctx !== context) {
-        Object.assign(context, ctx);
-      }
-      context.type = null;
-    });
+    return next()
+      .then(() => {
+        context.type = 'after';
+        return hook.call(context.self, context)
+      })
+      .then(mergeContext(context))
+      .then(() => {
+        context.type = null;
+      });
   }
 }
 
@@ -45,11 +49,7 @@ export function fromErrorHooks (hooks: LegacyHookFunction[]) {
 
       for (const hook of hooks) {
         promise = promise.then(() => hook.call(context.self, context))
-          .then(ctx => {
-            if (ctx && ctx !== context) {
-              Object.assign(context, ctx);
-            }
-          })
+          .then(mergeContext(context))
       }
 
       return promise.then(() => {

--- a/packages/feathers/test/hooks/hooks.test.ts
+++ b/packages/feathers/test/hooks/hooks.test.ts
@@ -354,4 +354,42 @@ describe('hooks basics', () => {
       params: {}
     });
   });
+
+  it('allows to return new context in basic hooks (#2451)', async () => {
+    const app = feathers().use('/dummy', {
+      async get () {
+        return {};
+      }
+    });
+    const service = app.service('dummy');
+
+    service.hooks({
+      before: {
+        get: [
+          context => {
+            return {
+              ...context,
+              value: 'something'
+            };
+          },
+          context => {
+            assert.strictEqual(context.value, 'something');
+          }
+        ]
+      },
+      after: {
+        get: [context => {
+          context.result = {
+            value: context.value
+          }
+        }]
+      }
+    });
+
+    const data = await service.get(10);
+
+    assert.deepStrictEqual(data, {
+      value: 'something'
+    });
+  });
 });


### PR DESCRIPTION
This fixes a regression in backwards compatibility that is difficult to debug.

Closes #2451