### PR TITLE
Document the need for third-party dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ To learn more about Feathers visit the website at [feathersjs.com](http://feathe
 
 The [Feathers docs](http://docs.feathersjs.com) are loaded with awesome stuff and tell you every thing you need to know about using and configuring Feathers.
 
+## Dependencies
+
+Here's a list of third party dependencies and why they may be included when using the feathers generator.
+
+- axios
+  - A Fetch API alternative that works in Node 16 and older. Used in the default tests.
+- feathers-sequelize
+  - Known bug, you may need this if you use SQL, but it get's included in generated projects regardless. Feel free to remove it.
+- install
+  - Included for compatibility... will be removed in Feathers v6
+- mocha (Installed upon request)
+- shx
+  - A set of convenient shell utilities. Used by default on generated tests.
+- winston
+  - A very popular logger with many plugins. This is easy to remove should you prefer another logger. There are no tight integrations with Feathers by default, it's merely preconfigured with the bare minimum.
+
 ## License
 
 Copyright (c) 2022 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)


### PR DESCRIPTION
Document the need for third-party dependencies in ReadMe. Some of them are not obvious and seem a little too lazy, like install and shx, whose use can typically be easily avoided.

I've also found feathers-sequelize getting installed by the generator for seemingly no reason.


This is closely related to #2522... I encountered a couple mystery dependencies while merging a 3 month old Dove server to a vite project without using monorepo tools... being clear about why dependencies are there really matters in that situation, especially when you're battling code rot with TypeScript/vite.