### PR TITLE
Support ambient types in dev environment by default

### DIFF
--- a/packages/cli/_templates/app/base/index.js
+++ b/packages/cli/_templates/app/base/index.js
@@ -45,7 +45,8 @@ module.exports = {
         '@types/mocha',
         feathers.framework === 'koa' ? '@types/koa-static' : '@types/compression',
         '@types/node',
-        'ts-node-dev',
+        'nodemon',
+        'ts-node',
         'typescript',
         'shx'
       );

--- a/packages/cli/_templates/app/base/ts/package.json.t
+++ b/packages/cli/_templates/app/base/ts/package.json.t
@@ -9,7 +9,7 @@ const pkg = {
   ...h.pkg,
   scripts: {
     ...h.pkg.scripts,
-    dev: 'nodemon -x ts-node ${h.lib}/',
+    dev: 'nodemon -x ts-node ${h.lib}/index.ts',
     compile: 'shx rm -rf lib/ && tsc',
     start: 'npm run compile && node lib/',
     test: 'mocha test/ --require ts-node/register --recursive --extension .ts --exit'

--- a/packages/cli/_templates/app/base/ts/package.json.t
+++ b/packages/cli/_templates/app/base/ts/package.json.t
@@ -9,7 +9,7 @@ const pkg = {
   ...h.pkg,
   scripts: {
     ...h.pkg.scripts,
-    dev: 'ts-node-dev --no-notify ${h.lib}/',
+    dev: 'nodemon -x ts-node ${h.lib}/',
     compile: 'shx rm -rf lib/ && tsc',
     start: 'npm run compile && node lib/',
     test: 'mocha test/ --require ts-node/register --recursive --extension .ts --exit'

--- a/packages/cli/_templates/app/base/ts/tsconfig.json.t
+++ b/packages/cli/_templates/app/base/ts/tsconfig.json.t
@@ -2,8 +2,11 @@
 to: "tsconfig.json"
 ---
 {
+  "ts-node": {
+    "files": true
+  },
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2020",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./<%= h.lib %>",


### PR DESCRIPTION
ts-node and by dependency, ts-node-dev, will ignore ambient types without the files flag. Meanwhile tsc, which we use to build... will load ambient types. This is unexpected for most people.

This PR fixes that and has few if any ramifications.

## Side effects
- New projects would use the latest ts-node v10, rather than ts-node v8, which is currently a sub-dependency in ts-node-dev
- Having ts-node or nodemon in package.json triggers the node template in codesandbox... so feathers projects would load in a Node container, rather than a ReactJS playground.
    - [source](https://github.com/codesandbox/codesandbox-importers/blob/cd59770d734da1b601e7c461218bee1dff86c825/packages/import-utils/src/create-sandbox/templates.ts#L214)

## Notes
- This does nothing about our lack of Module support... that's being resolved upstream in a matter of weeks https://github.com/TypeStrong/ts-node/issues/1414
- There are some incompatibilities between 16.10 and previous versions of Node that make the loader approach to supporting Node ESM with typescript difficult. Though something like the following is **currently, 2021-10-17** the only option, aside from using the unpublished ts-node@next `nodemon -x 'node --loader ts-node/esm' src/index.ts`