### PR TITLE
OAuth redirect lost sometimes due to session store race (#2514)

### DIFF
--- a/packages/authentication-oauth/src/express.ts
+++ b/packages/authentication-oauth/src/express.ts
@@ -57,7 +57,13 @@ export default (options: OauthSetupSettings) => {
       req.session.redirect = redirect as string;
       req.session.query = query;
 
-      res.redirect(`${path}/connect/${name}?${qs.stringify(query as any)}`);
+      req.session.save((err: any) => {
+        if (err) {
+          res.status(500).send(`Error storing session: ${err}`);
+        } else {
+          res.redirect(`${path}/connect/${name}?${qs.stringify(query as any)}`);
+        }
+      });
     });
 
     authApp.get('/:name/callback', (req: any, res: any) => {


### PR DESCRIPTION
### Summary

This PR solves the issue (described in greater detail in #2514) where Feathers OAuth does not always redirect to the path requested by the `redirect` query parameter and instead redirects to the root of the site specified by `authentication.oauth.redirect`. This happens only a small percentage of the time and only when using an external Express session store that is somewhat slow.

The issue is due to a race condition where the Express session created during a request to `/oauth/:name` does not get saved before the browser makes a subsequent request in the OAuth flow (to `/oauth/connect/:name`)  and that causes Express to create a new session, effectively discarding the original session which contains the `redirect` parameter.

The fix is for Feathers to explicitly save the Express session in the `/oauth/:name` handler before responding with the redirect to `/oauth/connect/:name`.

This fix is consistent with guidance from Express session's [docs](https://github.com/expressjs/session#sessionsavecallback) (see bolded phrase):

> **Session.save(callback)**
> Save the session back to the store, replacing the contents on the store with the contents in memory (though a store may do something else--consult the store's documentation for exact behavior).
> This method is automatically called at the end of the HTTP response if the session data has been altered (though this behavior can be altered with various options in the middleware constructor). Because of this, typically this method does not need to be called.
> **There are some cases where it is useful to call this method, for example, redirects,** long-lived requests or in WebSockets.
 
Also see issues like https://github.com/expressjs/session/issues/660

Fixes: #2514 

### Other Information

**Tests run**

- `npm run test`

**Note on TypeScript version**

The newer version of TypeScript that gets installed with a fresh clone of this repo does not compile successfully due to TS changing the default type of the error in catch blocks to `unknown`. So I ran my tests by pinning TypeScript to an older version.
