### PR TITLE
feat(http): Add `redirect` property to hook context

### DIFF
--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -313,6 +313,10 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
    */
   statusCode?: number;
   /**
+   * A writeable, optional property that allows to set a redirect location.
+   */
+  redirect?: string;
+  /**
    * The event emitted by this method. Can be set to `null` to skip event emitting.
    */
   event: string|null;

--- a/packages/koa/src/rest.ts
+++ b/packages/koa/src/rest.ts
@@ -37,14 +37,19 @@ export function rest () {
         route
       };
       const args = createArguments({ id, data, params });
-      const hookContext = createContext(service, method);
+      const contextBase = createContext(service, method);
+      ctx.hook = contextBase;
 
-      ctx.hook = hookContext as any;
+      const context = await (service as any)[method](...args, contextBase);
+      ctx.hook = context;
 
-      const result = await (service as any)[method](...args, hookContext);
+      const result = http.getData(context);
+      const statusCode = http.getStatusCode(context, result);
+      const location = http.getLocation(context, ctx.get('Referrer'));
 
-      ctx.response.status = http.getStatusCode(result, {});
-      ctx.body = http.getData(result);
+      ctx.body = result;
+      ctx.status = statusCode;
+      if (location) ctx.set('Location', location);
     }
 
     return next();

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -55,9 +55,11 @@
     "@feathersjs/commons": "^5.0.0-pre.14",
     "@feathersjs/errors": "^5.0.0-pre.14",
     "@feathersjs/feathers": "^5.0.0-pre.14",
+    "encodeurl": "^1.0.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@types/encodeurl": "^1.0.0",
     "@types/lodash": "^4.14.176",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.6",

--- a/packages/transport-commons/src/http.ts
+++ b/packages/transport-commons/src/http.ts
@@ -1,5 +1,6 @@
 import { MethodNotAllowed } from '@feathersjs/errors/lib';
 import { HookContext, NullableId, Params } from '@feathersjs/feathers';
+import encodeUrl from 'encodeurl';
 
 export const METHOD_HEADER = 'x-service-method';
 
@@ -13,7 +14,8 @@ export const statusCodes = {
   created: 201,
   noContent: 204,
   methodNotAllowed: 405,
-  success: 200
+  success: 200,
+  seeOther: 303
 };
 
 export const knownMethods: { [key: string]: string } = {
@@ -68,9 +70,23 @@ export function getStatusCode (context: HookContext, data?: any) {
     return statusCodes.created;
   }
 
+  if (context.redirect) {
+    return statusCodes.seeOther;
+  }
+
   if (!data) {
     return statusCodes.noContent;
   }
 
   return statusCodes.success;
+}
+
+export function getLocation(context: HookContext, referrer?: string) {
+  const redirect = context.redirect;
+
+  if (redirect === 'back') {
+    return encodeUrl(referrer || '/');
+  }
+
+  return redirect && encodeUrl(redirect);
 }


### PR DESCRIPTION
Adds standard way to specify a redirect location.

Before it was ok (not perfect, but ok) to do it with an express middleware but since there is now koa transport (and potentially in the future there will be other bare bone http one) it would be more beneficial to have a proper way for common functionality. 

To do it consistently had to add `encodeurl` dependency to `transport-commons` - both `koa` and `express` use it to escape location, but `koa` does not have `.location()` function (unlike express), only `.redirect()` which also does bunch of other stuff with body. 

If `statusCode` is not specified and `redirect` is present, then status defaults to 303. Default should be either that or 302 (former says to use GET request, later should be for temporary redirects with same request method).

Made code in rest between `koa` and `express` a little more consistent.

Also since a hook manager can theoretically (if overwritten) return a different context from one that was passed in to `initializeContext` have to set `res.hook`/`ctx.hook` twice - first when `base` is created (in case a method throws), second after a final context returned. (Not that anyone would do it, just a pedantic change.)

Still need to add some tests.