### PR TITLE
fix(core): Ensure that dynamically registered services are always set up

### DIFF
--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -158,8 +158,7 @@ export class Feathers<Services, Settings> extends EventEmitter implements Feathe
 
           return service.setup(this, path);
         }
-      }), Promise.resolve())
-      .then(() => this);
+      }), Promise.resolve()).then(() => this);
   }
 
   teardown () {

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -147,6 +147,8 @@ export class Feathers<Services, Settings> extends EventEmitter implements Feathe
   }
 
   setup () {
+    this._isSetup = true;
+
     return Object.keys(this.services).reduce((current, path) => current
       .then(() => {
         const service: any = this.service(path as any);
@@ -157,13 +159,12 @@ export class Feathers<Services, Settings> extends EventEmitter implements Feathe
           return service.setup(this, path);
         }
       }), Promise.resolve())
-      .then(() => {
-        this._isSetup = true;
-        return this;
-      });
+      .then(() => this);
   }
 
   teardown () {
+    this._isSetup = false;
+
     return Object.keys(this.services).reduce((current, path) => current
       .then(() => {
         const service: any = this.service(path as any);
@@ -173,10 +174,6 @@ export class Feathers<Services, Settings> extends EventEmitter implements Feathe
 
           return service.teardown(this, path);
         }
-      }), Promise.resolve())
-      .then(() => {
-        this._isSetup = false;
-        return this;
-      });
+      }), Promise.resolve()).then(() => this)
   }
 }

--- a/packages/feathers/test/application.test.ts
+++ b/packages/feathers/test/application.test.ts
@@ -344,18 +344,18 @@ describe('Feathers application', () => {
       assert.strictEqual(teardownCount, 2);
     });
 
-    it('registering a service after app.setup will be set up', done => {
+    it('registering app.setup but while still pending will be set up', done => {
       const app = feathers();
 
-      app.setup().then(() => {
-        app.use('/dummy', {
-          async setup (appRef: any, path: any) {
-            assert.ok((app as any)._isSetup);
-            assert.strictEqual(appRef, app);
-            assert.strictEqual(path, 'dummy');
-            done();
-          }
-        });
+      app.setup();
+
+      app.use('/dummy', {
+        async setup (appRef: any, path: any) {
+          assert.ok((app as any)._isSetup);
+          assert.strictEqual(appRef, app);
+          assert.strictEqual(path, 'dummy');
+          done();
+        }
       });
     });
   });


### PR DESCRIPTION
This should address the problem mentioned by @vonagam in https://github.com/feathersjs/feathers/pull/2510#issuecomment-1088128229