### PR TITLE
feat(transport-commons): Ability to register routes with custom params

### DIFF
--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -18,6 +18,7 @@ export interface ServiceOptions {
   events?: string[];
   methods?: string[];
   serviceEvents?: string[];
+  routeParams?: { [key: string]: any };
 }
 
 export interface ServiceMethods<T = any, D = Partial<T>> {
@@ -110,7 +111,7 @@ export type CustomMethods<T extends {[key: string]: [any, any]}> = {
   [K in keyof T]: (data: T[K][0], params?: Params) => Promise<T[K][1]>;
 }
 
-export type ServiceMixin<A> = (service: FeathersService<A>, path: string, options?: ServiceOptions) => void;
+export type ServiceMixin<A> = (service: FeathersService<A>, path: string, options: ServiceOptions) => void;
 
 export type ServiceGenericType<S> = S extends ServiceInterface<infer T> ? T : any;
 export type ServiceGenericData<S> = S extends ServiceInterface<infer _T, infer D> ? D : any;
@@ -234,7 +235,7 @@ export interface Query {
 export interface Params {
   query?: Query;
   provider?: string;
-  route?: { [key: string]: string };
+  route?: { [key: string]: any };
   headers?: { [key: string]: any };
   [key: string]: any; // (JL) not sure if we want this
 }

--- a/packages/transport-commons/src/routing/index.ts
+++ b/packages/transport-commons/src/routing/index.ts
@@ -1,4 +1,4 @@
-import { Application, Service } from '@feathersjs/feathers';
+import { Application, Service, ServiceOptions } from '@feathersjs/feathers';
 import { Router } from './router';
 
 declare module '@feathersjs/feathers/lib/declarations' {
@@ -41,8 +41,10 @@ export const routing = () => (app: Application) => {
   app.lookup = lookup;
 
   // Add a mixin that registers a service on the router
-  app.mixins.push((service: Service, path: string) => {
-    app.routes.insert(path, { service });
-    app.routes.insert(`${path}/:__id`, { service });
+  app.mixins.push((service: Service, path: string, options: ServiceOptions) => {
+    const { routeParams: params = {} } = options;
+
+    app.routes.insert(path, { service, params });
+    app.routes.insert(`${path}/:__id`, { service, params });
   });
 };

--- a/packages/transport-commons/src/routing/index.ts
+++ b/packages/transport-commons/src/routing/index.ts
@@ -4,42 +4,45 @@ import { Router } from './router';
 declare module '@feathersjs/feathers/lib/declarations' {
   interface RouteLookup {
     service: Service,
-    params: { [key: string]: string }
+    params: { [key: string]: any }
   }
 
   interface Application<Services, Settings> {  // eslint-disable-line
-    routes: Router;
+    routes: Router<{
+      service: Service,
+      params?: { [key: string]: any }
+    }>;
     lookup (path: string): RouteLookup;
   }
 }
 
 export * from './router';
 
+const lookup = function(this: Application, path: string) {
+  const result = this.routes.lookup(path);
+
+  if (result === null) {
+    return null;
+  }
+
+  const { params: colonParams, data: { service, params: dataParams } } = result;
+
+  const params = dataParams ? { ...dataParams, ...colonParams } : colonParams;
+
+  return { service, params };
+};
+
 export const routing = () => (app: Application) => {
   if (typeof app.lookup === 'function') {
     return;
   }
 
-  const routes = new Router();
-
-  Object.assign(app, {
-    routes,
-    lookup (this: Application, path: string) {
-      const result = this.routes.lookup(path);
-
-      if (result !== null) {
-        const { params, data: service } = result;
-
-        return { params, service };
-      }
-
-      return result;
-    }
-  });
+  app.routes = new Router();
+  app.lookup = lookup;
 
   // Add a mixin that registers a service on the router
   app.mixins.push((service: Service, path: string) => {
-    app.routes.insert(path, service);
-    app.routes.insert(`${path}/:__id`, service);
+    app.routes.insert(path, { service });
+    app.routes.insert(`${path}/:__id`, { service });
   });
 };

--- a/packages/transport-commons/test/routing/index.test.ts
+++ b/packages/transport-commons/test/routing/index.test.ts
@@ -69,4 +69,19 @@ describe('app.routes', () => {
       second: '::special'
     });
   });
+
+  it('can register routes with preset params', () => {
+    app.routes.insert('/my/service/:__id/preset', {
+      service: app.service('/my/service'),
+      params: { preset: true }
+    });
+
+    const result = app.lookup('/my/service/1234/preset');
+
+    assert.strictEqual(result.service, app.service('/my/service'));
+    assert.deepStrictEqual(result.params, {
+      preset: true,
+      __id: '1234'
+    });
+  });
 });

--- a/packages/transport-commons/test/routing/index.test.ts
+++ b/packages/transport-commons/test/routing/index.test.ts
@@ -84,4 +84,22 @@ describe('app.routes', () => {
       __id: '1234'
     });
   });
+
+  it('can pass route params during a service registration', () => {
+    app.use('/other/service', {
+      async get (id: any) {
+        return id;
+      }
+    }, {
+      routeParams: { used: true }
+    });
+
+    const result = app.lookup('/other/service/1234');
+
+    assert.strictEqual(result.service, app.service('/other/service'));
+    assert.deepStrictEqual(result.params, {
+      used: true,
+      __id: '1234'
+    });
+  });
 });


### PR DESCRIPTION
Allows to add routes with some predetermined route params which are not placeholder based.

```ts
// context.params.route.some will be 'param' for '/some/path' 
app.routes.insert('/some/path', { service, params: { some: 'param' } });
```