### PR TITLE
fix(express): Fix application typings to work with typed configuration

### DIFF
--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -27,7 +27,7 @@ export interface ExpressOverrides<Services> {
 }
 
 export type Application<Services = any, Settings = any> =
-  Omit<Express, 'listen'|'use'> &
+  Omit<Express, 'listen'|'use'|'get'|'set'> &
   FeathersApplication<Services, Settings> &
   ExpressOverrides<Services>;
 

--- a/packages/express/test/index.test.ts
+++ b/packages/express/test/index.test.ts
@@ -23,9 +23,19 @@ describe('@feathersjs/express', () => {
     assert.ok(expressify.errorHandler);
   });
 
-  it('returns an Express application', () => {
-    const app: Application = expressify.default(feathers());
+  it('returns an Express application, keeps Feathers service and configuration typings typings', () => {
+    type Config = {
+      hostname: string;
+      port: number;
+    }
 
+    const app = expressify.default<{}, Config>(feathers());
+
+    app.set('hostname', 'test.com');
+
+    const hostname = app.get('hostname');
+
+    assert.strictEqual(hostname, 'test.com');
     assert.strictEqual(typeof app, 'function');
   });
 


### PR DESCRIPTION
The Express types overwrote the ability to type your Feathers configuration `.set` and `.get` which should be fixed by this pull request.

Closes #2533