### PR TITLE
feat(transport-commons): add `context.http.response`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@types/axios": "^0.14.0",
 				"@types/bcryptjs": "^2.4.2",
 				"@types/config": "^0.0.41",
+				"@types/encodeurl": "^1.0.0",
 				"@types/express": "^4.17.13",
 				"@types/express-serve-static-core": "^4.17.28",
 				"@types/express-session": "^1.17.4",
@@ -36,6 +37,7 @@
 				"babel-loader": "^8.2.4",
 				"bcryptjs": "^2.4.3",
 				"config": "^3.3.7",
+				"encodeurl": "^1.0.2",
 				"events": "^3.3.0",
 				"express": "^4.17.3",
 				"express-session": "^1.17.2",
@@ -3356,6 +3358,11 @@
 			"version": "2.8.12",
 			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
 			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+		},
+		"node_modules/@types/encodeurl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/encodeurl/-/encodeurl-1.0.0.tgz",
+			"integrity": "sha512-iO2Q6xQOJ5DtOB6wJ2KIetFq9JRTbpzcKTe2aS6CCsa+W9KNWX2yXx9KeB5sY/nBfAWN43LkPg6SFB+ldsW9ZA=="
 		},
 		"node_modules/@types/eslint": {
 			"version": "8.4.1",
@@ -13024,11 +13031,11 @@
 			}
 		},
 		"node_modules/mongodb": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.4.1.tgz",
-			"integrity": "sha512-IAD3nFtCR4s22vi5qjqkCBnuyDDrOW8WVSSmgHquOvGaP1iTD+XpC5tr8wAUbZ2EeZkaswwBKQFHDvl4qYcKqQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.5.0.tgz",
+			"integrity": "sha512-A2l8MjEpKojnhbCM0MK3+UOGUSGvTNNSv7AkP1fsT7tkambrkkqN/5F2y+PhzsV0Nbv58u04TETpkaSEdI2zKA==",
 			"dependencies": {
-				"bson": "^4.6.1",
+				"bson": "^4.6.2",
 				"denque": "^2.0.1",
 				"mongodb-connection-string-url": "^2.5.2",
 				"socks": "^2.6.2"
@@ -21159,6 +21166,11 @@
 			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
 			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
 		},
+		"@types/encodeurl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/encodeurl/-/encodeurl-1.0.0.tgz",
+			"integrity": "sha512-iO2Q6xQOJ5DtOB6wJ2KIetFq9JRTbpzcKTe2aS6CCsa+W9KNWX2yXx9KeB5sY/nBfAWN43LkPg6SFB+ldsW9ZA=="
+		},
 		"@types/eslint": {
 			"version": "8.4.1",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -28871,11 +28883,11 @@
 			"dev": true
 		},
 		"mongodb": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.4.1.tgz",
-			"integrity": "sha512-IAD3nFtCR4s22vi5qjqkCBnuyDDrOW8WVSSmgHquOvGaP1iTD+XpC5tr8wAUbZ2EeZkaswwBKQFHDvl4qYcKqQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.5.0.tgz",
+			"integrity": "sha512-A2l8MjEpKojnhbCM0MK3+UOGUSGvTNNSv7AkP1fsT7tkambrkkqN/5F2y+PhzsV0Nbv58u04TETpkaSEdI2zKA==",
 			"requires": {
-				"bson": "^4.6.1",
+				"bson": "^4.6.2",
 				"denque": "^2.0.1",
 				"mongodb-connection-string-url": "^2.5.2",
 				"saslprep": "^1.0.3",

--- a/packages/express/src/rest.ts
+++ b/packages/express/src/rest.ts
@@ -39,13 +39,10 @@ const serviceMiddleware = (): RequestHandler => {
     const context = await (service as any)[method](...args, contextBase);
     res.hook = context;
 
-    const result = http.getData(context);
-    const statusCode = http.getStatusCode(context, result);
-    const responseHeaders = http.getResponseHeaders(context);
-
-    res.data = result;
-    res.statusCode = statusCode;
-    res.set(responseHeaders);
+    const response = http.getResponse(context);
+    res.statusCode = response.status;
+    res.set(response.headers);
+    res.data = response.body;
 
     return next();
   });

--- a/packages/express/src/rest.ts
+++ b/packages/express/src/rest.ts
@@ -36,14 +36,16 @@ const serviceMiddleware = (): RequestHandler => {
     const contextBase = createContext(service, method, { http: {} });
     res.hook = contextBase;
 
-    const context = await (service as any)[method](...args, contextBase);
+    const context = await (service as any)[method](...args, contextBase);
     res.hook = context;
 
     const result = http.getData(context);
     const statusCode = http.getStatusCode(context, result);
+    const responseHeaders = http.getResponseHeaders(context);
 
     res.data = result;
     res.statusCode = statusCode;
+    res.set(responseHeaders);
 
     return next();
   });

--- a/packages/express/test/rest.test.ts
+++ b/packages/express/test/rest.test.ts
@@ -196,7 +196,7 @@ describe('@feathersjs/express/rest provider', () => {
 
         app.service('hook-status').hooks({
           after (hook: HookContext) {
-            hook.http.statusCode = 206;
+            hook.http.status = 206;
           }
         });
 
@@ -214,14 +214,14 @@ describe('@feathersjs/express/rest provider', () => {
 
         app.service('hook-headers').hooks({
           after (hook: HookContext) {
-            hook.http!.responseHeaders = { foo: 'first', bar: ['second', 'third'] };
+            hook.http.headers = { foo: 'first', bar: ['second', 'third'] };
           }
         });
 
         const res = await axios.get<any>('http://localhost:4777/hook-headers/dishes');
 
-        assert.strictEqual(res.headers['foo'], 'first');
-        assert.strictEqual(res.headers['bar'], 'second, third');
+        assert.strictEqual(res.headers.foo, 'first');
+        assert.strictEqual(res.headers.bar, 'second, third');
       });
 
       it('sets the hook object in res.hook on error', async () => {

--- a/packages/express/test/rest.test.ts
+++ b/packages/express/test/rest.test.ts
@@ -205,6 +205,25 @@ describe('@feathersjs/express/rest provider', () => {
         assert.strictEqual(res.status, 206);
       });
 
+      it('allows to set response headers in a hook', async () => {
+        app.use('/hook-headers', {
+          async get () {
+            return {};
+          }
+        });
+
+        app.service('hook-headers').hooks({
+          after (hook: HookContext) {
+            hook.http!.responseHeaders = { foo: 'first', bar: ['second', 'third'] };
+          }
+        });
+
+        const res = await axios.get<any>('http://localhost:4777/hook-headers/dishes');
+
+        assert.strictEqual(res.headers['foo'], 'first');
+        assert.strictEqual(res.headers['bar'], 'second, third');
+      });
+
       it('sets the hook object in res.hook on error', async () => {
         const params = {
           route: {},

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -256,14 +256,17 @@ export interface Params {
 
 export interface Http {
   /**
-   * A writeable, optional property that allows to override the standard HTTP status
-   * code that should be returned.
+   * A writeable, optional property with status code override.
    */
-  statusCode?: number;
+  status?: number;
   /**
-   * A writeable, optional property that allows to provide HTTP response headers.
+   * A writeable, optional property with headers.
    */
-  responseHeaders?: { [key: string]: string | string[] };
+  headers?: { [key: string]: string | string[] };
+  /**
+   * A writeable, optional property with `Location` header's value.
+   */
+  location?: string;
 }
 
 export interface HookContext<A = Application, S = any> extends BaseHookContext<ServiceGenericType<S>> {
@@ -337,11 +340,11 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
    * A writeable, optional property that allows to override the standard HTTP status
    * code that should be returned.
    *
-   * @deprecated Use `http.statusCode` instead.
+   * @deprecated Use `http.status` instead.
    */
   statusCode?: number;
   /**
-   * A writeable, optional property that contains options specific to HTTP transports.
+   * A writeable, optional property with options specific to HTTP transports.
    */
   http?: Http;
   /**

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -260,6 +260,10 @@ export interface Http {
    * code that should be returned.
    */
   statusCode?: number;
+  /**
+   * A writeable, optional property that allows to provide HTTP response headers.
+   */
+  responseHeaders?: { [key: string]: string | string[] };
 }
 
 export interface HookContext<A = Application, S = any> extends BaseHookContext<ServiceGenericType<S>> {

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -82,10 +82,10 @@ export function hookMixin<A> (
         event: null,
         type: null,
         get statusCode () {
-          return this.http?.statusCode;
+          return this.http?.status;
         },
         set statusCode (value: number) {
-          (this.http ||= {}).statusCode = value;
+          (this.http ||= {}).status = value;
         }
       });
 

--- a/packages/koa/src/rest.ts
+++ b/packages/koa/src/rest.ts
@@ -35,13 +35,10 @@ const serviceMiddleware = (): Middleware => {
     const context = await (service as any)[method](...args, contextBase);
     ctx.hook = context;
 
-    const result = http.getData(context);
-    const statusCode = http.getStatusCode(context, result);
-    const responseHeaders = http.getResponseHeaders(context);
-
-    ctx.body = result;
-    ctx.status = statusCode;
-    ctx.set(responseHeaders);
+    const response = http.getResponse(context);
+    ctx.status = response.status;
+    ctx.set(response.headers);
+    ctx.body = response.body;
 
     return next();
   };

--- a/packages/koa/src/rest.ts
+++ b/packages/koa/src/rest.ts
@@ -32,14 +32,16 @@ const serviceMiddleware = (): Middleware => {
     const contextBase = createContext(service, method, { http: {} });
     ctx.hook = contextBase;
 
-    const context = await (service as any)[method](...args, contextBase);
+    const context = await (service as any)[method](...args, contextBase);
     ctx.hook = context;
 
     const result = http.getData(context);
     const statusCode = http.getStatusCode(context, result);
+    const responseHeaders = http.getResponseHeaders(context);
 
     ctx.body = result;
     ctx.status = statusCode;
+    ctx.set(responseHeaders);
 
     return next();
   };

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -53,12 +53,14 @@
     "*.js"
   ],
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.17",
-    "@feathersjs/errors": "^5.0.0-pre.17",
-    "@feathersjs/feathers": "^5.0.0-pre.17",
+    "@feathersjs/commons": "^5.0.0-pre.16",
+    "@feathersjs/errors": "^5.0.0-pre.16",
+    "@feathersjs/feathers": "^5.0.0-pre.16",
+    "encodeurl": "^1.0.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@types/encodeurl": "^1.0.0",
     "@types/lodash": "^4.14.181",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.23",

--- a/packages/transport-commons/src/http.ts
+++ b/packages/transport-commons/src/http.ts
@@ -74,3 +74,7 @@ export function getStatusCode (context: HookContext, data?: any) {
 
   return statusCodes.success;
 }
+
+export function getResponseHeaders (context: HookContext) {
+  return context.http?.responseHeaders ?? {};
+}

--- a/packages/transport-commons/test/http.test.ts
+++ b/packages/transport-commons/test/http.test.ts
@@ -13,11 +13,11 @@ describe('@feathersjs/transport-commons HTTP helpers', () => {
       dispatch
     };
 
-    assert.deepStrictEqual(http.getData(resultContext as HookContext), plainData);
-    assert.deepStrictEqual(http.getData(dispatchContext as HookContext), dispatch);
+    assert.strictEqual(http.getData(resultContext as HookContext), plainData);
+    assert.strictEqual(http.getData(dispatchContext as HookContext), dispatch);
   });
 
-  it('getStatusCode', async () => {
+  it('getStatusCode', () => {
     const statusContext = {
       http: { statusCode: 202 }
     };
@@ -38,5 +38,16 @@ describe('@feathersjs/transport-commons HTTP helpers', () => {
     assert.strictEqual(http.getServiceMethod('PoST', null, 'customMethod'), 'customMethod');
     assert.strictEqual(http.getServiceMethod('delete', null), 'remove');
     assert.throws(() => http.getServiceMethod('nonsense', null));
+  });
+
+  it('getResponseHeaders', () => {
+    const responseHeaders = { key: 'value' };
+    const headersContext = {
+      http: { responseHeaders }
+    };
+
+    assert.deepStrictEqual(http.getResponseHeaders({} as HookContext), {});
+    assert.deepStrictEqual(http.getResponseHeaders({http: {}} as HookContext), {});
+    assert.strictEqual(http.getResponseHeaders(headersContext as any as HookContext), responseHeaders);
   });
 });

--- a/packages/transport-commons/test/http.test.ts
+++ b/packages/transport-commons/test/http.test.ts
@@ -3,7 +3,7 @@ import { HookContext } from '@feathersjs/feathers';
 import { http } from '../src';
 
 describe('@feathersjs/transport-commons HTTP helpers', () => {
-  it('getData', () => {
+  it('getResponse body', () => {
     const plainData = { message: 'hi' };
     const dispatch = { message: 'from dispatch' };
     const resultContext = {
@@ -13,22 +13,41 @@ describe('@feathersjs/transport-commons HTTP helpers', () => {
       dispatch
     };
 
-    assert.strictEqual(http.getData(resultContext as HookContext), plainData);
-    assert.strictEqual(http.getData(dispatchContext as HookContext), dispatch);
+    assert.strictEqual(http.getResponse(resultContext as HookContext).body, plainData);
+    assert.strictEqual(http.getResponse(dispatchContext as HookContext).body, dispatch);
   });
 
-  it('getStatusCode', () => {
+  it('getResponse status', () => {
     const statusContext = {
-      http: { statusCode: 202 }
+      http: { status: 202 }
     };
     const createContext = {
       method: 'create'
     };
+    const redirectContext = {
+      http: { location: '/' }
+    };
 
-    assert.strictEqual(http.getStatusCode(statusContext as HookContext, {}), 202);
-    assert.strictEqual(http.getStatusCode(createContext as HookContext, {}), http.statusCodes.created);
-    assert.strictEqual(http.getStatusCode({} as HookContext), http.statusCodes.noContent);
-    assert.strictEqual(http.getStatusCode({} as HookContext, {}), http.statusCodes.success);
+    assert.strictEqual(http.getResponse(statusContext as HookContext).status, 202);
+    assert.strictEqual(http.getResponse(createContext as HookContext).status, http.statusCodes.created);
+    assert.strictEqual(http.getResponse(redirectContext as HookContext).status, http.statusCodes.seeOther);
+    assert.strictEqual(http.getResponse({} as HookContext).status, http.statusCodes.noContent);
+    assert.strictEqual(http.getResponse({result: true} as HookContext).status, http.statusCodes.success);
+  });
+
+  it('getResponse headers', () => {
+    const headers = { key: 'value' } as any;
+    const headersContext = {
+      http: { headers }
+    };
+    const locationContext = {
+      http: { location: '/' }
+    };
+
+    assert.deepStrictEqual(http.getResponse({} as HookContext).headers, {});
+    assert.deepStrictEqual(http.getResponse({http: {}} as HookContext).headers, {});
+    assert.strictEqual(http.getResponse(headersContext as HookContext).headers, headers);
+    assert.deepStrictEqual(http.getResponse(locationContext as HookContext).headers, { Location: '/' });
   });
 
   it('getServiceMethod', () => {
@@ -38,16 +57,5 @@ describe('@feathersjs/transport-commons HTTP helpers', () => {
     assert.strictEqual(http.getServiceMethod('PoST', null, 'customMethod'), 'customMethod');
     assert.strictEqual(http.getServiceMethod('delete', null), 'remove');
     assert.throws(() => http.getServiceMethod('nonsense', null));
-  });
-
-  it('getResponseHeaders', () => {
-    const responseHeaders = { key: 'value' };
-    const headersContext = {
-      http: { responseHeaders }
-    };
-
-    assert.deepStrictEqual(http.getResponseHeaders({} as HookContext), {});
-    assert.deepStrictEqual(http.getResponseHeaders({http: {}} as HookContext), {});
-    assert.strictEqual(http.getResponseHeaders(headersContext as any as HookContext), responseHeaders);
   });
 });


### PR DESCRIPTION
Allows to specify any response headers for http transports.
Related to #2484.

Not sure about naming though. About `response` part.
If `http` is only about outputs (and any inputs go into `params`) then there is no need to specify that this is response headers.
If `http` can contain something besides outputs, then status part should be maybe renamed to `responseStatus` for consistency.

I think the first option is more attractive to me with short names - so `status`, `headers` and possibly `location` and `cookies` (those are headers too, but can be beneficial to add easier way to set them).