### PR TITLE
fix(adapter-commons) each of the ServiceOptions is now optional

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -18,15 +18,18 @@ const alwaysMulti: { [key: string]: boolean } = {
 
 export interface ServiceOptions {
   events?: string[];
-  multi: boolean|string[];
-  id: string;
-  paginate: {
+  multi?: boolean|string[];
+  id?: string;
+  paginate?: {
     default?: number;
     max?: number;
   }
+  /**
+   * @deprecated renamed to `allow`.
+   */
   whitelist?: string[];
-  allow: string[];
-  filters: string[];
+  allow?: string[];
+  filters?: string[];
 }
 
 export interface AdapterOptions<M = any> extends Pick<ServiceOptions, 'multi'|'allow'|'paginate'> {


### PR DESCRIPTION
- Marks `whitelist` as `@deprecated`, noting that it has been renamed to `allow`.
- Sets all options to optional, allowing them to use the defaults.

Fixes this problem:
![Screen Shot 2021-11-29 at 1 50 39 AM](https://user-images.githubusercontent.com/128857/143836374-088035bc-f911-4ded-97f3-ea67182c35c6.jpg)

