### PR TITLE
feat(core): Add app.teardown functionality

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -231,4 +231,6 @@ export class AdapterService<
   }
 
   async setup () {}
+
+  async teardown () {}
 }

--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -23,6 +23,7 @@ export interface ExpressOverrides<Services> {
   listen(port: number, hostname: string, callback?: () => void): Promise<http.Server>;
   listen(port: number|string|any, callback?: () => void): Promise<http.Server>;
   listen(callback?: () => void): Promise<http.Server>;
+  close (): Promise<void>;
   use: ExpressUseHandler<this, Services>;
 }
 

--- a/packages/express/test/index.test.ts
+++ b/packages/express/test/index.test.ts
@@ -174,6 +174,42 @@ describe('@feathersjs/express', () => {
     await new Promise(resolve => server.close(() => resolve(server)));
   });
 
+  it('.close calls .teardown', async () => {
+    const app = feathersExpress(feathers());
+    let called = false;
+
+    app.use('/myservice', {
+      async get (id: Id) {
+        return { id };
+      },
+
+      async teardown (appParam, path) {
+        assert.strictEqual(appParam, app);
+        assert.strictEqual(path, 'myservice');
+        called = true;
+      }
+
+    });
+
+    await app.listen(8787);
+    await app.close();
+
+    assert.ok(called);
+  });
+
+  it('.close closes http server', async () => {
+    const app = feathersExpress(feathers());
+    let called = false;
+
+    const server = await app.listen(8787);
+    server.on('close', () => {
+      called = true;
+    })
+
+    await app.close();
+    assert.ok(called);
+  });
+
   it('passes middleware as options', () => {
     const feathersApp = feathers();
     const app = feathersExpress(feathersApp);

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -161,7 +161,7 @@ export class Feathers<Services, Settings> extends EventEmitter implements Feathe
     });
   }
 
-  async teardown () {
+  teardown () {
     let promise = Promise.resolve();
 
     // Teardown each service (pass the app so that they can look up other services etc.)

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -160,4 +160,26 @@ export class Feathers<Services, Settings> extends EventEmitter implements Feathe
       return this;
     });
   }
+
+  async teardown () {
+    let promise = Promise.resolve();
+
+    // Teardown each service (pass the app so that they can look up other services etc.)
+    for (const path of Object.keys(this.services)) {
+      promise = promise.then(() => {
+        const service: any = this.service(path as any);
+
+        if (typeof service.teardown === 'function') {
+          debug(`Teardown service for \`${path}\``);
+
+          return service.teardown(this, path);
+        }
+      });
+    }
+
+    return promise.then(() => {
+      this._isSetup = false;
+      return this;
+    });
+  }
 }

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -35,6 +35,8 @@ export interface ServiceMethods<T = any, D = Partial<T>> {
   remove (id: NullableId, params?: Params): Promise<T | T[]>;
 
   setup (app: Application, path: string): Promise<void>;
+
+  teardown (app: Application, path: string): Promise<void>;
 }
 
 export interface ServiceOverloads<T = any, D = Partial<T>> {
@@ -217,6 +219,8 @@ export interface FeathersApplication<Services = any, Settings = any> {
    * @param map The application hook settings.
    */
   hooks (map: HookOptions<this, any>): this;
+
+  teardown (cb?: () => Promise<void>): Promise<this>;
 }
 
 // This needs to be an interface instead of a type

--- a/packages/feathers/src/service.ts
+++ b/packages/feathers/src/service.ts
@@ -30,6 +30,7 @@ export const protectedMethods = Object.keys(Object.prototype)
     'error',
     'hooks',
     'setup',
+    'teardown',
     'publish'
   ]);
 

--- a/packages/koa/src/declarations.ts
+++ b/packages/koa/src/declarations.ts
@@ -5,6 +5,7 @@ import '@feathersjs/authentication';
 
 export type ApplicationAddons = {
   listen (port?: number, ...args: any[]): Promise<Server>;
+  close (): Promise<void>;
 }
 
 export type Application<T = any, C = any> =

--- a/packages/koa/test/index.test.ts
+++ b/packages/koa/test/index.test.ts
@@ -53,7 +53,7 @@ describe('@feathersjs/koa', () => {
 
   it('Koa wrapped and context.app are the same', async () => {
     const app = koa(feathers());
-    
+
     app.use('/test', {
       async get (id: Id) {
         return { id };
@@ -138,6 +138,42 @@ describe('@feathersjs/koa', () => {
 
       return true;
     });
+  });
+
+  it('.close calls .teardown', async () => {
+    const app = koa(feathers());
+    let called = false;
+
+    app.use('/myservice', {
+      async get (id: Id) {
+        return { id };
+      },
+
+      async teardown (appParam, path) {
+        assert.strictEqual(appParam, app);
+        assert.strictEqual(path, 'myservice');
+        called = true;
+      }
+
+    });
+
+    await app.listen(8787);
+    await app.close();
+
+    assert.ok(called);
+  });
+
+  it('.close closes http server', async () => {
+    const app = koa(feathers());
+    let called = false;
+
+    const server = await app.listen(8787);
+    server.on('close', () => {
+      called = true;
+    })
+
+    await app.close();
+    assert.ok(called);
   });
 
   restTests('Services', 'todo', 8465);


### PR DESCRIPTION
This feature is about to shut down the application and run teardown functionalities after the http server is closed on each service.

In some cases, e.g. when we stop/restart the Node application, the connections to various databases are not closed properly and remain open until the system closes these open connections after some time.

As a counterpart to `app.listen()` there is now the method `app.close()` which closes the http server and then calls the teardown methods of the individual services.

In this way, logic for teardown can also be implemented as in the setup methods of the services.


```ts
import app from './app';

const server = await app.listen(1234);

const close = async (): Promise<void> => {
  await app.close();
  process.exit(1);
};

process.on('SIGINT', close);
process.on('SIGTERM', close);
``` 

As I even saw in PR #2510, it would even be a good idea to implement an `addTeardown` method where we can configure the logic to happen at the application level.
