### PR TITLE
fix(authentication-oauth): Don't send origins in Grant's config

### DIFF
--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -41,7 +41,7 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
     }
   }
 
-  const grant = defaultsDeep({}, omit(oauth, 'redirect'), {
+  const grant = defaultsDeep({}, omit(oauth, ['redirect', 'origins']), {
     defaults: {
       prefix,
       origin: `${protocol}://${host}`,


### PR DESCRIPTION
Don't send "origins" (similar to how we don't send "redirect") in Grant's config, as it will be considered another auth provider by Grant.