### PR TITLE
[dove/cli] Address strictNullCheck error on app.test.ts

### DIFF
--- a/packages/cli/_templates/app/base/ts/app.test.ts.t
+++ b/packages/cli/_templates/app/base/ts/app.test.ts.t
@@ -33,11 +33,14 @@ describe('Feathers application tests', () => {
       });
       assert.fail('should never get here');
     } catch (error) {
-      const { response } = error;
-
-      assert.strictEqual(response.status, 404);
-      assert.strictEqual(response.data.code, 404);
-      assert.strictEqual(response.data.name, 'NotFound');
+      if (axios.isAxiosError(error)) {
+        const { response } = error
+        assert.strictEqual(response?.status, 404)
+        assert.strictEqual(response?.data?.code, 404)
+        assert.strictEqual(response?.data?.name, 'NotFound')
+      } else {
+        assert.fail('Response is not an AxiosError')
+      }
     }
   });
 });


### PR DESCRIPTION
Strict null checks are on in our tsconfig.json... so we run into the following error without this PR.
https://stackoverflow.com/a/58401023/370238

https://codesandbox.io/s/feathers-dove-cs7qc?file=/test/app.test.ts

**Before PR**:
```
test/app.test.ts:36:28 - error TS2532: Object is possibly 'undefined'.

36         assert.strictEqual(response.data.name, 'NotFound')
                              ~~~~~~~~
```

**After PR**:
```

  Feathers application tests
    ✔ starts and shows the index page (44ms)
    ✔ shows a 404 JSON error

  'messages' service
    ✔ registered the service


  3 passing (54ms)

```

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/crow/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
- [x] Is this PR dependent on PRs in other repos?
