### PR TITLE
chore: add directories to package.json-repository

### DIFF
--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/adapter-commons"
   },
   "author": {
     "name": "Feathers contributor",

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/adapter-tests"
   },
   "author": {
     "name": "Feathers contributor",

--- a/packages/authentication-client/package.json
+++ b/packages/authentication-client/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/authentication-client"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/authentication-local"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/authentication-oauth"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/authentication"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,8 @@
   "version": "5.0.0-pre.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/feathersjs/feathers.git"
+    "url": "https://github.com/feathersjs/feathers.git",
+    "directory": "packages/client"
   },
   "license": "MIT",
   "funding": {

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/commons"
   },
   "author": {
     "name": "Feathers contributor",

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/configuration"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/errors"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/express"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -5,7 +5,8 @@
   "homepage": "http://feathersjs.com",
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/feathers"
   },
   "keywords": [
     "feathers",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/koa"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/memory"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/rest-client"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/schema"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/socketio-client/package.json
+++ b/packages/socketio-client/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/socketio-client"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/socketio"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/tests"
   },
   "author": {
     "name": "Feathers contributors",

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/feathers.git"
+    "url": "git://github.com/feathersjs/feathers.git",
+    "directory": "packages/transport-commons"
   },
   "author": {
     "name": "Feathers contributors",


### PR DESCRIPTION
For packages like `@feathersjs/transport-commons`, `adapter-commons` or even `@feathersjs/feathers` on npmjs.com I had trouble to find the corresponding folder in this monorepo. `package.json` allows a `repository.directory` property to define the subdirectory in a mono-repo. By doing that, the click on the repository on npmjs.com lead directly to the sub directory of the package. On https://www.npmjs.com/package/@feathersjs/adapter-commons it's even worse because it leads to https://github.com/feathersjs/databases... 

[npm docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository) say:

> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:

```json
{
  "repository": {
    "type": "git",
    "url": "https://github.com/facebook/react.git",
    "directory": "packages/react-dom"
  }
}
```

So, the repository url on each `@feathersjs/...` package leads to the subdirectory of the github repo.

![image](https://user-images.githubusercontent.com/22286818/158401697-b2b880fb-a7d1-4b3e-ad97-93cca8e086fc.png)