### PR TITLE
feat(authentication-oauth): Allow dynamic oAuth redirect

### DIFF
--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -20,6 +20,7 @@ declare module 'express-session' {
       accessToken: string;
       query: { [key: string]: any };
       grant: { [key: string]: any };
+      headers: { [key: string]: any };
   }
 }
 
@@ -54,13 +55,14 @@ export default (options: OauthSetupSettings) => {
       }
       req.session.redirect = redirect as string;
       req.session.query = query;
+      req.session.headers = req.headers;
 
       next()
     });
 
     authApp.get('/:name/authenticate', async (req: Request, res: Response, next: NextFunction) => {
       const { name } = req.params ;
-      const { accessToken, grant, query = {}, redirect } = req.session;
+      const { accessToken, grant, query = {}, redirect, headers } = req.session;
       const service = app.defaultAuthentication(authService);
       const [ strategy ] = service.getStrategies(name) as OAuthStrategy[];
       const params = {
@@ -71,7 +73,8 @@ export default (options: OauthSetupSettings) => {
           accessToken
         } : null,
         query,
-        redirect
+        redirect,
+        headers
       };
       const sendResponse = async (data: AuthenticationResult|Error) => {
         try {

--- a/packages/authentication/src/core.ts
+++ b/packages/authentication/src/core.ts
@@ -156,6 +156,16 @@ export class AuthenticationBase {
   }
 
   /**
+   * Returns a single strategy by name
+   * 
+   * @param name The strategy name
+   * @returns The authentication strategy or undefined
+   */
+  getStrategy (name: string) {
+    return this.strategies[name];
+  }
+
+  /**
    * Create a new access token with payload and options.
    *
    * @param payload The JWT payload

--- a/packages/authentication/test/core.test.ts
+++ b/packages/authentication/test/core.test.ts
@@ -96,6 +96,12 @@ describe('authentication/core', () => {
       assert.strictEqual(invalid.length, 2, 'Filtered out invalid strategies');
     });
 
+    it('getStrategy', () => {
+      const first = auth.getStrategy('first');
+
+      assert.ok(first);
+    });
+
     it('calls setName, setApplication and setAuthentication if available', () => {
       const [ first ] = auth.getStrategies('first') as [ Strategy1 ];
 


### PR DESCRIPTION
This pull request allows dynamic oAuth redirects by adding an `origins` option to the oAuth configuration. This can be added _instead_ of the `redirect` option to include a list of URLs that are allowed to make oAuth requests. It will use the `Referer` HTTP header from the original request to redirect back to. For example a configuration like

```json
{
  "authentication": {
    "oauth": {
      "origins": [
        "https://feathersjs.com",
        "https://feathers.cloud"
      ]
    }
  }
}
```

Would allow and redirect any request made from those domains.

- Closes #2285
- Closes #2430