### PR TITLE
fix(schema): result resolver correctly resolves paginated find result

### DIFF
--- a/packages/schema/src/hooks.ts
+++ b/packages/schema/src/hooks.ts
@@ -73,16 +73,18 @@ export const resolveResult = <T> (resolver: Resolver<T, HookContext>) =>
 
     const ctx = getContext(context);
     const status = context.params.resolve;
-    const data = context.method === 'find' && context.result.data
-      ? context.result.data
-      : context.result;
 
-    if (Array.isArray(data)) {
-      context.result = await Promise.all(data.map(current =>
-        resolver.resolve(current, ctx, status)
-      ));
+    const isPaginated = context.method === 'find' && context.result.data;
+    const data = isPaginated ? context.result.data : context.result;
+
+    const result = Array.isArray(data) ?
+      await Promise.all(data.map(async current => resolver.resolve(current, ctx, status))) :
+      await resolver.resolve(data, ctx, status);
+
+    if (isPaginated) {
+      context.result.data = result;
     } else {
-      context.result = await resolver.resolve(data, ctx, status);
+      context.result = result;
     }
   };
 

--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -138,6 +138,7 @@ export const messageQueryResolver = resolve<MessageQuery, HookContext<Applicatio
 type ServiceTypes = {
   users: Service<UserResult, User>,
   messages: Service<MessageResult, Message>
+  pagintedMessages: Service<MessageResult, Message>
 }
 type Application = FeathersApplication<ServiceTypes>;
 
@@ -145,9 +146,17 @@ const app = feathers<ServiceTypes>()
   .use('users', memory({
     multi: ['create']
   }))
-  .use('messages', memory());
+  .use('messages', memory())
+  .use('pagintedMessages', memory({paginate: { default: 10 }}))
+  ;
 
 app.service('messages').hooks([
+  validateQuery(messageQuerySchema),
+  resolveQuery(messageQueryResolver),
+  resolveResult(messageResultResolver)
+]);
+
+app.service('pagintedMessages').hooks([
   validateQuery(messageQuerySchema),
   resolveQuery(messageQueryResolver),
   resolveResult(messageResultResolver)


### PR DESCRIPTION
### Summary

This pull request will resolves an issue with the resultResolver in combination with a paginated services.

Currently the schema resultResolver resolves the result on context.data. This will end up in an issue if you have a service configured with pagination enabled. 

Before the resultResolver is running we have the properties `total`, `limit`, `skip` and `data` on `context.result`. After all properties are resolved, the result of it will set to `context.result`. That means, that the paginated result structure gets los.



