### PR TITLE
Rename legacy hooks to regular hooks

### DIFF
--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -15,9 +15,9 @@ import {
   HookOptions,
   FeathersService,
   HookMap,
-  LegacyHookMap
+  RegularHookMap
 } from './declarations';
-import { enableLegacyHooks } from './hooks/legacy';
+import { enableRegularHooks } from './hooks/regular';
 
 const debug = createDebug('@feathersjs/feathers');
 
@@ -31,11 +31,11 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     [HOOKS]: [ (eventHook as any) ]
   };
 
-  private legacyHooks: (this: any, allHooks: any) => any;
+  private regularHooks: (this: any, allHooks: any) => any;
 
   constructor () {
     super();
-    this.legacyHooks = enableLegacyHooks(this);
+    this.regularHooks = enableRegularHooks(this);
   }
 
   get<L extends keyof AppSettings & string> (name: L): AppSettings[L] {
@@ -118,10 +118,10 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
   }
 
   hooks (hookMap: HookOptions<this, any>) {
-    const legacyMap = hookMap as LegacyHookMap<this, any>;
+    const regularMap = hookMap as RegularHookMap<this, any>;
 
-    if (legacyMap.before || legacyMap.after || legacyMap.error) {
-      return this.legacyHooks(legacyMap);
+    if (regularMap.before || regularMap.after || regularMap.error) {
+      return this.regularHooks(regularMap);
     }
 
     if (Array.isArray(hookMap)) {
@@ -146,10 +146,10 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     for (const path of Object.keys(this.services)) {
       promise = promise.then(() => {
         const service: any = this.service(path as any);
-  
+
         if (typeof service.setup === 'function') {
           debug(`Setting up service for \`${path}\``);
-  
+
           return service.setup(this, path);
         }
       });

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -317,23 +317,23 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
   event: string|null;
 }
 
-// Legacy hook typings
-export type LegacyHookFunction<A = Application, S = Service<any, any>> =
+// Regular hook typings
+export type RegularHookFunction<A = Application, S = Service<any, any>> =
   (this: S, context: HookContext<A, S>) => (Promise<HookContext<Application, S> | void> | HookContext<Application, S> | void);
 
-export type Hook<A = Application, S = Service<any, any>> = LegacyHookFunction<A, S>;
+export type Hook<A = Application, S = Service<any, any>> = RegularHookFunction<A, S>;
 
-type LegacyHookMethodMap<A, S> =
-  { [L in keyof S]?: SelfOrArray<LegacyHookFunction<A, S>>; } &
-  { all?: SelfOrArray<LegacyHookFunction<A, S>> };
+type RegularHookMethodMap<A, S> =
+  { [L in keyof S]?: SelfOrArray<RegularHookFunction<A, S>>; } &
+  { all?: SelfOrArray<RegularHookFunction<A, S>> };
 
-type LegacyHookTypeMap<A, S> =
-  SelfOrArray<LegacyHookFunction<A, S>> | LegacyHookMethodMap<A, S>;
+type RegularHookTypeMap<A, S> =
+  SelfOrArray<RegularHookFunction<A, S>> | RegularHookMethodMap<A, S>;
 
-export type LegacyHookMap<A, S> = {
-  before?: LegacyHookTypeMap<A, S>,
-  after?: LegacyHookTypeMap<A, S>,
-  error?: LegacyHookTypeMap<A, S>
+export type RegularHookMap<A, S> = {
+  before?: RegularHookTypeMap<A, S>,
+  after?: RegularHookTypeMap<A, S>,
+  error?: RegularHookTypeMap<A, S>
 }
 
 // New @feathersjs/hook typings
@@ -345,4 +345,4 @@ export type HookMap<A, S> = {
 };
 
 export type HookOptions<A, S> =
-  HookMap<A, S> | HookFunction<A, S>[] | LegacyHookMap<A, S>;
+  HookMap<A, S> | HookFunction<A, S>[] | RegularHookMap<A, S>;

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -6,12 +6,12 @@ import {
 } from '../declarations';
 import { defaultServiceArguments, getHookMethods } from '../service';
 import {
-  collectLegacyHooks,
-  enableLegacyHooks,
+  collectRegularHooks,
+  enableRegularHooks,
   fromAfterHook,
   fromBeforeHook,
   fromErrorHooks
-} from './legacy';
+} from './regular';
 
 export { fromAfterHook, fromBeforeHook, fromErrorHooks };
 
@@ -34,11 +34,11 @@ export class FeathersHookManager<A> extends HookManager {
   collectMiddleware (self: any, args: any[]): Middleware[] {
     const app = this.app as any as Application;
     const appHooks = app.appHooks[HOOKS].concat(app.appHooks[this.method] || []);
-    const legacyAppHooks = collectLegacyHooks(this.app, this.method);
+    const regularAppHooks = collectRegularHooks(this.app, this.method);
     const middleware = super.collectMiddleware(self, args);
-    const legacyHooks = collectLegacyHooks(self, this.method);
+    const regularHooks = collectRegularHooks(self, this.method);
 
-    return [...appHooks, ...legacyAppHooks, ...middleware, ...legacyHooks];
+    return [...appHooks, ...regularAppHooks, ...middleware, ...regularHooks];
   }
 
   initializeContext (self: any, args: any[], context: HookContext) {
@@ -79,13 +79,13 @@ export function hookMixin<A> (
 
     return res;
   }, {} as HookMap);
-  const handleLegacyHooks = enableLegacyHooks(service);
+  const handleRegularHooks = enableRegularHooks(service);
 
   hooks(service, serviceMethodHooks);
 
   service.hooks = function (this: any, hookOptions: any) {
     if (hookOptions.before || hookOptions.after || hookOptions.error) {
-      return handleLegacyHooks.call(this, hookOptions);
+      return handleRegularHooks.call(this, hookOptions);
     }
 
     if (Array.isArray(hookOptions)) {

--- a/packages/feathers/src/hooks/regular.ts
+++ b/packages/feathers/src/hooks/regular.ts
@@ -1,5 +1,5 @@
 import { _ } from '../dependencies';
-import { LegacyHookFunction } from '../declarations';
+import { RegularHookFunction } from '../declarations';
 
 const { each } = _;
 const mergeContext = (context: any) => (res: any) => {
@@ -9,7 +9,7 @@ const mergeContext = (context: any) => (res: any) => {
   return res;
 }
 
-export function fromBeforeHook (hook: LegacyHookFunction) {
+export function fromBeforeHook (hook: RegularHookFunction) {
   return (context: any, next: any) => {
     context.type = 'before';
 
@@ -22,7 +22,7 @@ export function fromBeforeHook (hook: LegacyHookFunction) {
   };
 }
 
-export function fromAfterHook (hook: LegacyHookFunction) {
+export function fromAfterHook (hook: RegularHookFunction) {
   return (context: any, next: any) => {
     return next()
       .then(() => {
@@ -36,7 +36,7 @@ export function fromAfterHook (hook: LegacyHookFunction) {
   }
 }
 
-export function fromErrorHooks (hooks: LegacyHookFunction[]) {
+export function fromErrorHooks (hooks: RegularHookFunction[]) {
   return (context: any, next: any) => {
     return next().catch((error: any) => {
       let promise: Promise<any> = Promise.resolve();
@@ -63,7 +63,7 @@ export function fromErrorHooks (hooks: LegacyHookFunction[]) {
   }
 }
 
-export function collectLegacyHooks (target: any, method: string) {
+export function collectRegularHooks (target: any, method: string) {
   const {
     before: { [method]: before = [] },
     after: { [method]: after = [] },
@@ -95,7 +95,7 @@ export function convertHookData (obj: any) {
 }
 
 // Add `.hooks` functionality to an object
-export function enableLegacyHooks (
+export function enableRegularHooks (
   obj: any,
   methods: string[] = ['find', 'get', 'create', 'update', 'patch', 'remove'],
   types: string[] = ['before', 'after', 'error']
@@ -114,7 +114,7 @@ export function enableLegacyHooks (
     writable: true
   });
 
-  return function legacyHooks (this: any, allHooks: any) {
+  return function regularHooks (this: any, allHooks: any) {
     each(allHooks, (current: any, type) => {
       if (!this.__hooks[type]) {
         throw new Error(`'${type}' is not a valid hook type`);

--- a/packages/feathers/test/application.test.ts
+++ b/packages/feathers/test/application.test.ts
@@ -174,7 +174,7 @@ describe('Feathers application', () => {
       app1.service('testing').create({ message: 'Hi' });
     });
 
-    it('async hooks run before legacy hooks', async () => {
+    it('async hooks run before regular hooks', async () => {
       const app = feathers();
 
       app.use('/dummy', {
@@ -197,11 +197,11 @@ describe('Feathers application', () => {
         ctx.data.order = [ 'async' ];
         await next();
       }]);
-      
+
       const result = await dummy.create({
         message: 'hi'
       });
-      
+
       assert.deepStrictEqual(result, {
         message: 'hi',
         order: ['async', 'before']

--- a/packages/feathers/test/hooks/hooks.test.ts
+++ b/packages/feathers/test/hooks/hooks.test.ts
@@ -40,22 +40,22 @@ describe('hooks basics', () => {
 
     app.hooks({
       before: [(ctx: HookContext) => {
-        ctx.params.chain.push('app.hooks legacy before');
+        ctx.params.chain.push('app.hooks regular before');
       }],
       after: [(ctx: HookContext) => {
-        ctx.params.chain.push('app.hooks legacy after');
+        ctx.params.chain.push('app.hooks regular after');
       }]
     });
 
     service.hooks({
       before: {
         get: (ctx: HookContext) => {
-          ctx.params.chain.push('service.hooks legacy before');
+          ctx.params.chain.push('service.hooks regular before');
         }
       },
       after: {
         get: (ctx: HookContext) => {
-          ctx.params.chain.push('service.hooks legacy after');
+          ctx.params.chain.push('service.hooks regular after');
         }
       }
     });
@@ -71,12 +71,12 @@ describe('hooks basics', () => {
     service.hooks({
       before: {
         get: (ctx: HookContext) => {
-          ctx.params.chain.push('service.hooks 2 legacy before');
+          ctx.params.chain.push('service.hooks 2 regular before');
         }
       },
       after: {
         get: (ctx: HookContext) => {
-          ctx.params.chain.push('service.hooks 2 legacy after');
+          ctx.params.chain.push('service.hooks 2 regular after');
         }
       }
     });
@@ -85,18 +85,18 @@ describe('hooks basics', () => {
 
     assert.deepStrictEqual(chain, [
       'app.hooks before',
-      'app.hooks legacy before',
+      'app.hooks regular before',
       '@hooks all before',
       '@hooks get before',
       'service.hooks get before',
-      'service.hooks legacy before',
-      'service.hooks 2 legacy before',
-      'service.hooks legacy after',
-      'service.hooks 2 legacy after',
+      'service.hooks regular before',
+      'service.hooks 2 regular before',
+      'service.hooks regular after',
+      'service.hooks 2 regular after',
       'service.hooks get after',
       '@hooks get after',
       '@hooks all after',
-      'app.hooks legacy after',
+      'app.hooks regular after',
       'app.hooks after'
     ])
   });


### PR DESCRIPTION
This renames "legacy hooks" to "regular hooks".  The new hook format continues to be named "async hooks".

So now we have
- Regular Hooks (the format we have had for years)
- Async hooks (the new format similar to Koa hooks)