### PR TITLE
fix(express): missing express types for Request, Response

### DIFF
--- a/packages/express/src/authentication.ts
+++ b/packages/express/src/authentication.ts
@@ -1,6 +1,6 @@
 import { createDebug } from '@feathersjs/commons';
 import { merge, flatten } from 'lodash';
-import { NextFunction, RequestHandler } from 'express';
+import { NextFunction, RequestHandler, Request, Response } from 'express';
 
 const debug = createDebug('@feathersjs/express/authentication');
 


### PR DESCRIPTION
Fixes this issue:
![Screen Shot 2021-11-26 at 9 47 53 AM](https://user-images.githubusercontent.com/128857/143611599-4aed8489-3727-49e2-9732-2a88088a79ef.jpg)


