### PR TITLE
fix(express): Fix typo in types reference in package.json

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -4,7 +4,7 @@
   "version": "5.0.0-pre.18",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
-  "type": "lib/",
+  "types": "lib/",
   "keywords": [
     "feathers",
     "feathers-plugin"


### PR DESCRIPTION
This pull request fixes a typo in `@feathersjs/express` `package.json` `types` field. Due to the error TypeScript types were not linked properly.

The typo was introduced recently in this commit: https://github.com/feathersjs/feathers/commit/c7612d1146db50a81e4d30012883f14a7024f0f5

Thanks for this amazing framework!