### PR TITLE
fix(transport-commons): Ensure socket queries are always plain objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -225,14 +225,14 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.17.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz",
-			"integrity": "sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz",
+			"integrity": "sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.16.7",
 				"@babel/helper-environment-visitor": "^7.16.7",
-				"@babel/helper-function-name": "^7.16.7",
-				"@babel/helper-member-expression-to-functions": "^7.16.7",
+				"@babel/helper-function-name": "^7.17.9",
+				"@babel/helper-member-expression-to-functions": "^7.17.7",
 				"@babel/helper-optimise-call-expression": "^7.16.7",
 				"@babel/helper-replace-supers": "^7.16.7",
 				"@babel/helper-split-export-declaration": "^7.16.7"
@@ -308,24 +308,12 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-			"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
 			"dependencies": {
-				"@babel/helper-get-function-arity": "^7.16.7",
 				"@babel/template": "^7.16.7",
-				"@babel/types": "^7.16.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-			"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-			"dependencies": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.17.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1253,9 +1241,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.7.tgz",
-			"integrity": "sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz",
+			"integrity": "sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==",
 			"dependencies": {
 				"@babel/helper-module-transforms": "^7.17.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
@@ -1374,11 +1362,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
-			"integrity": "sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz",
+			"integrity": "sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==",
 			"dependencies": {
-				"regenerator-transform": "^0.14.2"
+				"regenerator-transform": "^0.15.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1612,9 +1600,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
-			"integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+			"integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -7464,9 +7452,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
-			"integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+			"integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -11766,9 +11754,9 @@
 			}
 		},
 		"node_modules/loader-runner": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
 			"engines": {
 				"node": ">=6.11.5"
 			}
@@ -15917,9 +15905,9 @@
 			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
 		},
 		"node_modules/regenerator-transform": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
-			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.0.tgz",
+			"integrity": "sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==",
 			"dependencies": {
 				"@babel/runtime": "^7.8.4"
 			}
@@ -18058,9 +18046,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.71.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
-			"integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
+			"version": "5.72.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+			"integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
 				"@types/estree": "^0.0.51",
@@ -18778,14 +18766,14 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.17.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz",
-			"integrity": "sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz",
+			"integrity": "sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.16.7",
 				"@babel/helper-environment-visitor": "^7.16.7",
-				"@babel/helper-function-name": "^7.16.7",
-				"@babel/helper-member-expression-to-functions": "^7.16.7",
+				"@babel/helper-function-name": "^7.17.9",
+				"@babel/helper-member-expression-to-functions": "^7.17.7",
 				"@babel/helper-optimise-call-expression": "^7.16.7",
 				"@babel/helper-replace-supers": "^7.16.7",
 				"@babel/helper-split-export-declaration": "^7.16.7"
@@ -18839,21 +18827,12 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-			"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.16.7",
 				"@babel/template": "^7.16.7",
-				"@babel/types": "^7.16.7"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-			"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-			"requires": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.17.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -19467,9 +19446,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.7.tgz",
-			"integrity": "sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz",
+			"integrity": "sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.17.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
@@ -19540,11 +19519,11 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
-			"integrity": "sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz",
+			"integrity": "sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==",
 			"requires": {
-				"regenerator-transform": "^0.14.2"
+				"regenerator-transform": "^0.15.0"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
@@ -19714,9 +19693,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
-			"integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+			"integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -24533,9 +24512,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
-			"integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+			"integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
 			"requires": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -27890,9 +27869,9 @@
 			}
 		},
 		"loader-runner": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-			"integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
 		},
 		"loader-utils": {
 			"version": "2.0.2",
@@ -31152,9 +31131,9 @@
 			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
 		},
 		"regenerator-transform": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
-			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.0.tgz",
+			"integrity": "sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==",
 			"requires": {
 				"@babel/runtime": "^7.8.4"
 			}
@@ -32780,9 +32759,9 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.71.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
-			"integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
+			"version": "5.72.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+			"integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
 				"@types/estree": "^0.0.51",

--- a/packages/transport-commons/src/socket/utils.ts
+++ b/packages/transport-commons/src/socket/utils.ts
@@ -91,7 +91,7 @@ export async function runMethod (app: Application, connection: RealTimeConnectio
     }
 
     const position = paramsPositions[method] !== undefined ? paramsPositions[method] : DEFAULT_PARAMS_POSITION;
-    const query = methodArgs[position] || {};
+    const query = Object.assign({}, methodArgs[position]);
     // `params` have to be re-mapped to the query and added with the route
     const params = Object.assign({ query, route, connection }, connection);
 


### PR DESCRIPTION
This is related to https://github.com/feathersjs-ecosystem/feathers-sequelize/pull/389 and ensures that silly JavaScript prototype gymnastics can't be done for any websocket query.