### PR TITLE
fix(authentication-oauth): Fix issue with overriding the default Grant configuration

### DIFF
--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import defaultsDeep from 'lodash/defaultsDeep';
 import each from 'lodash/each';
 import omit from 'lodash/omit';
 import { createDebug } from '@feathersjs/commons';
@@ -41,14 +41,14 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
     }
   }
 
-  const grant = merge({
+  const grant = defaultsDeep({}, omit(oauth, 'redirect'), {
     defaults: {
       prefix,
       origin: `${protocol}://${host}`,
       transport: 'session',
       response: ['tokens', 'raw', 'profile']
     }
-  }, omit(oauth, 'redirect'));
+  });
 
   const getUrl = (url: string) => {
     const { defaults } = grant;


### PR DESCRIPTION
This fixes an issue with overriding the default Grant config, as some of the options are arrays (i.e.: the `defaults.response` key) and using `_.merge` to apply user specified configs doesn't work. This fix uses `_.defaultsDeep` instead of `_.merge`.