### PR TITLE
chore(transport-commons): export channel, combined & connection

### DIFF
--- a/packages/transport-commons/src/channels/index.ts
+++ b/packages/transport-commons/src/channels/index.ts
@@ -110,3 +110,5 @@ export function channels () {
     });
   };
 }
+
+export { Channel, CombinedChannel, RealTimeConnection }

--- a/packages/transport-commons/src/index.ts
+++ b/packages/transport-commons/src/index.ts
@@ -1,6 +1,13 @@
 import { socket } from './socket';
 import { routing } from './routing';
-import { channels } from './channels';
+import { channels, Channel, CombinedChannel, RealTimeConnection } from './channels';
 
 export * as http from './http';
-export { socket, routing, channels };
+export {
+  socket,
+  routing,
+  channels,
+  Channel,
+  CombinedChannel,
+  RealTimeConnection
+};


### PR DESCRIPTION
As of today, I do this at [feathers-casl](https://github.com/fratzinger/feathers-casl/blob/master/lib/channels/getChannelsWithReadAbility.ts#L7):
```ts
import { Channel } from "@feathersjs/transport-commons/lib/channels/channel/base";
```

This PR makes it possible to do the following:

```ts
import { Channel, CombinedChannel, RealtimeConnection } from "@feathersjs/transport-commons";
```

Nothing fancy here.