### PR TITLE
feat(core): add `context.http` and move `statusCode` there

### DIFF
--- a/packages/express/src/rest.ts
+++ b/packages/express/src/rest.ts
@@ -66,7 +66,7 @@ export const serviceMethodHandler = (
   }
 
   const args = getArgs(options);
-  const context = createContext(service, method);
+  const context = createContext(service, method, { http: {} });
 
   res.hook = context;
 

--- a/packages/express/test/rest.test.ts
+++ b/packages/express/test/rest.test.ts
@@ -158,6 +158,7 @@ describe('@feathersjs/express/rest provider', () => {
           type: null,
           method: 'get',
           path: 'hook',
+          http: {},
           event: null,
           result: { description: 'You have to do dishes' },
           addedProperty: true
@@ -196,7 +197,7 @@ describe('@feathersjs/express/rest provider', () => {
 
         app.service('hook-status').hooks({
           after (hook: HookContext) {
-            hook.statusCode = 206;
+            hook.http!.statusCode = 206;
           }
         });
 
@@ -244,7 +245,8 @@ describe('@feathersjs/express/rest provider', () => {
               type: null,
               event: null,
               method: 'get',
-              path: 'hook-error'
+              path: 'hook-error',
+              http: {}
             },
             error: { message: 'I blew up' }
           });

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -240,6 +240,14 @@ export interface Params {
   [key: string]: any; // (JL) not sure if we want this
 }
 
+export interface Http {
+  /**
+   * A writeable, optional property that allows to override the standard HTTP status
+   * code that should be returned.
+   */
+  statusCode?: number;
+}
+
 export interface HookContext<A = Application, S = any> extends BaseHookContext<ServiceGenericType<S>> {
   /**
    * A read only property that contains the Feathers application object. This can be used to
@@ -310,8 +318,14 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
   /**
    * A writeable, optional property that allows to override the standard HTTP status
    * code that should be returned.
+   *
+   * @deprecated Use `http.statusCode` instead.
    */
   statusCode?: number;
+  /**
+   * A writeable, optional property that contains options specific to HTTP transports.
+   */
+  http?: Http;
   /**
    * The event emitted by this method. Can be set to `null` to skip event emitting.
    */

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -80,7 +80,13 @@ export function hookMixin<A> (
         method,
         service,
         event: null,
-        type: null
+        type: null,
+        get statusCode() {
+          return this.http?.statusCode;
+        },
+        set statusCode(value: number) {
+          (this.http ||= {}).statusCode = value;
+        }
       });
 
     return res;

--- a/packages/koa/src/rest.ts
+++ b/packages/koa/src/rest.ts
@@ -37,7 +37,7 @@ export function rest () {
         route
       };
       const args = createArguments({ id, data, params });
-      const hookContext = createContext(service, method);
+      const hookContext = createContext(service, method, { http: {} });
 
       ctx.hook = hookContext as any;
 

--- a/packages/transport-commons/src/http.ts
+++ b/packages/transport-commons/src/http.ts
@@ -60,8 +60,8 @@ export function getData (context: HookContext) {
 }
 
 export function getStatusCode (context: HookContext, data?: any) {
-  if (context.statusCode) {
-    return context.statusCode;
+  if (context.http?.statusCode) {
+    return context.http.statusCode;
   }
 
   if (context.method === 'create') {

--- a/packages/transport-commons/test/http.test.ts
+++ b/packages/transport-commons/test/http.test.ts
@@ -19,7 +19,7 @@ describe('@feathersjs/transport-commons HTTP helpers', () => {
 
   it('getStatusCode', async () => {
     const statusContext = {
-      statusCode: 202
+      http: { statusCode: 202 }
     };
     const createContext = {
       method: 'create'


### PR DESCRIPTION
This is `context.http` from #2484.

Here it contains only `statusCode` (can be renamed to `status` or not, don't have an opinion one way or another so kept previous name), with the idea to add `responseHeaders` later (`redirect` is not needed since it will be covered by those two).

I used getter/setter to prevent having two sources of truth and things getting out of sync. Also ideally a depreciation message should be added to those accessors that will write a warning first time one of them is accessed (a helper function for such depreciations can be added to `@feathersjs/commons`).