### PR TITLE
feat(schema): Allow hooks to run resolvers in sequence

### DIFF
--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -33,7 +33,7 @@ export const userResultSchema = schema({
 } as const);
 
 export type User = Infer<typeof userSchema>;
-export type UserResult = Infer<typeof userResultSchema>;
+export type UserResult = Infer<typeof userResultSchema> & { name: string };
 
 export const userDataResolver = resolve<User, HookContext<Application>>({
   schema: userSchema,
@@ -48,9 +48,17 @@ export const userDataResolver = resolve<User, HookContext<Application>>({
 export const userResultResolver = resolve<UserResult, HookContext<Application>>({
   schema: userResultSchema,
   properties: {
+    name: async (_value, user) => user.email.split('@')[0],
     password: async (value, _user, context) => {
       return context.params.provider ? undefined : value;
     }
+  }
+});
+
+export const secondUserResultResolver = resolve<UserResult, HookContext<Application>>({
+  schema: userResultSchema,
+  properties: {
+    name: async (value, user) => `${value} (${user.email})`
   }
 });
 
@@ -168,7 +176,7 @@ app.service('paginatedMessages').hooks([
 ]);
 
 app.service('users').hooks([
-  resolveResult(userResultResolver)
+  resolveResult(userResultResolver, secondUserResultResolver)
 ]);
 
 app.service('users').hooks({

--- a/packages/schema/test/hooks.test.ts
+++ b/packages/schema/test/hooks.test.ts
@@ -23,6 +23,10 @@ describe('@feathersjs/schema/hooks', () => {
     });
   });
 
+  it('ran resolvers in sequence', async () => {
+    assert.strictEqual(user.name, 'hello (hello@feathersjs.com)');
+  });
+
   it('validates data', async () => {
     assert.rejects(() => app.service('users').create({ password: 'failing' }), {
       name: 'BadRequest'


### PR DESCRIPTION
This pull request adds the ability for resolver hooks to run multiple resolvers in sequence re-using the previous value. This allows to resolve properties that are dependent on the results of a previous resolver.

Closes https://github.com/feathersjs/feathers/issues/2601