### PR TITLE
fix(configuration): Only validate the initial configuration against the schema

### DIFF
--- a/packages/configuration/src/index.ts
+++ b/packages/configuration/src/index.ts
@@ -11,21 +11,24 @@ export = function init (schema?: Schema<any>) {
       return config;
     }
 
+
+    const configuration: { [key: string]: unknown } = { ...config };
+
     debug(`Initializing configuration for ${config.util.getEnv('NODE_ENV')} environment`);
 
-    Object.keys(config).forEach(name => {
-      const value = (config as any)[name];
+    Object.keys(configuration).forEach(name => {
+      const value = configuration[name];
       debug(`Setting ${name} configuration value to`, value);
       app.set(name, value);
     });
 
     if (schema) {
       app.hooks({
-        setup: [async (context: ApplicationHookContext, next: NextFunction) => {
-          await schema.validate(context.app.settings);
+        setup: [async (_context: ApplicationHookContext, next: NextFunction) => {
+          await schema.validate(configuration);
           await next();
         }]
-      })
+      });
     }
 
     return config;


### PR DESCRIPTION
This is still not ideal but at least ensures that the schema only runs against the initial configuration provided by `node-config` and not anything set via `app.set` before `setup` is called.