### PR TITLE
feat(typescript): Improve params and query typeability

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -16,14 +16,16 @@ const alwaysMulti: { [key: string]: boolean } = {
   update: false
 };
 
+export interface PaginationOptions {
+  default?: number;
+  max?: number;
+}
+
 export interface ServiceOptions {
   events?: string[];
   multi?: boolean|string[];
   id?: string;
-  paginate?: {
-    default?: number;
-    max?: number;
-  }
+  paginate?: PaginationOptions
   /**
    * @deprecated renamed to `allow`.
    */
@@ -38,6 +40,7 @@ export interface AdapterOptions<M = any> extends Pick<ServiceOptions, 'multi'|'a
 
 export interface AdapterParams<M = any> extends Params {
   adapter?: Partial<AdapterOptions<M>>;
+  paginate?: false|PaginationOptions;
 }
 
 /**

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -2,7 +2,7 @@
 // @ts-ignore
 import querystring from 'querystring';
 import {
-  AuthenticationRequest, AuthenticationBaseStrategy, AuthenticationResult
+  AuthenticationRequest, AuthenticationBaseStrategy, AuthenticationResult, AuthenticationParams
 } from '@feathersjs/authentication';
 import { Params } from '@feathersjs/feathers';
 import { NotAuthenticated } from '@feathersjs/errors';
@@ -84,7 +84,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     return redirect;
   }
 
-  async getRedirect (data: AuthenticationResult|Error, params?: Params): Promise<string | null> {
+  async getRedirect (data: AuthenticationResult|Error, params?: AuthenticationParams): Promise<string | null> {
     const queryRedirect = (params && params.redirect) || '';
     const redirect = await this.getAllowedOrigin(params);
 
@@ -156,7 +156,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     });
   }
 
-  async authenticate (authentication: AuthenticationRequest, originalParams: Params) {
+  async authenticate (authentication: AuthenticationRequest, originalParams: AuthenticationParams) {
     const entity: string = this.configuration.entity;
     const { provider, ...params } = originalParams;
     const profile = await this.getProfile(authentication, params);

--- a/packages/authentication-oauth/test/fixture.ts
+++ b/packages/authentication-oauth/test/fixture.ts
@@ -1,11 +1,11 @@
-import { feathers, Params } from '@feathersjs/feathers';
+import { feathers } from '@feathersjs/feathers';
 import express, { rest, errorHandler } from '@feathersjs/express';
 import { memory } from '@feathersjs/memory';
-import { AuthenticationService, JWTStrategy, AuthenticationRequest } from '@feathersjs/authentication';
+import { AuthenticationService, JWTStrategy, AuthenticationRequest, AuthenticationParams } from '@feathersjs/authentication';
 import { express as oauth, OAuthStrategy } from '../src';
 
 export class TestOAuthStrategy extends OAuthStrategy {
-  async authenticate (data: AuthenticationRequest, params: Params) {
+  async authenticate (data: AuthenticationRequest, params: AuthenticationParams) {
     const { fromMiddleware } = params;
     const authResult = await super.authenticate(data, params);
 

--- a/packages/authentication/src/core.ts
+++ b/packages/authentication/src/core.ts
@@ -18,6 +18,14 @@ export interface AuthenticationRequest {
   [key: string]: any;
 }
 
+export interface AuthenticationParams extends Params {
+  payload?: { [key: string]: any };
+  jwtOptions?: SignOptions;
+  authStrategies?: string[];
+  secret?: string;
+  [key: string]: any;
+}
+
 export type ConnectionEvent = 'login' | 'logout' | 'disconnect';
 
 export interface AuthenticationStrategy {
@@ -57,7 +65,7 @@ export interface AuthenticationStrategy {
    * @param authentication The authentication request
    * @param params The service call parameters
    */
-  authenticate? (authentication: AuthenticationRequest, params: Params): Promise<AuthenticationResult>;
+  authenticate? (authentication: AuthenticationRequest, params: AuthenticationParams): Promise<AuthenticationResult>;
   /**
    * Update a real-time connection according to this strategy.
    *
@@ -232,7 +240,7 @@ export class AuthenticationBase {
    * @param params Service call parameters
    * @param allowed A list of allowed strategy names
    */
-  async authenticate (authentication: AuthenticationRequest, params: Params, ...allowed: string[]) {
+  async authenticate (authentication: AuthenticationRequest, params: AuthenticationParams, ...allowed: string[]) {
     const { strategy } = authentication || {};
     const [ authStrategy ] = this.getStrategies(strategy);
     const strategyAllowed = allowed.includes(strategy);

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -5,6 +5,7 @@ export {
   AuthenticationRequest,
   AuthenticationResult,
   AuthenticationStrategy,
+  AuthenticationParams,
   ConnectionEvent
 } from './core';
 export { AuthenticationBaseStrategy } from './strategy';

--- a/packages/authentication/src/jwt.ts
+++ b/packages/authentication/src/jwt.ts
@@ -8,7 +8,7 @@ import { createDebug } from '@feathersjs/commons';
 import lt from 'long-timeout';
 
 import { AuthenticationBaseStrategy } from './strategy';
-import { AuthenticationRequest, AuthenticationResult, ConnectionEvent } from './core';
+import { AuthenticationParams, AuthenticationRequest, AuthenticationResult, ConnectionEvent } from './core';
 
 const debug = createDebug('@feathersjs/authentication/jwt');
 const SPLIT_HEADER = /(\S+)\s+(\S+)/;
@@ -116,7 +116,7 @@ export class JWTStrategy extends AuthenticationBaseStrategy {
     return authResult.authentication.payload.sub;
   }
 
-  async authenticate (authentication: AuthenticationRequest, params: Params) {
+  async authenticate (authentication: AuthenticationRequest, params: AuthenticationParams) {
     const { accessToken } = authentication;
     const { entity } = this.configuration;
 

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -29,7 +29,7 @@ declare module '@feathersjs/feathers/lib/declarations' {
 // eslint-disable-next-line
 export interface AuthenticationService extends ServiceAddons<AuthenticationResult, AuthenticationResult> {}
 
-export class AuthenticationService extends AuthenticationBase implements Partial<ServiceMethods<AuthenticationResult>> {
+export class AuthenticationService extends AuthenticationBase implements Partial<ServiceMethods<AuthenticationResult, AuthenticationRequest>> {
   constructor (app: any, configKey = 'authentication', options = {}) {
     super(app, configKey, options);
 

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -1,10 +1,10 @@
 import merge from 'lodash/merge';
 import { NotAuthenticated } from '@feathersjs/errors';
-import { AuthenticationBase, AuthenticationResult, AuthenticationRequest } from './core';
+import { AuthenticationBase, AuthenticationResult, AuthenticationRequest, AuthenticationParams } from './core';
 import { connection, event } from './hooks';
 import '@feathersjs/transport-commons';
 import { createDebug } from '@feathersjs/commons';
-import { Params, ServiceMethods, ServiceAddons } from '@feathersjs/feathers';
+import { ServiceMethods, ServiceAddons } from '@feathersjs/feathers';
 import jsonwebtoken from 'jsonwebtoken';
 
 const debug = createDebug('@feathersjs/authentication/service');
@@ -29,7 +29,7 @@ declare module '@feathersjs/feathers/lib/declarations' {
 // eslint-disable-next-line
 export interface AuthenticationService extends ServiceAddons<AuthenticationResult, AuthenticationResult> {}
 
-export class AuthenticationService extends AuthenticationBase implements Partial<ServiceMethods<AuthenticationResult, AuthenticationRequest>> {
+export class AuthenticationService extends AuthenticationBase implements Partial<ServiceMethods<AuthenticationResult, AuthenticationRequest, AuthenticationParams>> {
   constructor (app: any, configKey = 'authentication', options = {}) {
     super(app, configKey, options);
 
@@ -51,7 +51,7 @@ export class AuthenticationService extends AuthenticationBase implements Partial
    * @param _authResult The current authentication result
    * @param params The service call parameters
    */
-  async getPayload (_authResult: AuthenticationResult, params: Params) {
+  async getPayload (_authResult: AuthenticationResult, params: AuthenticationParams) {
     // Uses `params.payload` or returns an empty payload
     const { payload = {} } = params;
 
@@ -65,7 +65,7 @@ export class AuthenticationService extends AuthenticationBase implements Partial
    * @param authResult The authentication result
    * @param params Service call parameters
    */
-  async getTokenOptions (authResult: AuthenticationResult, params: Params) {
+  async getTokenOptions (authResult: AuthenticationResult, params: AuthenticationParams) {
     const { service, entity, entityId } = this.configuration;
     const jwtOptions = merge({}, params.jwtOptions, params.jwt);
     const value = service && entity && authResult[entity];
@@ -92,7 +92,7 @@ export class AuthenticationService extends AuthenticationBase implements Partial
    * @param data The authentication request (should include `strategy` key)
    * @param params Service call parameters
    */
-  async create (data: AuthenticationRequest, params?: Params) {
+  async create (data: AuthenticationRequest, params?: AuthenticationParams) {
     const authStrategies = params.authStrategies || this.configuration.authStrategies;
 
     if (!authStrategies.length) {
@@ -131,7 +131,7 @@ export class AuthenticationService extends AuthenticationBase implements Partial
    * @param id The JWT to remove or null
    * @param params Service call parameters
    */
-  async remove (id: string | null, params?: Params) {
+  async remove (id: string | null, params?: AuthenticationParams) {
     const { authentication } = params;
     const { authStrategies } = this.configuration;
 

--- a/packages/authentication/test/hooks/event.test.ts
+++ b/packages/authentication/test/hooks/event.test.ts
@@ -1,11 +1,11 @@
 import assert from 'assert';
-import { feathers, Params, HookContext } from '@feathersjs/feathers';
+import { feathers, HookContext } from '@feathersjs/feathers';
 
 import hook from '../../src/hooks/event';
-import { AuthenticationRequest, AuthenticationResult } from '../../src/core';
+import { AuthenticationParams, AuthenticationRequest, AuthenticationResult } from '../../src/core';
 
 describe('authentication/hooks/events', () => {
-  const app = feathers().use('/authentication', {
+  const app = feathers().use('authentication', {
     async create (data: AuthenticationRequest) {
       return data;
     },
@@ -27,7 +27,7 @@ describe('authentication/hooks/events', () => {
       message: 'test'
     };
 
-    app.once('login', (result: AuthenticationResult, params: Params, context: HookContext) => {
+    app.once('login', (result: AuthenticationResult, params: AuthenticationParams, context: HookContext) => {
       try {
         assert.deepStrictEqual(result, data);
         assert.ok(params.testParam);
@@ -41,11 +41,11 @@ describe('authentication/hooks/events', () => {
     service.create(data, {
       testParam: true,
       provider: 'test'
-    });
+    }as any);
   });
 
   it('logout', done => {
-    app.once('logout', (result: AuthenticationResult, params: Params, context: HookContext) => {
+    app.once('logout', (result: AuthenticationResult, params: AuthenticationParams, context: HookContext) => {
       try {
         assert.deepStrictEqual(result, {
           id: 'test'
@@ -61,7 +61,7 @@ describe('authentication/hooks/events', () => {
     service.remove('test', {
       testParam: true,
       provider: 'test'
-    });
+    } as any);
   });
 
   it('does nothing when provider is not set', done => {

--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -9,7 +9,7 @@ interface ExpressUseHandler<T, Services> {
   <L extends keyof Services & string> (
     path: L,
     ...middlewareOrService: (
-      Express|express.RequestHandler|
+      Express|express.RequestHandler|express.RequestHandler[]|
       (keyof any extends keyof Services ? ServiceInterface : Services[L])
     )[]
   ): T;

--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -44,7 +44,7 @@ declare module '@feathersjs/feathers/lib/declarations' {
 
 declare module 'express-serve-static-core' {
   interface Request {
-    feathers?: Partial<FeathersParams>;
+    feathers?: Partial<FeathersParams> & { [key: string]: any };
     lookup?: RouteLookup;
   }
 

--- a/packages/express/test/rest.test.ts
+++ b/packages/express/test/rest.test.ts
@@ -380,10 +380,9 @@ describe('@feathersjs/express/rest provider', () => {
     it('allows middleware arrays before and after a service', async () => {
       const app = expressify(feathers());
 
-      app
-        .use(express.json())
-        .configure(rest())
-        .use('/todo', [function (req: Request, _res: Response, next: NextFunction) {
+      app.use(express.json());
+      app.configure(rest());
+      app.use('/todo', [function (req: Request, _res: Response, next: NextFunction) {
           req.body.before = ['before first'];
           next();
         }, function (req: Request, _res: Response, next: NextFunction) {

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -21,87 +21,87 @@ export interface ServiceOptions {
   routeParams?: { [key: string]: any };
 }
 
-export interface ServiceMethods<T = any, D = Partial<T>> {
-  find (params?: Params): Promise<T | T[]>;
+export interface ServiceMethods<T = any, D = Partial<T>, P = Params> {
+  find (params?: P): Promise<T | T[]>;
 
-  get (id: Id, params?: Params): Promise<T>;
+  get (id: Id, params?: P): Promise<T>;
 
-  create (data: D, params?: Params): Promise<T>;
+  create (data: D, params?: P): Promise<T>;
 
-  update (id: NullableId, data: D, params?: Params): Promise<T | T[]>;
+  update (id: NullableId, data: D, params?: P): Promise<T | T[]>;
 
-  patch (id: NullableId, data: D, params?: Params): Promise<T | T[]>;
+  patch (id: NullableId, data: D, params?: P): Promise<T | T[]>;
 
-  remove (id: NullableId, params?: Params): Promise<T | T[]>;
+  remove (id: NullableId, params?: P): Promise<T | T[]>;
 
   setup (app: Application, path: string): Promise<void>;
 
   teardown (app: Application, path: string): Promise<void>;
 }
 
-export interface ServiceOverloads<T = any, D = Partial<T>> {
-  create? (data: D[], params?: Params): Promise<T[]>;
+export interface ServiceOverloads<T = any, D = Partial<T>, P = Params> {
+  create? (data: D[], params?: P): Promise<T[]>;
 
-  update? (id: Id, data: D, params?: Params): Promise<T>;
+  update? (id: Id, data: D, params?: P): Promise<T>;
 
-  update? (id: null, data: D, params?: Params): Promise<T[]>;
+  update? (id: null, data: D, params?: P): Promise<T[]>;
 
-  patch? (id: Id, data: D, params?: Params): Promise<T>;
+  patch? (id: Id, data: D, params?: P): Promise<T>;
 
-  patch? (id: null, data: D, params?: Params): Promise<T[]>;
+  patch? (id: null, data: D, params?: P): Promise<T[]>;
 
-  remove? (id: Id, params?: Params): Promise<T>;
+  remove? (id: Id, params?: P): Promise<T>;
 
-  remove? (id: null, params?: Params): Promise<T[]>;
+  remove? (id: null, params?: P): Promise<T[]>;
 }
 
-export type Service<T = any, D = Partial<T>> =
-  ServiceMethods<T, D> &
-  ServiceOverloads<T, D>;
+export type Service<T = any, D = Partial<T>, P = Params> =
+  ServiceMethods<T, D, P> &
+  ServiceOverloads<T, D, P>;
 
-export type ServiceInterface<T = any, D = Partial<T>> =
-  Partial<ServiceMethods<T, D>>;
+export type ServiceInterface<T = any, D = Partial<T>, P = Params> =
+  Partial<ServiceMethods<T, D, P>>;
 
 export interface ServiceAddons<A = Application, S = Service> extends EventEmitter {
   id?: string;
   hooks (options: HookOptions<A, S>): this;
 }
 
-export interface ServiceHookOverloads<S> {
+export interface ServiceHookOverloads<S, P = Params> {
   find (
-    params: Params,
+    params: P,
     context: HookContext
   ): Promise<HookContext>;
 
   get (
     id: Id,
-    params: Params,
+    params: P,
     context: HookContext
   ): Promise<HookContext>;
 
   create (
     data: ServiceGenericData<S> | ServiceGenericData<S>[],
-    params: Params,
+    params: P,
     context: HookContext
   ): Promise<HookContext>;
 
   update (
     id: NullableId,
     data: ServiceGenericData<S>,
-    params: Params,
+    params: P,
     context: HookContext
   ): Promise<HookContext>;
 
   patch (
     id: NullableId,
     data: ServiceGenericData<S>,
-    params: Params,
+    params: P,
     context: HookContext
   ): Promise<HookContext>;
 
   remove (
     id: NullableId,
-    params: Params,
+    params: P,
     context: HookContext
   ): Promise<HookContext>;
 }
@@ -117,6 +117,7 @@ export type ServiceMixin<A> = (service: FeathersService<A>, path: string, option
 
 export type ServiceGenericType<S> = S extends ServiceInterface<infer T> ? T : any;
 export type ServiceGenericData<S> = S extends ServiceInterface<infer _T, infer D> ? D : any;
+export type ServiceGenericParams<S> = S extends ServiceInterface<infer _T, infer _D, infer P> ? P : any;
 
 export interface FeathersApplication<Services = any, Settings = any> {
   /**
@@ -246,12 +247,11 @@ export interface Query {
   [key: string]: any;
 }
 
-export interface Params {
-  query?: Query;
+export interface Params<Q = Query> {
+  query?: Q;
   provider?: string;
   route?: { [key: string]: any };
   headers?: { [key: string]: any };
-  [key: string]: any; // (JL) not sure if we want this
 }
 
 export interface Http {
@@ -319,7 +319,7 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
    * A writeable property that contains the service method parameters (including
    * params.query).
    */
-  params: Params;
+  params: ServiceGenericParams<S>;
   /**
    * A writeable property containing the result of the successful service method call.
    * It is only available in after hooks.

--- a/packages/feathers/test/events.test.ts
+++ b/packages/feathers/test/events.test.ts
@@ -236,10 +236,15 @@ describe('Service events', () => {
     });
 
     it('.remove and removed with array', async () => {
+      const removeItems = [
+        { message: 'Hello 0' },
+        { message: 'Hello 1' }
+      ];
+
       const app = feathers().use('/creator', {
         async remove (id: any, data: any) {
-          if (Array.isArray(data)) {
-            return Promise.all(data.map((current, index) =>
+          if (id === null) {
+            return Promise.all(removeItems.map((current, index) =>
               (this as any).remove(index, current))
             );
           }
@@ -248,10 +253,6 @@ describe('Service events', () => {
       });
 
       const service = app.service('creator');
-      const removeItems = [
-        { message: 'Hello 0' },
-        { message: 'Hello 1' }
-      ];
 
       const events = Promise.all(removeItems.map((element, index) => {
         return new Promise<void>((resolve) => {
@@ -264,7 +265,7 @@ describe('Service events', () => {
         });
       }));
 
-      await service.remove(null, removeItems);
+      await service.remove(null);
       await events;
     });
   });

--- a/packages/feathers/test/hooks/app.test.ts
+++ b/packages/feathers/test/hooks/app.test.ts
@@ -1,12 +1,29 @@
 import assert from 'assert';
 
-import { feathers, Application, ApplicationHookMap } from '../../src';
+import { feathers, Application, ApplicationHookMap, ServiceInterface, Params } from '../../src';
+
+type Todo = {
+  id?: string,
+  params?: TodoParams,
+  data?: any,
+  test?: string,
+  order?: string[]
+}
+
+interface TodoParams extends Params {
+  order: string[];
+  ran: boolean;
+}
+
+type TodoService = ServiceInterface<Todo, Todo, TodoParams>;
+
+type App = Application<{ todos: TodoService }>;
 
 describe('app.hooks', () => {
-  let app: Application;
+  let app: App;
 
   beforeEach(() => {
-    app = feathers().use('/todos', {
+    app = feathers().use('todos', {
       async get (id: any, params: any) {
         if (id === 'error') {
           throw new Error('Something went wrong');

--- a/packages/feathers/test/hooks/before.test.ts
+++ b/packages/feathers/test/hooks/before.test.ts
@@ -1,10 +1,16 @@
 import assert from 'assert';
-import { feathers } from '../../src';
+import { feathers, Params, ServiceInterface } from '../../src';
 
 describe('`before` hooks', () => {
   it('.before hooks can return a promise', async () => {
-    const app = feathers().use('/dummy', {
-      async get (id: any, params: any) {
+    interface DummyParams extends Params {
+      ran: boolean;
+    }
+
+    type DummyService = ServiceInterface<any, any, DummyParams>;
+
+    const app = feathers<{ dummy: DummyService }>().use('dummy', {
+      async get (id: any, params: DummyParams) {
         assert.ok(params.ran, 'Ran through promise hook');
 
         return {
@@ -43,7 +49,13 @@ describe('`before` hooks', () => {
   });
 
   it('.before hooks do not need to return anything', async () => {
-    const app = feathers().use('/dummy', {
+    interface DummyParams extends Params {
+      ran: boolean;
+    }
+
+    type DummyService = ServiceInterface<any, any, DummyParams>;
+
+    const app = feathers<{ dummy: DummyService }>().use('dummy', {
       async get (id: any, params: any) {
         assert.ok(params.ran, 'Ran through promise hook');
 
@@ -198,6 +210,12 @@ describe('`before` hooks', () => {
   });
 
   it('calling back with no arguments uses the old ones', async () => {
+    interface DummyParams extends Params {
+      my: string;
+    }
+
+    type DummyService = ServiceInterface<any, any, DummyParams>;
+
     const dummyService = {
       async remove (id: any, params: any) {
         assert.strictEqual(id, 1, 'Got id');
@@ -206,7 +224,7 @@ describe('`before` hooks', () => {
         return { id };
       }
     };
-    const app = feathers().use('/dummy', dummyService);
+    const app = feathers<{ dummy: DummyService }>().use('dummy', dummyService);
     const service = app.service('dummy');
 
     service.hooks({
@@ -221,6 +239,12 @@ describe('`before` hooks', () => {
   });
 
   it('adds .hooks() and chains multiple hooks for the same method', async () => {
+    interface DummyParams extends Params {
+      modified: string;
+    }
+
+    type DummyService = ServiceInterface<any, any, DummyParams>;
+
     const dummyService = {
       async create (data: any, params: any) {
         assert.deepStrictEqual(data, {
@@ -235,7 +259,7 @@ describe('`before` hooks', () => {
         return data;
       }
     };
-    const app = feathers().use('/dummy', dummyService);
+    const app = feathers<{ dummy: DummyService }>().use('dummy', dummyService);
     const service = app.service('dummy');
 
     service.hooks({
@@ -262,6 +286,12 @@ describe('`before` hooks', () => {
   });
 
   it('chains multiple before hooks using array syntax', async () => {
+    interface DummyParams extends Params {
+      modified: string;
+    }
+
+    type DummyService = ServiceInterface<any, any, DummyParams>;
+
     const dummyService = {
       async create (data: any, params: any) {
         assert.deepStrictEqual(data, {
@@ -277,7 +307,7 @@ describe('`before` hooks', () => {
       }
     };
 
-    const app = feathers().use('/dummy', dummyService);
+    const app = feathers<{ dummy: DummyService }>().use('dummy', dummyService);
     const service = app.service('dummy');
 
     service.hooks({
@@ -301,7 +331,13 @@ describe('`before` hooks', () => {
   });
 
   it('.before hooks run in the correct order (#13)', async () => {
-    const app = feathers().use('/dummy', {
+    interface DummyParams extends Params {
+      items: string[];
+    }
+
+    type DummyService = ServiceInterface<any, any, DummyParams>;
+
+    const app = feathers<{ dummy: DummyService }>().use('dummy', {
       async get (id: any, params: any) {
         assert.deepStrictEqual(params.items, ['first', 'second', 'third']);
 
@@ -344,7 +380,14 @@ describe('`before` hooks', () => {
   });
 
   it('before all hooks (#11)', async () => {
-    const app = feathers().use('/dummy', {
+    interface DummyParams extends Params {
+      beforeAllObject: boolean;
+      beforeAllMethodArray: boolean;
+    }
+
+    type DummyService = ServiceInterface<any, any, DummyParams>;
+
+    const app = feathers<{ dummy: DummyService }>().use('dummy', {
       async get (id: any, params: any) {
         assert.ok(params.beforeAllObject);
         assert.ok(params.beforeAllMethodArray);
@@ -389,10 +432,14 @@ describe('`before` hooks', () => {
   });
 
   it('before hooks have service as context and keep it in service method (#17)', async () => {
-    class Dummy {
+    interface DummyParams extends Params {
+      test: number;
+    }
+
+    class Dummy implements ServiceInterface<any, any, DummyParams> {
       number = 42;
 
-      async get (id: any, params: any) {
+      async get (id: any, params?: DummyParams) {
         return {
           id,
           number: this.number,
@@ -401,7 +448,7 @@ describe('`before` hooks', () => {
       }
     }
 
-    const app = feathers().use('/dummy', new Dummy());
+    const app = feathers<{ dummy: Dummy }>().use('dummy', new Dummy());
     const service = app.service('dummy');
 
     service.hooks({

--- a/packages/feathers/test/hooks/hooks.test.ts
+++ b/packages/feathers/test/hooks/hooks.test.ts
@@ -1,11 +1,15 @@
 import assert from 'assert';
 import { hooks, NextFunction } from '@feathersjs/hooks';
-import { HookContext, createContext, feathers, Id, Params } from '../../src';
+import { HookContext, createContext, feathers, Id, Params, ServiceInterface } from '../../src';
 
 describe('hooks basics', () => {
   it('mix @feathersjs/hooks and .hooks', async () => {
+    interface SimpleParams extends Params {
+      chain: string[];
+
+    }
     class SimpleService {
-      async get (id: Id, params: Params) {
+      async get (id: Id, params: SimpleParams) {
         return { id, chain: params.chain };
       }
     }
@@ -121,7 +125,11 @@ describe('hooks basics', () => {
   // });
 
   it('works with services that return a promise (feathers-hooks#28)', async () => {
-    const app = feathers().use('/dummy', {
+    interface DummyParams extends Params {
+      user: string;
+    }
+
+    const app = feathers<{ dummy: ServiceInterface<any, any, DummyParams> }>().use('dummy', {
       async get (id: any, params: any) {
         return { id, user: params.user };
       }

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -22,7 +22,7 @@ const _select = (data: any, params: any, ...args: any[]) => {
 };
 
 export class Service<T = any, D = Partial<T>> extends AdapterService<T, D> implements InternalServiceMethods<T> {
-  options: MemoryServiceOptions;
+  options: MemoryServiceOptions<T>;
   store: MemoryServiceStore<T>;
   _uId: number;
 

--- a/packages/rest-client/src/axios.ts
+++ b/packages/rest-client/src/axios.ts
@@ -1,8 +1,7 @@
-import { Params } from '@feathersjs/feathers';
-import { Base } from './base';
+import { Base, RestClientParams } from './base';
 
 export class AxiosClient extends Base {
-  request (options: any, params: Params) {
+  request (options: any, params: RestClientParams) {
     const config = Object.assign({
       url: options.url,
       method: options.method,

--- a/packages/rest-client/src/base.ts
+++ b/packages/rest-client/src/base.ts
@@ -11,6 +11,10 @@ function toError (error: Error & { code: string }) {
   throw convert(error);
 }
 
+export interface RestClientParams extends Params {
+  connection?: any;
+}
+
 interface RestClientSettings {
   name: string;
   base: string;
@@ -73,7 +77,7 @@ export abstract class Base<T = any, D = Partial<T>> implements ServiceInterface<
     return this;
   }
 
-  find (params: Params = {}) {
+  find (params: RestClientParams = {}) {
     return this.request({
       url: this.makeUrl(params.query),
       method: 'GET',
@@ -81,7 +85,7 @@ export abstract class Base<T = any, D = Partial<T>> implements ServiceInterface<
     }, params).catch(toError);
   }
 
-  get (id: Id, params: Params = {}) {
+  get (id: Id, params: RestClientParams = {}) {
     if (typeof id === 'undefined') {
       return Promise.reject(new Error('id for \'get\' can not be undefined'));
     }
@@ -93,7 +97,7 @@ export abstract class Base<T = any, D = Partial<T>> implements ServiceInterface<
     }, params).catch(toError);
   }
 
-  create (body: D, params: Params = {}) {
+  create (body: D, params: RestClientParams = {}) {
     return this.request({
       url: this.makeUrl(params.query),
       body,
@@ -102,7 +106,7 @@ export abstract class Base<T = any, D = Partial<T>> implements ServiceInterface<
     }, params).catch(toError);
   }
 
-  update (id: NullableId, body: D, params: Params = {}) {
+  update (id: NullableId, body: D, params: RestClientParams = {}) {
     if (typeof id === 'undefined') {
       return Promise.reject(new Error('id for \'update\' can not be undefined, only \'null\' when updating multiple entries'));
     }
@@ -115,7 +119,7 @@ export abstract class Base<T = any, D = Partial<T>> implements ServiceInterface<
     }, params).catch(toError);
   }
 
-  patch (id: NullableId, body: D, params: Params = {}) {
+  patch (id: NullableId, body: D, params: RestClientParams = {}) {
     if (typeof id === 'undefined') {
       return Promise.reject(new Error('id for \'patch\' can not be undefined, only \'null\' when updating multiple entries'));
     }
@@ -128,7 +132,7 @@ export abstract class Base<T = any, D = Partial<T>> implements ServiceInterface<
     }, params).catch(toError);
   }
 
-  remove (id: NullableId, params: Params = {}) {
+  remove (id: NullableId, params: RestClientParams = {}) {
     if (typeof id === 'undefined') {
       return Promise.reject(new Error('id for \'remove\' can not be undefined, only \'null\' when removing multiple entries'));
     }

--- a/packages/rest-client/src/fetch.ts
+++ b/packages/rest-client/src/fetch.ts
@@ -1,9 +1,8 @@
-import { Params } from '@feathersjs/feathers';
 import { errors } from '@feathersjs/errors';
-import { Base } from './base';
+import { Base, RestClientParams } from './base';
 
 export class FetchClient extends Base {
-  request (options: any, params: Params) {
+  request (options: any, params: RestClientParams) {
     const fetchOptions = Object.assign({}, options, params.connection);
 
     fetchOptions.headers = Object.assign({

--- a/packages/rest-client/src/superagent.ts
+++ b/packages/rest-client/src/superagent.ts
@@ -1,8 +1,7 @@
-import { Params } from '@feathersjs/feathers';
-import { Base } from './base';
+import { Base, RestClientParams } from './base';
 
 export class SuperagentClient extends Base {
-  request (options: any, params: Params) {
+  request (options: any, params: RestClientParams) {
     const superagent = this.connection(options.method, options.url)
       .set(this.options.headers || {})
       .set('Accept', 'application/json')

--- a/packages/rest-client/test/server.ts
+++ b/packages/rest-client/test/server.ts
@@ -29,9 +29,13 @@ const errorHandler = function (error: FeathersError, _req: any, res: any, _next:
   });
 };
 
+interface TodoServiceParams extends Params {
+  authorization: any;
+}
+
 // Create an in-memory CRUD service for our Todos
 class TodoService extends Service {
-  get (id: Id, params: Params) {
+  get (id: Id, params: TodoServiceParams) {
     if (params.query.error) {
       throw new Error('Something went wrong');
     }

--- a/packages/schema/test/hooks.test.ts
+++ b/packages/schema/test/hooks.test.ts
@@ -53,7 +53,7 @@ describe('@feathersjs/schema/hooks', () => {
     await assert.rejects(() => app.service('messages').find({
       provider: 'external',
       error: true
-    }), {
+    } as any), {
       name: 'BadRequest',
       message: 'Error resolving data',
       code: 400,
@@ -90,7 +90,7 @@ describe('@feathersjs/schema/hooks', () => {
 
     const userMessages = await app.service('messages').find({
       user
-    }) as MessageResult[];
+    } as any) as MessageResult[];
 
     assert.strictEqual(userMessages.length, 1);
     assert.strictEqual(userMessages[0].userId, user.id);

--- a/packages/socketio/src/middleware.ts
+++ b/packages/socketio/src/middleware.ts
@@ -7,7 +7,7 @@ const debug = createDebug('@feathersjs/socketio/middleware');
 export type ParamsGetter = (socket: Socket) => any;
 export type NextFunction = (err?: any) => void;
 export interface FeathersSocket extends Socket {
-  feathers?: Params
+  feathers?: Params & { [key: string]: any }
 }
 
 export const disconnect = (app: Application, getParams: ParamsGetter) =>


### PR DESCRIPTION
This improves typing for `params` (removing the catch-all) and allows to pass your own instance to services as well as making `params.query` typeable.