### PR TITLE
feat(schema): Add querySyntax helper to create full query schemas

### DIFF
--- a/packages/schema/src/query.ts
+++ b/packages/schema/src/query.ts
@@ -1,5 +1,30 @@
 import { JSONSchema } from 'json-schema-to-ts';
 
+export type PropertyQuery<D extends JSONSchema> = {
+  anyOf: [
+    D,
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        $gt: D,
+        $gte: D,
+        $lt: D,
+        $lte: D,
+        $ne: D,
+        $in: {
+          type: 'array',
+          items: D
+        },
+        $nin: {
+          type: 'array',
+          items: D
+        }
+      }
+    }
+  ]
+}
+
 export const queryProperty = <T extends JSONSchema> (definition: T) => ({
   anyOf: [
     definition,
@@ -24,3 +49,40 @@ export const queryProperty = <T extends JSONSchema> (definition: T) => ({
     }
   ]
 } as const);
+
+export const queryProperties = <T extends { [key: string]: JSONSchema }> (definition: T) =>
+  Object.keys(definition).reduce((res, key) => {
+    (res as any)[key] = queryProperty(definition[key])
+
+    return res
+  }, {} as { [K in keyof T]: PropertyQuery<T[K]> })
+
+export const querySyntax = <T extends { [key: string]: JSONSchema }> (definition: T) => ({
+  $limit: {
+    type: 'number',
+    minimum: 0
+  },
+  $skip: {
+    type: 'number',
+    minimum: 0
+  },
+  $sort: {
+    type: 'object',
+    properties: Object.keys(definition).reduce((res, key) => {
+      (res as any)[key] = {
+        type: 'number',
+        enum: [1, -1]
+      }
+
+      return res
+    }, {} as { [K in keyof T]: { readonly type: 'number', readonly enum: [1, -1] } })
+  },
+  $select: {
+    type: 'array',
+    items: {
+      type: 'string',
+      enum: Object.keys(definition) as any as (keyof T)[]
+    }
+  },
+  ...queryProperties(definition)
+} as const)

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -12,6 +12,7 @@ export type JSONSchemaDefinition = JSONSchema & {
   $id: string,
   $async?: boolean,
   properties?: { [key: string]: JSONSchema }
+  required?: readonly string[]
 };
 
 export interface Schema<T> {
@@ -32,7 +33,11 @@ export class SchemaWrapper<S extends JSONSchemaDefinition> implements Schema<Fro
   }
 
   get properties () {
-    return this.definition.properties as S['properties']
+    return this.definition.properties as S['properties'];
+  }
+
+  get required () {
+    return this.definition.required as S['required'];
   }
 
   async validate <T = FromSchema<S>> (...args: Parameters<ValidateFunction<T>>) {

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -8,7 +8,11 @@ export const DEFAULT_AJV = new Ajv({
 
 export { Ajv };
 
-export type JSONSchemaDefinition = JSONSchema & { $id: string, $async?: boolean };
+export type JSONSchemaDefinition = JSONSchema & {
+  $id: string,
+  $async?: boolean,
+  properties?: { [key: string]: JSONSchema }
+};
 
 export interface Schema<T> {
   validate <X = T> (...args: Parameters<ValidateFunction<X>>): Promise<X>;
@@ -25,6 +29,10 @@ export class SchemaWrapper<S extends JSONSchemaDefinition> implements Schema<Fro
       $async: true,
       ...(this.definition as any)
     }) as AsyncValidateFunction;
+  }
+
+  get properties () {
+    return this.definition.properties as S['properties']
   }
 
   async validate <T = FromSchema<S>> (...args: Parameters<ValidateFunction<T>>) {

--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -5,8 +5,8 @@ import { memory, MemoryService } from '@feathersjs/memory';
 import { GeneralError } from '@feathersjs/errors';
 
 import {
-  schema, resolve, Infer, resolveResult,
-  queryProperty, resolveQuery, resolveData, validateData, validateQuery
+  schema, resolve, Infer, resolveResult, resolveQuery,
+  resolveData, validateData, validateQuery, querySyntax
 } from '../src';
 import { AdapterParams } from '../../memory/node_modules/@feathersjs/adapter-commons/lib';
 
@@ -27,7 +27,7 @@ export const userResultSchema = schema({
   additionalProperties: false,
   required: ['id', ...userSchema.definition.required],
   properties: {
-    ...userSchema.definition.properties,
+    ...userSchema.properties,
     id: { type: 'number' }
   }
 } as const);
@@ -79,7 +79,7 @@ export const messageResultSchema = schema({
   additionalProperties: false,
   required: ['id', 'user', ...messageSchema.definition.required],
   properties: {
-    ...messageSchema.definition.properties,
+    ...messageSchema.properties,
     id: { type: 'number' },
     user: { $ref: 'UserResult' }
   }
@@ -109,22 +109,13 @@ export const messageQuerySchema = schema({
   $id: 'MessageQuery',
   type: 'object',
   additionalProperties: false,
+  required: [],
   properties: {
-    $limit: {
-      type: 'number',
-      minimum: 0,
-      maximum: 100
-    },
-    $skip: {
-      type: 'number'
-    },
+    ...querySyntax(messageSchema.properties),
     $resolve: {
       type: 'array',
       items: { type: 'string' }
-    },
-    userId: queryProperty({
-      type: 'number'
-    })
+    }
   }
 } as const);
 
@@ -157,11 +148,12 @@ type ServiceTypes = {
 type Application = FeathersApplication<ServiceTypes>;
 
 const app = feathers<ServiceTypes>()
-  .use('users', memory({
-    multi: ['create']
-  }))
-  .use('messages', memory())
-  .use('paginatedMessages', memory({paginate: { default: 10 }}));
+
+app.use('users', memory({
+  multi: ['create']
+}))
+app.use('messages', memory())
+app.use('paginatedMessages', memory({paginate: { default: 10 }}));
 
 app.service('messages').hooks([
   validateQuery(messageQuerySchema),

--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -25,7 +25,7 @@ export const userResultSchema = schema({
   $id: 'UserResult',
   type: 'object',
   additionalProperties: false,
-  required: ['id', ...userSchema.definition.required],
+  required: ['id', ...userSchema.required],
   properties: {
     ...userSchema.properties,
     id: { type: 'number' }
@@ -77,7 +77,7 @@ export const messageResultSchema = schema({
   $id: 'MessageResult',
   type: 'object',
   additionalProperties: false,
-  required: ['id', 'user', ...messageSchema.definition.required],
+  required: ['id', 'user', ...messageSchema.required],
   properties: {
     ...messageSchema.properties,
     id: { type: 'number' },


### PR DESCRIPTION
This pull request adds a `querySyntax` helper to `@feathersjs/schema` that automatically creates schema and types for the [Feathers query syntax](https://dove.docs.feathersjs.com/api/databases/querying.html) based on the properties of another schema. This includes types for allowed entries for `$select: [ 'property' ]` and `$sort: { property: 1|-1 }`

```ts
import { querySyntax } from '@feathersjs/schema';

export const userQuerySchema = schema({
  $id: 'UserQuery',
  type: 'object',
  additionalProperties: false,
  properties: {
    ...querySyntax(userSchema.properties)
  }
} as const);

export type UserQuery = Infer<typeof userQuerySchema>

const userQuery: UserQuery = {
  $limit: 10,
  $select: [ 'email', 'id' ],
  $sort: {
    email: 1
  }
}
```