### PR TITLE
fix(schema): Allow compound oneOf for queryProperty

### DIFF
--- a/packages/schema/src/query.ts
+++ b/packages/schema/src/query.ts
@@ -1,7 +1,7 @@
 import { JSONSchema } from 'json-schema-to-ts';
 
 export const queryProperty = <T extends JSONSchema> (definition: T) => ({
-  oneOf: [
+  anyOf: [
     definition,
     {
       type: 'object',


### PR DESCRIPTION
Currently we use `oneOf` to create the `queryProperty` validations.  This works fine until you nest it inside of another `oneOf`.  In this case it fails every time.  I've switched it to `anyOf` and have also added two tests to make sure it's both passing and failing correctly.