### PR TITLE
fix(rest-client): Import `errors` from @feathers/errors

### DIFF
--- a/packages/rest-client/lib/fetch.js
+++ b/packages/rest-client/lib/fetch.js
@@ -1,4 +1,5 @@
 const Base = require('./base');
+const errors = require('@feathersjs/errors');
 
 class FetchService extends Base {
   request (options, params) {


### PR DESCRIPTION
### Summary
- [x] Tell us about the problem your pull request is solving.
`errors` is undefined on line 34.
- [x] Are there any open issues that are related to this?
None that I found.
- [x] Is this PR dependent on PRs in other repos?
No