### PR TITLE
fix(hooks): Allow all built-in hooks to be used the async and regular way

### DIFF
--- a/packages/authentication-local/src/hooks/hash-password.ts
+++ b/packages/authentication-local/src/hooks/hash-password.ts
@@ -53,7 +53,7 @@ export default function hashPassword (field: string, options: HashPasswordOption
     }
 
     if (typeof next === 'function') {
-      await next();
+      return next();
     }
   };
 }

--- a/packages/authentication-local/src/hooks/protect.ts
+++ b/packages/authentication-local/src/hooks/protect.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import { HookContext, NextFunction } from '@feathersjs/feathers';
 
-export default (...fields: string[]) => async (context: HookContext, next?: NextFunction) => {
+export default (...fields: string[]) => {
   const o = (current: any) => {
     if (typeof current === 'object' && !Array.isArray(current)) {
       const data = typeof current.toJSON === 'function'
@@ -13,25 +13,27 @@ export default (...fields: string[]) => async (context: HookContext, next?: Next
     return current;
   };
 
-  if (typeof next === 'function') {
-    await next();
-  }
-
-  const result = context.dispatch || context.result;
-
-  if (result) {
-    if (Array.isArray(result)) {
-      context.dispatch = result.map(o);
-    } else if (result.data && context.method === 'find') {
-      context.dispatch = Object.assign({}, result, {
-        data: result.data.map(o)
-      });
-    } else {
-      context.dispatch = o(result);
+  return async (context: HookContext, next?: NextFunction) => {
+    if (typeof next === 'function') {
+      await next();
     }
 
-    if (context.params && context.params.provider) {
-      context.result = context.dispatch;
+    const result = context.dispatch || context.result;
+
+    if (result) {
+      if (Array.isArray(result)) {
+        context.dispatch = result.map(o);
+      } else if (result.data && context.method === 'find') {
+        context.dispatch = Object.assign({}, result, {
+          data: result.data.map(o)
+        });
+      } else {
+        context.dispatch = o(result);
+      }
+
+      if (context.params && context.params.provider) {
+        context.result = context.dispatch;
+      }
     }
-  }
+  };
 };

--- a/packages/schema/src/resolver.ts
+++ b/packages/schema/src/resolver.ts
@@ -22,7 +22,7 @@ export interface ResolverConfig<T, C> {
 export interface ResolverStatus<T, C> {
   path: string[];
   originalContext?: C;
-  properties?: (keyof T)[];
+  properties?: string[];
   stack: PropertyResolver<T, any, C>[];
 }
 


### PR DESCRIPTION
This way schema hooks can also be used as regular `before` and `after` hooks.