### PR TITLE
feat(core): add `app.addSetup` for asynchronous configuration steps

### DIFF
--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -209,6 +209,8 @@ export interface FeathersApplication<Services = any, Settings = any> {
     path: L
   ): FeathersService<this, keyof any extends keyof Services ? Service : Services[L]>;
 
+  addSetup (setup: Setup<this>): this;
+
   setup (server?: any): Promise<this>;
 
   /**
@@ -361,3 +363,5 @@ export type HookMap<A, S> = {
 
 export type HookOptions<A, S> =
   HookMap<A, S> | HookFunction<A, S>[] | RegularHookMap<A, S>;
+
+export type Setup<A = Application> = (app: A, server?: any) => void | Promise<void>;

--- a/packages/feathers/test/application.test.ts
+++ b/packages/feathers/test/application.test.ts
@@ -315,6 +315,31 @@ describe('Feathers application', () => {
       assert.strictEqual(setupCount, 2);
     });
 
+    it('app.setup calls functions passed to .addSetup', async () => {
+      const app = feathers();
+      const server = {};
+      let setupCount = 0;
+
+      const funcSetup = (count: number) => (appRef: typeof app, serverRef: any) => {
+        assert.strictEqual(setupCount++, count);
+        assert.strictEqual(appRef, app);
+        assert.strictEqual(serverRef, server);
+      };
+      const serviceSetup = (count: number) => async () => {
+        assert.strictEqual(setupCount++, count);
+      };
+
+      app.addSetup(funcSetup(0));
+      app.use('/first', { setup: serviceSetup(1) });
+      app.addSetup(funcSetup(2));
+      app.use('/second', { setup: serviceSetup(3) });
+      app.addSetup(funcSetup(4));
+      assert.strictEqual(setupCount, 0);
+
+      await app.setup(server);
+      assert.strictEqual(setupCount, 5);
+    });
+
     it('registering a service after app.setup will be set up', done => {
       const app = feathers();
 


### PR DESCRIPTION
Connected to #2500 and contains small fixes from #1611.

Adds `app.addSetup()` which allows adding asynchronous configuration/initialization steps.  
Those will run with services setups during `app.setup()` call. 

Services use this method to add their own setup calls to queue,
so one can add a step that runs before or after a specific service setup.

This is for cases when you don't have an appropriate service to implement `setup` method in.

Will add tests if that sounds as a reasonable addition.