### PR TITLE
chore: Fix all package types fields and unify test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "update-dependencies": "ncu -u && lerna exec -- ncu -u -x node-fetch",
     "clean": "find . -name node_modules -exec rm -rf '{}' + && find . -name package-lock.json -exec rm -rf '{}' +",
     "test:deno": "deno test --config deno/tsconfig.json deno/test.ts",
-    "test": "npm run lint && nyc lerna run test"
+    "test": "npm run lint && lerna run compile && nyc lerna run test"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.10.2",

--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -33,8 +33,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts",
-    "test": "npm run compile && npm run mocha"
+    "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {
     "lib": "lib"

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -28,12 +28,12 @@
   "engines": {
     "node": ">= 12"
   },
-  "main": "lib/index.js",
+  "main": "lib/",
+  "types": "lib/",
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts",
-    "test": "npm run compile && npm run mocha"
+    "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {
     "lib": "lib"

--- a/packages/authentication-client/package.json
+++ b/packages/authentication-client/package.json
@@ -43,8 +43,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
+    "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {
     "lib": "lib"

--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -43,8 +43,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
+    "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {
     "lib": "lib"

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -43,8 +43,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
+    "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {
     "lib": "lib"

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -43,8 +43,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
-    "mocha": "NODE_CONFIG_DIR=./test/config mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
+    "test": "NODE_CONFIG_DIR=./test/config mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "semistandard": {
     "env": [

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
+  "type": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -48,8 +48,7 @@
     "version": "npm run write-version",
     "publish": "npm run reset-version",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/"
+    "test": "mocha --config ../../.mocharc.json --recursive test/"
   },
   "engines": {
     "node": ">= 12"

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers",
     "koajs"

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -39,8 +39,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
+    "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {
     "lib": "lib"

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.0-pre.17",
   "homepage": "https://github.com/feathersjs/feathers",
   "main": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"
@@ -37,8 +38,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
-    "mocha": "mocha --config ../../.mocharc.json --recursive test/**/*.test.ts"
+    "test": "mocha --config ../../.mocharc.json --recursive test/**/*.test.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -3,7 +3,8 @@
   "description": "REST client services for different Ajax libraries",
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
-  "main": "lib/index.js",
+  "main": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/packages/socketio-client/package.json
+++ b/packages/socketio-client/package.json
@@ -3,7 +3,8 @@
   "description": "The client for Socket.io through feathers-socketio",
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
-  "main": "lib/index.js",
+  "main": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"
@@ -33,7 +34,8 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
+    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts",
+    "test": "npm run mocha"
   },
   "directories": {
     "lib": "lib"

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
+  "type": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -4,7 +4,7 @@
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
-  "type": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -5,6 +5,7 @@
   "version": "5.0.0-pre.17",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers"
   ],

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "compile": "shx rm -rf lib/ && tsc",
-    "test": "npm run compile && npm run mocha",
+    "test": "npm run mocha",
     "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {


### PR DESCRIPTION
The NPM package page thinks this package is missing types... it's not. This PR makes it show the TS symbol next to the name. 

https://www.npmjs.com/package/@feathersjs/koa

Should have the same TS symbol that the main package does...
![Screenshot 2022-03-30 11 17 14](https://user-images.githubusercontent.com/876076/160882916-16654bb0-8ddc-4e8c-aaef-01b692bc5e47.png)
