### PR TITLE
feat(schema): Improve schema typing, validation and extensibility

### DIFF
--- a/packages/schema/src/query.ts
+++ b/packages/schema/src/query.ts
@@ -24,11 +24,3 @@ export const queryProperty = <T extends JSONSchema> (definition: T) => ({
     }
   ]
 } as const);
-
-export const queryArray = <T extends readonly string[]> (fields: T) => ({
-  type: 'array',
-  items: {
-    type: 'string',
-    enum: fields
-  }
-} as const);

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -1,44 +1,27 @@
-import Ajv, { AsyncValidateFunction } from 'ajv';
-import { JSONSchema6 } from 'json-schema';
+import Ajv, { AsyncValidateFunction, ValidateFunction } from 'ajv';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 
 export const AJV = new Ajv({
   coerceTypes: true
 });
 
-export type JSONSchemaDefinition = JSONSchema & { $id: string };
+export type JSONSchemaDefinition = JSONSchema & { $id: string, $async?: boolean };
 
 export class Schema<S extends JSONSchemaDefinition> {
   ajv: Ajv;
-  validate: AsyncValidateFunction<FromSchema<S>>;
-  definition: JSONSchema6;
+  validator: AsyncValidateFunction;
   readonly _type!: FromSchema<S>;
 
-  constructor (definition: S, ajv: Ajv = AJV) {
+  constructor (public definition: S, ajv: Ajv = AJV) {
     this.ajv = ajv;
-    this.definition = definition as JSONSchema6;
-    this.validate = this.ajv.compile({
+    this.validator = this.ajv.compile({
       $async: true,
-      ...this.definition
-    });
+      ...(this.definition as any)
+    }) as AsyncValidateFunction;
   }
 
-  get propertyNames () {
-    return Object.keys(this.definition.properties || {});
-  }
-
-  extend <D extends JSONSchemaDefinition> (definition: D) {
-    const def = definition as JSONSchema6;
-    const extended = {
-      ...this.definition,
-      ...def,
-      properties: {
-        ...this.definition.properties,
-        ...def.properties
-      }
-    } as const;
-
-    return new Schema <D & S> (extended as any, this.ajv);
+  validate <T = FromSchema<S>> (...args: Parameters<ValidateFunction<T>>) {
+    return this.validator(...args) as any as Promise<T>;
   }
 
   toJSON () {

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -1,5 +1,6 @@
 import Ajv, { AsyncValidateFunction, ValidateFunction } from 'ajv';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { BadRequest } from '@feathersjs/errors';
 
 export const AJV = new Ajv({
   coerceTypes: true
@@ -20,8 +21,14 @@ export class Schema<S extends JSONSchemaDefinition> {
     }) as AsyncValidateFunction;
   }
 
-  validate <T = FromSchema<S>> (...args: Parameters<ValidateFunction<T>>) {
-    return this.validator(...args) as any as Promise<T>;
+  async validate <T = FromSchema<S>> (...args: Parameters<ValidateFunction<T>>) {
+    try {
+      const validated = await this.validator(...args) as T;
+
+      return validated;
+    } catch (error: any) {
+      throw new BadRequest(error.message, error.errors);
+    }
   }
 
   toJSON () {

--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -24,15 +24,15 @@ export const userResultSchema = schema({
   $id: 'UserResult',
   type: 'object',
   additionalProperties: false,
-  required: ['id'],
-  allOf: [{ $ref: 'UserData' }],
+  required: ['id', ...userSchema.definition.required ],
   properties: {
+    ...userSchema.definition.properties,
     id: { type: 'number' }
   }
 } as const);
 
 export type User = Infer<typeof userSchema>;
-export type UserResult = User & Infer<typeof userResultSchema>;
+export type UserResult = Infer<typeof userResultSchema>;
 
 export const userDataResolver = resolve<User, HookContext<Application>>({
   properties: {
@@ -65,16 +65,16 @@ export const messageResultSchema = schema({
   $id: 'MessageResult',
   type: 'object',
   additionalProperties: false,
-  required: ['id', 'user'],
-  allOf: [{ $ref: 'MessageData' }],
+  required: ['id', 'user', ...messageSchema.definition.required],
   properties: {
+    ...messageSchema.definition.properties,
     id: { type: 'number' },
     user: { $ref: 'UserResult' }
   }
 } as const);
 
 export type Message = Infer<typeof messageSchema>;
-export type MessageResult = Message & Infer<typeof messageResultSchema> & {
+export type MessageResult = Infer<typeof messageResultSchema> & {
   user: User;
 };
 

--- a/packages/schema/test/schema.test.ts
+++ b/packages/schema/test/schema.test.ts
@@ -58,6 +58,19 @@ describe('@feathersjs/schema/schema', () => {
       read: false,
       upvotes: 10
     });
+
+    await assert.rejects(() => messageSchema.validate({ text: 'failing' }), {
+      name: 'BadRequest',
+      data: [{
+        instancePath: '',
+        keyword: 'required',
+        message: 'must have required property \'read\'',
+        params: {
+          missingProperty: 'read'
+        },
+        schemaPath: '#/required'
+      }]
+    });
   });
 
   it('uses custom AJV with format validation', async () => {
@@ -87,7 +100,7 @@ describe('@feathersjs/schema/schema', () => {
         createdAt: '2021-12-22T23:59:59.bbb'
       });
     } catch (error: any) {
-      assert.equal(error.errors[0].message, 'must match format "date-time"')
+      assert.equal(error.data[0].message, 'must match format "date-time"')
     }
   });
 


### PR DESCRIPTION
This pull request improves schema typing by allowing to pass your own generic type to the `.validate<>` method so that you can use your own types (e.g. when using a `$ref` reference).

It also removes the `schema.extend` functionality since it did not produce reliable definitions and types. Instead, schemas can be composed by spreading the properties you want from `schema.definition`:

```ts
   const messageSchema = schema({
      $id: 'message-ext',
      type: 'object',
      required: [ 'text', 'read' ],
      additionalProperties: false,
      properties: {
        text: {
          type: 'string'
        },
        read: {
          type: 'boolean'
        }
      }
    } as const);

    const messageResultSchema = schema({
      $id: 'message-ext-vote',
      type: 'object',
      required: [ 'upvotes', ...messageSchema.definition.required ],
      additionalProperties: false,
      properties: {
        ...messageSchema.definition.properties,
        upvotes: {
          type: 'number'
        }
      }
    } as const);

    type MessageResult = Infer<typeof messageResultSchema>;
```

Also closes https://github.com/feathersjs/feathers/issues/2507