### PR TITLE
fix: Small improvements

### DIFF
--- a/packages/adapter-commons/test/service.test.ts
+++ b/packages/adapter-commons/test/service.test.ts
@@ -27,7 +27,7 @@ describe('@feathersjs/adapter-commons/service', () => {
   });
 
   describe('works when methods exist', () => {
-    class MethodService extends AdapterService implements InternalServiceMethods<any> {
+    class MethodService extends AdapterService implements InternalServiceMethods {
       _find (_params?: Params) {
         return Promise.resolve([]);
       }

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -48,6 +48,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@types/mocha": "^9.0.0",
     "@types/node": "^16.10.4",
     "mocha": "^9.1.2",
     "shx": "^0.3.3",

--- a/packages/authentication-client/src/index.ts
+++ b/packages/authentication-client/src/index.ts
@@ -4,7 +4,7 @@ import { Application } from '@feathersjs/feathers';
 import { Storage, MemoryStorage, StorageWrapper } from './storage';
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  interface Application<ServiceTypes, AppSettings> { // eslint-disable-line
+  interface Application<Services, Settings> { // eslint-disable-line
     io?: any;
     rest?: any;
     authentication: AuthenticationClient;

--- a/packages/authentication-local/src/hooks/hash-password.ts
+++ b/packages/authentication-local/src/hooks/hash-password.ts
@@ -18,7 +18,7 @@ export default function hashPassword (field: string, options: HashPasswordOption
     throw new Error('The hashPassword hook requires a field name option');
   }
 
-  return async (context: HookContext<any, any>, next?: NextFunction) => {
+  return async (context: HookContext, next?: NextFunction) => {
     const { app, data, params } = context;
 
     if (data !== undefined) {

--- a/packages/authentication-local/src/hooks/protect.ts
+++ b/packages/authentication-local/src/hooks/protect.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import { HookContext, NextFunction } from '@feathersjs/feathers';
 
-export default (...fields: string[]) => async (context: HookContext<any, any>, next?: NextFunction) => {
+export default (...fields: string[]) => async (context: HookContext, next?: NextFunction) => {
   const o = (current: any) => {
     if (typeof current === 'object' && !Array.isArray(current)) {
       const data = typeof current.toJSON === 'function'

--- a/packages/authentication/src/hooks/authenticate.ts
+++ b/packages/authentication/src/hooks/authenticate.ts
@@ -20,7 +20,7 @@ export default (originalSettings: string | AuthenticateHookSettings, ...original
     throw new Error('The authenticate hook needs at least one allowed strategy');
   }
 
-  return async (context: HookContext<any, any>, _next?: NextFunction) => {
+  return async (context: HookContext, _next?: NextFunction) => {
     const next = typeof _next === 'function' ? _next : async () => context;
     const { app, params, type, path, service } = context;
     const { strategies } = settings;

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -1,9 +1,5 @@
-import * as hooks from './hooks';
-
-const { authenticate } = hooks;
-
-export { hooks };
-export { authenticate };
+export * as hooks from './hooks';
+export { authenticate } from './hooks';
 export {
   AuthenticationBase,
   AuthenticationRequest,

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -10,7 +10,7 @@ import jsonwebtoken from 'jsonwebtoken';
 const debug = createDebug('@feathersjs/authentication/service');
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  interface FeathersApplication<ServiceTypes, AppSettings> { // eslint-disable-line
+  interface FeathersApplication<Services, Settings> { // eslint-disable-line
     /**
      * Returns the default authentication service or the
      * authentication service for a given path.

--- a/packages/authentication/src/strategy.ts
+++ b/packages/authentication/src/strategy.ts
@@ -22,7 +22,7 @@ export class AuthenticationBaseStrategy implements AuthenticationStrategy {
     return this.authentication.configuration[this.name];
   }
 
-  get entityService (): Service<any> {
+  get entityService (): Service {
     const { service } = this.configuration;
 
     if (!service) {

--- a/packages/authentication/test/hooks/authenticate.test.ts
+++ b/packages/authentication/test/hooks/authenticate.test.ts
@@ -10,7 +10,7 @@ describe('authentication/hooks/authenticate', () => {
   let app: Application<{
     authentication: AuthenticationService,
     'auth-v2': AuthenticationService,
-    users: Partial<ServiceMethods<any>> & { id: string }
+    users: Partial<ServiceMethods> & { id: string }
   }>;
 
   beforeEach(() => {

--- a/packages/authentication/test/jwt.test.ts
+++ b/packages/authentication/test/jwt.test.ts
@@ -12,8 +12,8 @@ const { authenticate } = hooks;
 describe('authentication/jwt', () => {
   let app: Application<{
     authentication: AuthenticationService,
-    users: Partial<Service<any>>,
-    protected: Partial<Service<any>>
+    users: Partial<Service>,
+    protected: Partial<Service>
   }>;
   let user: any;
   let accessToken: string;

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -51,16 +51,19 @@
   "dependencies": {
     "@feathersjs/commons": "^5.0.0-pre.14",
     "@feathersjs/errors": "^5.0.0-pre.14",
+    "@feathersjs/feathers": "^5.0.0-pre.14",
+    "@feathersjs/hooks": "^0.6.5",
     "@feathersjs/transport-commons": "^5.0.0-pre.14",
     "@types/express": "^4.17.13",
+    "@types/express-serve-static-core": "^4.17.24",
     "express": "^4.17.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@feathersjs/authentication": "^5.0.0-pre.14",
     "@feathersjs/authentication-local": "^5.0.0-pre.14",
-    "@feathersjs/feathers": "^5.0.0-pre.14",
     "@feathersjs/tests": "^5.0.0-pre.14",
+    "@types/lodash": "^4.14.175",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.10.4",
     "axios": "^0.23.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -52,7 +52,6 @@
     "@feathersjs/commons": "^5.0.0-pre.14",
     "@feathersjs/errors": "^5.0.0-pre.14",
     "@feathersjs/feathers": "^5.0.0-pre.14",
-    "@feathersjs/hooks": "^0.6.5",
     "@feathersjs/transport-commons": "^5.0.0-pre.14",
     "@types/express": "^4.17.13",
     "@types/express-serve-static-core": "^4.17.24",

--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -5,12 +5,12 @@ import {
   HookContext, ServiceMethods, ServiceInterface
 } from '@feathersjs/feathers';
 
-interface ExpressUseHandler<T, ServiceTypes> {
-  <L extends keyof ServiceTypes & string> (
+interface ExpressUseHandler<T, Services> {
+  <L extends keyof Services & string> (
     path: L,
     ...middlewareOrService: (
       Express|express.RequestHandler|
-      (keyof any extends keyof ServiceTypes ? ServiceInterface<any> : ServiceTypes[L])
+      (keyof any extends keyof Services ? ServiceInterface<any> : Services[L])
     )[]
   ): T;
   (path: string|RegExp, ...expressHandlers: express.RequestHandler[]): T;
@@ -18,18 +18,18 @@ interface ExpressUseHandler<T, ServiceTypes> {
   (handler: Express|express.ErrorRequestHandler): T;
 }
 
-export interface ExpressOverrides<ServiceTypes> {
+export interface ExpressOverrides<Services> {
   listen(port: number, hostname: string, backlog: number, callback?: () => void): Promise<http.Server>;
   listen(port: number, hostname: string, callback?: () => void): Promise<http.Server>;
   listen(port: number|string|any, callback?: () => void): Promise<http.Server>;
   listen(callback?: () => void): Promise<http.Server>;
-  use: ExpressUseHandler<this, ServiceTypes>;
+  use: ExpressUseHandler<this, Services>;
 }
 
-export type Application<ServiceTypes = any, AppSettings = any> =
+export type Application<Services = any, Settings = any> =
   Omit<Express, 'listen'|'use'> &
-  FeathersApplication<ServiceTypes, AppSettings> &
-  ExpressOverrides<ServiceTypes>;
+  FeathersApplication<Services, Settings> &
+  ExpressOverrides<Services>;
 
 declare module '@feathersjs/feathers/lib/declarations' {
   export interface ServiceOptions {

--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -10,7 +10,7 @@ interface ExpressUseHandler<T, Services> {
     path: L,
     ...middlewareOrService: (
       Express|express.RequestHandler|
-      (keyof any extends keyof Services ? ServiceInterface<any> : Services[L])
+      (keyof any extends keyof Services ? ServiceInterface : Services[L])
     )[]
   ): T;
   (path: string|RegExp, ...expressHandlers: express.RequestHandler[]): T;
@@ -32,7 +32,7 @@ export type Application<Services = any, Settings = any> =
   ExpressOverrides<Services>;
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  export interface ServiceOptions {
+  interface ServiceOptions {
     middleware?: {
       before: express.RequestHandler[],
       after: express.RequestHandler[]
@@ -54,7 +54,7 @@ declare module 'express-serve-static-core' {
       // eslint-disable-next-line
       <P extends Params = ParamsDictionary, ResBody = any, ReqBody = any>(
           path: PathParams,
-          ...handlers: (RequestHandler<P, ResBody, ReqBody> | Partial<ServiceMethods<any, any>> | Application)[]
+          ...handlers: (RequestHandler<P, ResBody, ReqBody> | Partial<ServiceMethods> | Application)[]
       ): T;
   }
 }

--- a/packages/express/src/rest.ts
+++ b/packages/express/src/rest.ts
@@ -1,15 +1,14 @@
 import { MethodNotAllowed } from '@feathersjs/errors';
-import { HookContext } from '@feathersjs/hooks';
 import { createDebug } from '@feathersjs/commons';
 import { http } from '@feathersjs/transport-commons';
-import { createContext, defaultServiceMethods, getServiceOptions } from '@feathersjs/feathers';
+import { HookContext, createContext, defaultServiceMethods, getServiceOptions } from '@feathersjs/feathers';
 import { Request, Response, NextFunction, RequestHandler, Router } from 'express';
 
 import { parseAuthentication } from './authentication';
 
 const debug = createDebug('@feathersjs/express/rest');
 
-export type ServiceCallback = (req: Request, res: Response, options: http.ServiceParams) => Promise<HookContext|any>;
+export type ServiceCallback = (req: Request, res: Response, options: http.ServiceParams) => Promise<HookContext>;
 
 export const feathersParams = (req: Request, _res: Response, next: NextFunction) => {
   req.feathers = {
@@ -69,7 +68,7 @@ export const serviceMethodHandler = (
   const args = getArgs(options);
   const context = createContext(service, method);
 
-  res.hook = context as any;
+  res.hook = context;
 
   return service[method](...args, context);
 });

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -53,13 +53,13 @@ export class Feathers<Services, Settings> extends EventEmitter implements Feathe
     return this;
   }
 
-  defaultService (location: string): ServiceInterface<any> {
+  defaultService (location: string): ServiceInterface {
     throw new Error(`Can not find service '${location}'`);
   }
 
   service<L extends keyof Services & string> (
     location: L
-  ): FeathersService<this, keyof any extends keyof Services ? Service<any> : Services[L]> {
+  ): FeathersService<this, keyof any extends keyof Services ? Service : Services[L]> {
     const path = (stripSlashes(location) || '/') as L;
     const current = this.services[path];
 

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -21,13 +21,13 @@ import { enableLegacyHooks } from './hooks/legacy';
 
 const debug = createDebug('@feathersjs/feathers');
 
-export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements FeathersApplication<ServiceTypes, AppSettings> {
-  services: ServiceTypes = ({} as ServiceTypes);
-  settings: AppSettings = ({} as AppSettings);
-  mixins: ServiceMixin<Application<ServiceTypes, AppSettings>>[] = [ hookMixin, eventMixin ];
+export class Feathers<Services, Settings> extends EventEmitter implements FeathersApplication<Services, Settings> {
+  services: Services = ({} as Services);
+  settings: Settings = ({} as Settings);
+  mixins: ServiceMixin<Application<Services, Settings>>[] = [ hookMixin, eventMixin ];
   version: string = version;
   _isSetup = false;
-  appHooks: HookMap<Application<ServiceTypes, AppSettings>, any> = {
+  appHooks: HookMap<Application<Services, Settings>, any> = {
     [HOOKS]: [ (eventHook as any) ]
   };
 
@@ -38,11 +38,11 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     this.legacyHooks = enableLegacyHooks(this);
   }
 
-  get<L extends keyof AppSettings & string> (name: L): AppSettings[L] {
+  get<L extends keyof Settings & string> (name: L): Settings[L] {
     return this.settings[name];
   }
 
-  set<L extends keyof AppSettings & string> (name: L, value: AppSettings[L]) {
+  set<L extends keyof Settings & string> (name: L, value: Settings[L]) {
     this.settings[name] = value;
     return this;
   }
@@ -57,9 +57,9 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     throw new Error(`Can not find service '${location}'`);
   }
 
-  service<L extends keyof ServiceTypes & string> (
+  service<L extends keyof Services & string> (
     location: L
-  ): FeathersService<this, keyof any extends keyof ServiceTypes ? Service<any> : ServiceTypes[L]> {
+  ): FeathersService<this, keyof any extends keyof Services ? Service<any> : Services[L]> {
     const path = (stripSlashes(location) || '/') as L;
     const current = this.services[path];
 
@@ -71,9 +71,9 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     return current as any;
   }
 
-  use<L extends keyof ServiceTypes & string> (
+  use<L extends keyof Services & string> (
     path: L,
-    service: keyof any extends keyof ServiceTypes ? ServiceInterface<any> | Application : ServiceTypes[L],
+    service: keyof any extends keyof Services ? ServiceInterface | Application : Services[L],
     options?: ServiceOptions
   ): this {
     if (typeof path !== 'string') {
@@ -127,7 +127,7 @@ export class Feathers<ServiceTypes, AppSettings> extends EventEmitter implements
     if (Array.isArray(hookMap)) {
       this.appHooks[HOOKS].push(...hookMap as any);
     } else {
-      const methodHookMap = hookMap as HookMap<Application<ServiceTypes, AppSettings>, any>;
+      const methodHookMap = hookMap as HookMap<Application<Services, Settings>, any>;
 
       Object.keys(methodHookMap).forEach(key => {
         const methodHooks = this.appHooks[key] || [];

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -115,7 +115,7 @@ export type ServiceMixin<A> = (service: FeathersService<A>, path: string, option
 export type ServiceGenericType<S> = S extends ServiceInterface<infer T> ? T : any;
 export type ServiceGenericData<S> = S extends ServiceInterface<infer _T, infer D> ? D : any;
 
-export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
+export interface FeathersApplication<Services = any, Settings = any> {
   /**
    * The Feathers application version
    */
@@ -124,7 +124,7 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
   /**
    * A list of callbacks that run when a new service is registered
    */
-  mixins: ServiceMixin<Application<ServiceTypes, AppSettings>>[];
+  mixins: ServiceMixin<Application<Services, Settings>>[];
 
   /**
    * The index of all services keyed by their path.
@@ -132,13 +132,13 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
    * __Important:__ Services should always be retrieved via `app.service('name')`
    * not via `app.services`.
    */
-  services: ServiceTypes;
+  services: Services;
 
   /**
    * The application settings that can be used via
    * `app.get` and `app.set`
    */
-  settings: AppSettings;
+  settings: Settings;
 
   /**
    * A private-ish indicator if `app.setup()` has been called already
@@ -148,14 +148,14 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
   /**
    * Contains all registered application level hooks.
    */
-  appHooks: HookMap<Application<ServiceTypes, AppSettings>, any>;
+  appHooks: HookMap<Application<Services, Settings>, any>;
 
   /**
    * Retrieve an application setting by name
    *
    * @param name The setting name
    */
-  get<L extends keyof AppSettings & string> (name: L): AppSettings[L];
+  get<L extends keyof Settings & string> (name: L): Settings[L];
 
   /**
    * Set an application setting
@@ -163,7 +163,7 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
    * @param name The setting name
    * @param value The setting value
    */
-  set<L extends keyof AppSettings & string> (name: L, value: AppSettings[L]): this;
+  set<L extends keyof Settings & string> (name: L, value: Settings[L]): this;
 
   /**
    * Runs a callback configure function with the current application instance.
@@ -191,9 +191,9 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
    * Feathers application to use a sub-app under the `path` prefix.
    * @param options The options for this service
    */
-  use<L extends keyof ServiceTypes & string> (
+  use<L extends keyof Services & string> (
     path: L,
-    service: keyof any extends keyof ServiceTypes ? ServiceInterface<any> | Application : ServiceTypes[L],
+    service: keyof any extends keyof Services ? ServiceInterface | Application : Services[L],
     options?: ServiceOptions
   ): this;
 
@@ -204,9 +204,9 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
    *
    * @param path The name of the service.
    */
-  service<L extends keyof ServiceTypes & string> (
+  service<L extends keyof Services & string> (
     path: L
-  ): FeathersService<this, keyof any extends keyof ServiceTypes ? Service<any> : ServiceTypes[L]>;
+  ): FeathersService<this, keyof any extends keyof Services ? Service<any> : Services[L]>;
 
   setup (server?: any): Promise<this>;
 
@@ -220,7 +220,7 @@ export interface FeathersApplication<ServiceTypes = any, AppSettings = any> {
 
 // This needs to be an interface instead of a type
 // so that the declaration can be extended by other modules
-export interface Application<ServiceTypes = any, AppSettings = any> extends FeathersApplication<ServiceTypes, AppSettings>, EventEmitter {
+export interface Application<Services = any, Settings = any> extends FeathersApplication<Services, Settings>, EventEmitter {
 
 }
 

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -20,7 +20,7 @@ export interface ServiceOptions {
   serviceEvents?: string[];
 }
 
-export interface ServiceMethods<T, D = Partial<T>> {
+export interface ServiceMethods<T = any, D = Partial<T>> {
   find (params?: Params): Promise<T | T[]>;
 
   get (id: Id, params?: Params): Promise<T>;
@@ -36,7 +36,7 @@ export interface ServiceMethods<T, D = Partial<T>> {
   setup (app: Application, path: string): Promise<void>;
 }
 
-export interface ServiceOverloads<T, D> {
+export interface ServiceOverloads<T = any, D = Partial<T>> {
   create? (data: D[], params?: Params): Promise<T[]>;
 
   update? (id: Id, data: D, params?: Params): Promise<T>;
@@ -52,14 +52,14 @@ export interface ServiceOverloads<T, D> {
   remove? (id: null, params?: Params): Promise<T[]>;
 }
 
-export type Service<T, D = Partial<T>> =
+export type Service<T = any, D = Partial<T>> =
   ServiceMethods<T, D> &
   ServiceOverloads<T, D>;
 
-export type ServiceInterface<T, D = Partial<T>> =
+export type ServiceInterface<T = any, D = Partial<T>> =
   Partial<ServiceMethods<T, D>>;
 
-export interface ServiceAddons<A = Application, S = Service<any, any>> extends EventEmitter {
+export interface ServiceAddons<A = Application, S = Service> extends EventEmitter {
   id?: string;
   hooks (options: HookOptions<A, S>): this;
 }
@@ -103,7 +103,7 @@ export interface ServiceHookOverloads<S> {
   ): Promise<HookContext>;
 }
 
-export type FeathersService<A = FeathersApplication, S = Service<any>> =
+export type FeathersService<A = FeathersApplication, S = Service> =
   S & ServiceAddons<A, S> & OptionalPick<ServiceHookOverloads<S>, keyof S>;
 
 export type CustomMethod<Methods extends string> = {
@@ -179,7 +179,7 @@ export interface FeathersApplication<Services = any, Settings = any> {
    *
    * @param location The path of the service
    */
-  defaultService (location: string): ServiceInterface<any>;
+  defaultService (location: string): ServiceInterface;
 
   /**
    * Register a new service or a sub-app. When passed another
@@ -206,7 +206,7 @@ export interface FeathersApplication<Services = any, Settings = any> {
    */
   service<L extends keyof Services & string> (
     path: L
-  ): FeathersService<this, keyof any extends keyof Services ? Service<any> : Services[L]>;
+  ): FeathersService<this, keyof any extends keyof Services ? Service : Services[L]>;
 
   setup (server?: any): Promise<this>;
 
@@ -318,10 +318,10 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
 }
 
 // Legacy hook typings
-export type LegacyHookFunction<A = Application, S = Service<any, any>> =
+export type LegacyHookFunction<A = Application, S = Service> =
   (this: S, context: HookContext<A, S>) => (Promise<HookContext<Application, S> | void> | HookContext<Application, S> | void);
 
-export type Hook<A = Application, S = Service<any, any>> = LegacyHookFunction<A, S>;
+export type Hook<A = Application, S = Service> = LegacyHookFunction<A, S>;
 
 type LegacyHookMethodMap<A, S> =
   { [L in keyof S]?: SelfOrArray<LegacyHookFunction<A, S>>; } &
@@ -337,7 +337,7 @@ export type LegacyHookMap<A, S> = {
 }
 
 // New @feathersjs/hook typings
-export type HookFunction<A = Application, S = Service<any, any>> =
+export type HookFunction<A = Application, S = Service> =
   (context: HookContext<A, S>, next: NextFunction) => Promise<void>;
 
 export type HookMap<A, S> = {

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -106,8 +106,8 @@ export interface ServiceHookOverloads<S> {
 export type FeathersService<A = FeathersApplication, S = Service> =
   S & ServiceAddons<A, S> & OptionalPick<ServiceHookOverloads<S>, keyof S>;
 
-export type CustomMethod<Methods extends string> = {
-  [k in Methods]: <X = any> (data: any, params?: Params) => Promise<X>;
+export type CustomMethods<T extends {[key: string]: [any, any]}> = {
+  [K in keyof T]: (data: T[K][0], params?: Params) => Promise<T[K][1]>;
 }
 
 export type ServiceMixin<A> = (service: FeathersService<A>, path: string, options?: ServiceOptions) => void;

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -63,7 +63,9 @@ export function hookMixin<A> (
   }
 
   const app = this;
-  const serviceMethodHooks = getHookMethods(service, options).reduce((res, method) => {
+  const hookMethods = getHookMethods(service, options);
+
+  const serviceMethodHooks = hookMethods.reduce((res, method) => {
     const params = (defaultServiceArguments as any)[method] || [ 'data', 'params' ];
 
     res[method] = new FeathersHookManager<A>(app, method)
@@ -79,7 +81,8 @@ export function hookMixin<A> (
 
     return res;
   }, {} as HookMap);
-  const handleLegacyHooks = enableLegacyHooks(service);
+
+  const handleLegacyHooks = enableLegacyHooks(service, hookMethods);
 
   hooks(service, serviceMethodHooks);
 

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -15,7 +15,7 @@ import {
 
 export { fromAfterHook, fromBeforeHook, fromErrorHooks };
 
-export function createContext (service: Service<any>, method: string, data: HookContextData = {}) {
+export function createContext (service: Service, method: string, data: HookContextData = {}) {
   const createContext = (service as any)[method].createContext;
 
   if (typeof createContext !== 'function') {

--- a/packages/feathers/test/hooks/error.test.ts
+++ b/packages/feathers/test/hooks/error.test.ts
@@ -170,7 +170,7 @@ describe('`error` hooks', () => {
     const errorMessage = 'before hook broke';
 
     let app: Application;
-    let service: FeathersService<any>;
+    let service: FeathersService;
 
     beforeEach(() => {
       app = feathers().use('/dummy', {

--- a/packages/koa/src/declarations.ts
+++ b/packages/koa/src/declarations.ts
@@ -1,6 +1,6 @@
 import Koa from 'koa';
 import { Server } from 'http';
-import { Application as FeathersApplication } from '@feathersjs/feathers';
+import { Application as FeathersApplication, HookContext, Params } from '@feathersjs/feathers';
 import '@feathersjs/authentication';
 
 export type ApplicationAddons = {
@@ -13,3 +13,10 @@ export type Application<T = any, C = any> =
 export type FeathersKoaContext<A = Application> = Koa.Context & {
   app: A;
 };
+
+declare module 'koa' {
+  interface ExtendableContext {
+    feathers?: Partial<Params>;
+    hook?: HookContext;
+  }
+}

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -15,11 +15,11 @@ export * from './authenticate';
 export { rest } from './rest';
 export { Koa, bodyParser, errorHandler };
 
-export function koa (_app?: FeathersApplication): Application<any> {
+export function koa (_app?: FeathersApplication): Application {
   const koaApp = new Koa();
 
   if (!_app) {
-    return koaApp as unknown as Application<any>;
+    return koaApp as unknown as Application;
   }
 
   if (typeof _app.setup !== 'function') {

--- a/packages/koa/src/rest.ts
+++ b/packages/koa/src/rest.ts
@@ -10,7 +10,7 @@ const debug = createDebug('@feathersjs/koa:rest');
 export function rest () {
   return async (ctx: FeathersKoaContext, next: Next) => {
     const { app, request } = ctx;
-    const { query: koaQuery, path, body: data, method: httpMethod } = request;
+    const { query: koaQuery, headers, path, body: data, method: httpMethod } = request;
     const query = { ...koaQuery };
     const methodOverride = request.headers[http.METHOD_HEADER] ?
       request.headers[http.METHOD_HEADER] as string : null;
@@ -33,6 +33,7 @@ export function rest () {
       const params = {
         ...ctx.feathers,
         query,
+        headers,
         route
       };
       const args = createArguments({ id, data, params });

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -63,6 +63,7 @@
     "@feathersjs/tests": "^5.0.0-pre.14",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.10.4",
+    "@types/qs": "^6.9.7",
     "axios": "^0.23.0",
     "mocha": "^9.1.2",
     "node-fetch": "^2.6.1",

--- a/packages/rest-client/test/declarations.ts
+++ b/packages/rest-client/test/declarations.ts
@@ -1,6 +1,6 @@
-import { CustomMethod } from '@feathersjs/feathers';
+import { CustomMethods } from '@feathersjs/feathers';
 import { RestService } from '../src';
 
 export type ServiceTypes = {
-  todos: RestService & CustomMethod<'customMethod'>
+  todos: RestService & CustomMethods<{customMethod: any}>
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@feathersjs/errors": "^5.0.0-pre.14",
     "@feathersjs/feathers": "^5.0.0-pre.14",
+    "@types/json-schema": "^7.0.9",
     "ajv": "^8.6.3",
     "json-schema": "^0.3.0",
     "json-schema-to-ts": "^1.6.4"

--- a/packages/socketio-client/test/index.test.ts
+++ b/packages/socketio-client/test/index.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { Server } from 'http';
-import { CustomMethod, feathers } from '@feathersjs/feathers';
+import { CustomMethods, feathers } from '@feathersjs/feathers';
 import { io, Socket } from 'socket.io-client';
 import { clientTests } from '@feathersjs/tests';
 
@@ -9,7 +9,7 @@ import socketio, { SocketService } from '../src';
 
 type ServiceTypes = {
   '/': SocketService,
-  'todos': SocketService & CustomMethod<'customMethod'>,
+  'todos': SocketService & CustomMethods<{customMethod: any}>,
   [key: string]: any;
 }
 

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -51,13 +51,13 @@
   },
   "dependencies": {
     "@feathersjs/commons": "^5.0.0-pre.14",
+    "@feathersjs/feathers": "^5.0.0-pre.14",
     "@feathersjs/transport-commons": "^5.0.0-pre.14",
     "socket.io": "^4.2.0"
   },
   "devDependencies": {
     "@feathersjs/commons": "^5.0.0-pre.2",
     "@feathersjs/express": "^5.0.0-pre.14",
-    "@feathersjs/feathers": "^5.0.0-pre.14",
     "@feathersjs/memory": "^5.0.0-pre.14",
     "@feathersjs/tests": "^5.0.0-pre.14",
     "@types/mocha": "^9.0.0",

--- a/packages/socketio/src/index.ts
+++ b/packages/socketio/src/index.ts
@@ -9,7 +9,7 @@ import { disconnect, params, authentication, FeathersSocket } from './middleware
 const debug = createDebug('@feathersjs/socketio');
 
 declare module '@feathersjs/feathers/lib/declarations' {
-  interface Application<ServiceTypes, AppSettings> { // eslint-disable-line
+  interface Application<Services, Settings> { // eslint-disable-line
     io: Server;
     listen (options: any): Promise<http.Server>;
   }

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -54,10 +54,12 @@
   "dependencies": {
     "@feathersjs/commons": "^5.0.0-pre.14",
     "@feathersjs/errors": "^5.0.0-pre.14",
+    "@feathersjs/feathers": "^5.0.0-pre.14",
+    "@feathersjs/hooks": "^0.6.5",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@feathersjs/feathers": "^5.0.0-pre.14",
+    "@types/lodash": "^4.14.175",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.10.4",
     "mocha": "^9.1.2",

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -55,7 +55,6 @@
     "@feathersjs/commons": "^5.0.0-pre.14",
     "@feathersjs/errors": "^5.0.0-pre.14",
     "@feathersjs/feathers": "^5.0.0-pre.14",
-    "@feathersjs/hooks": "^0.6.5",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -51,7 +51,7 @@ export function channels () {
       }
     });
 
-    app.mixins.push((service: FeathersService<any>, path: string) => {
+    app.mixins.push((service: FeathersService, path: string) => {
       const { serviceEvents } = getServiceOptions(service);
 
       if (typeof service.publish === 'function') {

--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -18,7 +18,7 @@ declare module '@feathersjs/feathers/lib/declarations' {
     registerPublisher (event: Event, publisher: Publisher<ServiceGenericType<S>>): this;
   }
 
-  interface Application<ServiceTypes, AppSettings> { // eslint-disable-line
+  interface Application<Services, Settings> { // eslint-disable-line
     channels: string[];
 
     channel (name: string[]): Channel;

--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -11,24 +11,24 @@ const { CHANNELS } = keys;
 
 declare module '@feathersjs/feathers/lib/declarations' {
   interface ServiceAddons<A, S> extends EventEmitter { // eslint-disable-line
-    publish (publisher: Publisher<ServiceGenericType<S>>): this;
-    publish (event: Event, publisher: Publisher<ServiceGenericType<S>>): this;
+    publish (publisher: Publisher<ServiceGenericType<S>, A, this>): this;
+    publish (event: Event, publisher: Publisher<ServiceGenericType<S>, A, this>): this;
 
-    registerPublisher (publisher: Publisher<ServiceGenericType<S>>): this;
-    registerPublisher (event: Event, publisher: Publisher<ServiceGenericType<S>>): this;
+    registerPublisher (publisher: Publisher<ServiceGenericType<S>, A, this>): this;
+    registerPublisher (event: Event, publisher: Publisher<ServiceGenericType<S>, A, this>): this;
   }
 
   interface Application<Services, Settings> { // eslint-disable-line
     channels: string[];
 
-    channel (name: string[]): Channel;
+    channel (name: string | string[]): Channel;
     channel (...names: string[]): Channel;
 
-    publish<T> (publisher: Publisher<T>): this;
-    publish<T> (event: Event, publisher: Publisher<T>): this;
+    publish<T> (publisher: Publisher<T, this>): this;
+    publish<T> (event: Event, publisher: Publisher<T, this>): this;
 
-    registerPublisher<T> (publisher: Publisher<T>): this;
-    registerPublisher<T> (event: Event, publisher: Publisher<T>): this;
+    registerPublisher<T> (publisher: Publisher<T, this>): this;
+    registerPublisher<T> (event: Event, publisher: Publisher<T, this>): this;
   }
 
   interface Params {

--- a/packages/transport-commons/src/channels/mixins.ts
+++ b/packages/transport-commons/src/channels/mixins.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import { HookContext, getServiceOptions } from '@feathersjs/feathers';
+import { Application, HookContext, getServiceOptions } from '@feathersjs/feathers';
 import { createDebug } from '@feathersjs/commons';
 import { Channel } from './channel/base';
 import { CombinedChannel } from './channel/combined';
@@ -63,7 +63,7 @@ export function channelMixin () {
 
 export type Event = string|(typeof ALL_EVENTS);
 
-export type Publisher<T = any> = (data: T, context: HookContext<T>) => Channel | Channel[] | void | Promise<Channel | Channel[] | void>;
+export type Publisher<T = any, A = Application, S = any> = (data: T, context: HookContext<A, S>) => Channel | Channel[] | void | Promise<Channel | Channel[] | void>;
 
 export interface PublishMixin<T = any> {
   [PUBLISHERS]: { [ALL_EVENTS]?: Publisher<T>, [key: string]: Publisher<T> };

--- a/packages/transport-commons/src/http.ts
+++ b/packages/transport-commons/src/http.ts
@@ -1,6 +1,5 @@
 import { MethodNotAllowed } from '@feathersjs/errors/lib';
 import { HookContext, NullableId, Params } from '@feathersjs/feathers';
-import { BaseHookContext } from '@feathersjs/hooks';
 
 export const METHOD_HEADER = 'x-service-method';
 
@@ -17,7 +16,7 @@ export const statusCodes = {
   success: 200
 };
 
-export const knownMethods: { [key: string]: any } = {
+export const knownMethods: { [key: string]: string } = {
   post: 'create',
   patch: 'patch',
   put: 'update',
@@ -54,25 +53,19 @@ export const argumentsFor = {
   default: ({ data, params }: ServiceParams) => [ data, params ]
 }
 
-export function getData (context: HookContext|{ [key: string]: any }) {
-  if (!(context instanceof BaseHookContext)) {
-    return context;
-  }
-
+export function getData (context: HookContext) {
   return context.dispatch !== undefined
     ? context.dispatch
     : context.result;
 }
 
 export function getStatusCode (context: HookContext, data?: any) {
-  if (context instanceof BaseHookContext) {
-    if (context.statusCode) {
-      return context.statusCode;
-    }
+  if (context.statusCode) {
+    return context.statusCode;
+  }
 
-    if (context.method === 'create') {
-      return statusCodes.created;
-    }
+  if (context.method === 'create') {
+    return statusCodes.created;
   }
 
   if (!data) {

--- a/packages/transport-commons/src/routing/index.ts
+++ b/packages/transport-commons/src/routing/index.ts
@@ -7,7 +7,7 @@ declare module '@feathersjs/feathers/lib/declarations' {
     params: { [key: string]: string }
   }
 
-  interface Application<ServiceTypes, AppSettings> {  // eslint-disable-line
+  interface Application<Services, Settings> {  // eslint-disable-line
     routes: Router<any>;
     lookup (path: string): RouteLookup;
   }

--- a/packages/transport-commons/src/routing/index.ts
+++ b/packages/transport-commons/src/routing/index.ts
@@ -3,12 +3,12 @@ import { Router } from './router';
 
 declare module '@feathersjs/feathers/lib/declarations' {
   interface RouteLookup {
-    service: Service<any>,
+    service: Service,
     params: { [key: string]: string }
   }
 
   interface Application<Services, Settings> {  // eslint-disable-line
-    routes: Router<any>;
+    routes: Router;
     lookup (path: string): RouteLookup;
   }
 }
@@ -38,7 +38,7 @@ export const routing = () => (app: Application) => {
   });
 
   // Add a mixin that registers a service on the router
-  app.mixins.push((service: Service<any>, path: string) => {
+  app.mixins.push((service: Service, path: string) => {
     app.routes.insert(path, service);
     app.routes.insert(`${path}/:__id`, service);
   });

--- a/packages/transport-commons/src/routing/router.ts
+++ b/packages/transport-commons/src/routing/router.ts
@@ -77,7 +77,7 @@ export class RouteNode<T = any> {
   }
 }
 
-export class Router<T> {
+export class Router<T = any> {
   constructor (public root: RouteNode<T> = new RouteNode<T>('', 0)) {}
 
   getPath (path: string) {

--- a/packages/transport-commons/test/client.test.ts
+++ b/packages/transport-commons/test/client.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { EventEmitter } from 'events';
-import { CustomMethod } from '@feathersjs/feathers';
+import { CustomMethods } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
 import { Service, SocketService } from '../src/client';
 
@@ -9,7 +9,7 @@ declare type DummyCallback = (err: any, data?: any) => void;
 describe('client', () => {
   let connection: any;
   let testData: any;
-  let service: SocketService & CustomMethod<'customMethod'> & EventEmitter;
+  let service: SocketService & CustomMethods<{customMethod: any}> & EventEmitter;
 
   beforeEach(() => {
     connection = new EventEmitter();

--- a/packages/transport-commons/test/http.test.ts
+++ b/packages/transport-commons/test/http.test.ts
@@ -1,32 +1,29 @@
 import assert from 'assert';
 import { HookContext } from '@feathersjs/feathers';
-import { BaseHookContext } from '@feathersjs/hooks';
-
 import { http } from '../src';
 
 describe('@feathersjs/transport-commons HTTP helpers', () => {
   it('getData', () => {
     const plainData = { message: 'hi' };
     const dispatch = { message: 'from dispatch' };
-    const resultContext = new BaseHookContext({
+    const resultContext = {
       result: plainData
-    });
-    const dispatchContext = new BaseHookContext({
+    };
+    const dispatchContext = {
       dispatch
-    });
+    };
 
-    assert.deepStrictEqual(http.getData(plainData), plainData);
-    assert.deepStrictEqual(http.getData(resultContext), plainData);
-    assert.deepStrictEqual(http.getData(dispatchContext), dispatch);
+    assert.deepStrictEqual(http.getData(resultContext as HookContext), plainData);
+    assert.deepStrictEqual(http.getData(dispatchContext as HookContext), dispatch);
   });
 
   it('getStatusCode', async () => {
-    const statusContext = new BaseHookContext({
+    const statusContext = {
       statusCode: 202
-    });
-    const createContext = new BaseHookContext({
+    };
+    const createContext = {
       method: 'create'
-    });
+    };
 
     assert.strictEqual(http.getStatusCode(statusContext as HookContext, {}), 202);
     assert.strictEqual(http.getStatusCode(createContext as HookContext, {}), http.statusCodes.created);


### PR DESCRIPTION
- Added missing dependencies.
- Renamed `Application` type parameters `ServiceTypes` to `Services` and `AppSettings` to `Settings`. That's the change that does not solve anything and a breakish one (since when somebody augment a module they have to use same names). Can remove.
- Default `T` to `any` in `Service` type (and its relatives), so that you can simply write `Service` instead of `Service<any>`. There is some slight difference between `Service`/`Service<any>` and `Service<any, any>` - first one has `D` as `Partial<any>`. If this change comes up somewhere, there is a way to add new type later to default `D` to `any` if `T` is `any`.
- `authentication` package had a problem with [`lib/index.d.ts`](https://unpkg.com/@feathersjs/authentication@5.0.0-pre.14/lib/index.d.ts) where there was an import of `@feathersjs/hooks` which is not a direct dependency of the package, fixed by tweaking exports.
- in `transport-commons` fix types for `Publisher` (wrong type for `context` arg) and `Application.channel` (not supporting an argument of type `string | string[]`).
- Rename `CustomMethod` type to `CustomMethods` and allow to easily specify `data` and return type or keep it `any` as it currently is.
- Pass hook enabled methods to `enableLegacyHooks` (so include custom and filter out unused ones).
- In `koa` add headers to params (not sure if should be cloned as query is, in `express` neither query nor headers are cloned).
- In `koa` add types for feathers props on koa context - `feathers` and `hook`.
- In `transport-commons` and `express` remove `hooks` dependency and use correct type for context - it isn't supposed to work with generic hook context, only with feathers one.