### PR TITLE
fix(dependencies): Lock monorepo package version numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1818,9 +1818,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.11",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-			"integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
+			"version": "1.4.12",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz",
+			"integrity": "sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.9",
@@ -3266,9 +3266,9 @@
 			"integrity": "sha512-iO2Q6xQOJ5DtOB6wJ2KIetFq9JRTbpzcKTe2aS6CCsa+W9KNWX2yXx9KeB5sY/nBfAWN43LkPg6SFB+ldsW9ZA=="
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
-			"integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
+			"integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -3510,14 +3510,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
-			"integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz",
+			"integrity": "sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.21.0",
-				"@typescript-eslint/type-utils": "5.21.0",
-				"@typescript-eslint/utils": "5.21.0",
+				"@typescript-eslint/scope-manager": "5.22.0",
+				"@typescript-eslint/type-utils": "5.22.0",
+				"@typescript-eslint/utils": "5.22.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -3543,14 +3543,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
-			"integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
+			"integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.21.0",
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/typescript-estree": "5.21.0",
+				"@typescript-eslint/scope-manager": "5.22.0",
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/typescript-estree": "5.22.0",
 				"debug": "^4.3.2"
 			},
 			"engines": {
@@ -3570,13 +3570,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
-			"integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz",
+			"integrity": "sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/visitor-keys": "5.21.0"
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/visitor-keys": "5.22.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3587,12 +3587,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
-			"integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz",
+			"integrity": "sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.21.0",
+				"@typescript-eslint/utils": "5.22.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			},
@@ -3613,9 +3613,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
-			"integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.22.0.tgz",
+			"integrity": "sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3626,13 +3626,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
-			"integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz",
+			"integrity": "sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/visitor-keys": "5.21.0",
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/visitor-keys": "5.22.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -3653,15 +3653,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
-			"integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.22.0.tgz",
+			"integrity": "sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.21.0",
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/typescript-estree": "5.21.0",
+				"@typescript-eslint/scope-manager": "5.22.0",
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/typescript-estree": "5.22.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -3677,12 +3677,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
-			"integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz",
+			"integrity": "sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/types": "5.22.0",
 				"eslint-visitor-keys": "^3.0.0"
 			},
 			"engines": {
@@ -4213,14 +4213,14 @@
 			"dev": true
 		},
 		"node_modules/array-includes": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-			"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+			"integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5",
 				"get-intrinsic": "^1.1.1",
 				"is-string": "^1.0.7"
 			},
@@ -6098,9 +6098,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001334",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
-			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
+			"version": "1.0.30001335",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
+			"integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6790,9 +6790,9 @@
 			"hasInstallScript": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
-			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz",
+			"integrity": "sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==",
 			"dependencies": {
 				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
@@ -7247,9 +7247,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.129",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
-			"integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ=="
+			"version": "1.4.132",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz",
+			"integrity": "sha512-JYdZUw/1068NWN+SwXQ7w6Ue0bWYGihvSUNNQwurvcDV/SM7vSiGZ3NuFvFgoEiCs4kB8xs3cX2an3wB7d4TBw=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -7337,9 +7337,9 @@
 			}
 		},
 		"node_modules/engine.io-client": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.1.tgz",
-			"integrity": "sha512-5cu7xubVxEwoB6O9hJ6Zfu990yBVjXfyMlE1ZvfO5L8if3Kvc9bgDNEapV0C5pMp+5Om1UZFnljxoOuFm6dBKA==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
+			"integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1",
@@ -8617,9 +8617,9 @@
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.14.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+			"integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
 			"funding": [
 				{
 					"type": "individual",
@@ -13865,9 +13865,9 @@
 			}
 		},
 		"node_modules/npm-check-updates/node_modules/pacote": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-13.1.1.tgz",
-			"integrity": "sha512-MTT3k1OhUo+IpvoHGp25OwsRU0L+kJQM236OCywxvY4OIJ/YfloNW2/Yc3HMASH10BkfZaGMVK/pxybB7fWcLw==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-13.2.0.tgz",
+			"integrity": "sha512-IT4/xHT8eLi4cJdKSGCuqooWp2YwRP5OgrQypbBlLG8Ubzw+h7s57QbrA2SegQcdGefD81ZvuI+aL0JlfFcPCA==",
 			"dev": true,
 			"dependencies": {
 				"@npmcli/git": "^3.0.0",
@@ -16791,26 +16791,28 @@
 			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -19725,9 +19727,9 @@
 			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg=="
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.11",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-			"integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
+			"version": "1.4.12",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz",
+			"integrity": "sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA=="
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.9",
@@ -20945,9 +20947,9 @@
 			"integrity": "sha512-iO2Q6xQOJ5DtOB6wJ2KIetFq9JRTbpzcKTe2aS6CCsa+W9KNWX2yXx9KeB5sY/nBfAWN43LkPg6SFB+ldsW9ZA=="
 		},
 		"@types/eslint": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
-			"integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
+			"integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -21188,14 +21190,14 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
-			"integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz",
+			"integrity": "sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.21.0",
-				"@typescript-eslint/type-utils": "5.21.0",
-				"@typescript-eslint/utils": "5.21.0",
+				"@typescript-eslint/scope-manager": "5.22.0",
+				"@typescript-eslint/type-utils": "5.22.0",
+				"@typescript-eslint/utils": "5.22.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -21205,52 +21207,52 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
-			"integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
+			"integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.21.0",
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/typescript-estree": "5.21.0",
+				"@typescript-eslint/scope-manager": "5.22.0",
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/typescript-estree": "5.22.0",
 				"debug": "^4.3.2"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
-			"integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz",
+			"integrity": "sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/visitor-keys": "5.21.0"
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/visitor-keys": "5.22.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
-			"integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz",
+			"integrity": "sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.21.0",
+				"@typescript-eslint/utils": "5.22.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
-			"integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.22.0.tgz",
+			"integrity": "sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
-			"integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz",
+			"integrity": "sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/visitor-keys": "5.21.0",
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/visitor-keys": "5.22.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -21259,26 +21261,26 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
-			"integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.22.0.tgz",
+			"integrity": "sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.21.0",
-				"@typescript-eslint/types": "5.21.0",
-				"@typescript-eslint/typescript-estree": "5.21.0",
+				"@typescript-eslint/scope-manager": "5.22.0",
+				"@typescript-eslint/types": "5.22.0",
+				"@typescript-eslint/typescript-estree": "5.22.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
-			"integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz",
+			"integrity": "sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/types": "5.22.0",
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},
@@ -21716,14 +21718,14 @@
 			"dev": true
 		},
 		"array-includes": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-			"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+			"integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5",
 				"get-intrinsic": "^1.1.1",
 				"is-string": "^1.0.7"
 			}
@@ -23325,9 +23327,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001334",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
-			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw=="
+			"version": "1.0.30001335",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
+			"integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -23866,9 +23868,9 @@
 			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
 		},
 		"core-js-compat": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
-			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz",
+			"integrity": "sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==",
 			"requires": {
 				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
@@ -24227,9 +24229,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.4.129",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
-			"integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ=="
+			"version": "1.4.132",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz",
+			"integrity": "sha512-JYdZUw/1068NWN+SwXQ7w6Ue0bWYGihvSUNNQwurvcDV/SM7vSiGZ3NuFvFgoEiCs4kB8xs3cX2an3wB7d4TBw=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -24320,9 +24322,9 @@
 			}
 		},
 		"engine.io-client": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.1.tgz",
-			"integrity": "sha512-5cu7xubVxEwoB6O9hJ6Zfu990yBVjXfyMlE1ZvfO5L8if3Kvc9bgDNEapV0C5pMp+5Om1UZFnljxoOuFm6dBKA==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
+			"integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
 			"requires": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1",
@@ -25324,9 +25326,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.14.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+			"integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -29456,9 +29458,9 @@
 					}
 				},
 				"pacote": {
-					"version": "13.1.1",
-					"resolved": "https://registry.npmjs.org/pacote/-/pacote-13.1.1.tgz",
-					"integrity": "sha512-MTT3k1OhUo+IpvoHGp25OwsRU0L+kJQM236OCywxvY4OIJ/YfloNW2/Yc3HMASH10BkfZaGMVK/pxybB7fWcLw==",
+					"version": "13.2.0",
+					"resolved": "https://registry.npmjs.org/pacote/-/pacote-13.2.0.tgz",
+					"integrity": "sha512-IT4/xHT8eLi4cJdKSGCuqooWp2YwRP5OgrQypbBlLG8Ubzw+h7s57QbrA2SegQcdGefD81ZvuI+aL0JlfFcPCA==",
 					"dev": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
@@ -31737,23 +31739,25 @@
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			}
 		},
 		"strip-ansi": {

--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -49,9 +49,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19"
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/packages/authentication-client/package.json
+++ b/packages/authentication-client/package.json
@@ -52,18 +52,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/authentication": "^5.0.0-pre.19",
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19"
+    "@feathersjs/authentication": "5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19"
   },
   "devDependencies": {
-    "@feathersjs/authentication-local": "^5.0.0-pre.19",
-    "@feathersjs/express": "^5.0.0-pre.19",
-    "@feathersjs/memory": "^5.0.0-pre.19",
-    "@feathersjs/rest-client": "^5.0.0-pre.19",
-    "@feathersjs/socketio": "^5.0.0-pre.19",
-    "@feathersjs/socketio-client": "^5.0.0-pre.19",
+    "@feathersjs/authentication-local": "5.0.0-pre.19",
+    "@feathersjs/express": "5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
+    "@feathersjs/rest-client": "5.0.0-pre.19",
+    "@feathersjs/socketio": "5.0.0-pre.19",
+    "@feathersjs/socketio-client": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "axios": "^0.27.2",

--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -52,15 +52,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/authentication": "^5.0.0-pre.19",
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
+    "@feathersjs/authentication": "5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
     "bcryptjs": "^2.4.3",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@feathersjs/memory": "^5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
     "@types/bcryptjs": "^2.4.2",
     "@types/lodash": "^4.14.182",
     "@types/mocha": "^9.1.1",

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -53,17 +53,17 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/authentication": "^5.0.0-pre.19",
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/express": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
+    "@feathersjs/authentication": "5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/express": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
     "express-session": "^1.17.2",
     "grant": "^5.4.21",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@feathersjs/memory": "^5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
     "@types/express": "^4.17.13",
     "@types/express-session": "^1.17.4",
     "@types/lodash": "^4.14.182",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -52,10 +52,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/transport-commons": "^5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/transport-commons": "5.0.0-pre.19",
     "@types/jsonwebtoken": "^8.5.8",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
@@ -63,8 +63,8 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@feathersjs/memory": "^5.0.0-pre.19",
-    "@feathersjs/schema": "^5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
+    "@feathersjs/schema": "5.0.0-pre.19",
     "@types/lodash": "^4.14.182",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -49,19 +49,19 @@
     "IE 11"
   ],
   "dependencies": {
-    "@feathersjs/authentication-client": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/rest-client": "^5.0.0-pre.19",
-    "@feathersjs/socketio-client": "^5.0.0-pre.19"
+    "@feathersjs/authentication-client": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/rest-client": "5.0.0-pre.19",
+    "@feathersjs/socketio-client": "5.0.0-pre.19"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
     "@babel/preset-env": "^7.17.10",
-    "@feathersjs/express": "^5.0.0-pre.19",
-    "@feathersjs/memory": "^5.0.0-pre.19",
-    "@feathersjs/socketio": "^5.0.0-pre.19",
-    "@feathersjs/tests": "^5.0.0-pre.19",
+    "@feathersjs/express": "5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
+    "@feathersjs/socketio": "5.0.0-pre.19",
+    "@feathersjs/tests": "5.0.0-pre.19",
     "babel-loader": "^8.2.5",
     "mocha": "^10.0.0",
     "mocha-puppeteer": "^0.14.0",

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -57,9 +57,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/schema": "^5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/schema": "5.0.0-pre.19",
     "@types/config": "^0.0.41",
     "config": "^3.3.7"
   },

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -48,7 +48,7 @@
     "*.js"
   ],
   "devDependencies": {
-    "@feathersjs/feathers": "^5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "mocha": "^10.0.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -51,18 +51,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/authentication": "^5.0.0-pre.19",
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/transport-commons": "^5.0.0-pre.19",
+    "@feathersjs/authentication": "5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/transport-commons": "5.0.0-pre.19",
     "@types/express": "^4.17.13",
     "@types/express-serve-static-core": "^4.17.28",
     "express": "^4.18.1"
   },
   "devDependencies": {
-    "@feathersjs/authentication-local": "^5.0.0-pre.19",
-    "@feathersjs/tests": "^5.0.0-pre.19",
+    "@feathersjs/authentication-local": "5.0.0-pre.19",
+    "@feathersjs/tests": "5.0.0-pre.19",
     "@types/lodash": "^4.14.182",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -57,7 +57,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
     "@feathersjs/hooks": "^0.7.4",
     "events": "^3.3.0"
   },

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -48,10 +48,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/authentication": "^5.0.0-pre.19",
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/transport-commons": "^5.0.0-pre.19",
+    "@feathersjs/authentication": "5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/transport-commons": "5.0.0-pre.19",
     "@types/koa": "^2.13.4",
     "@types/koa-bodyparser": "^4.3.7",
     "@types/koa-qs": "^2.0.0",
@@ -61,10 +61,10 @@
     "koa-qs": "^3.0.0"
   },
   "devDependencies": {
-    "@feathersjs/authentication-local": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/memory": "^5.0.0-pre.19",
-    "@feathersjs/tests": "^5.0.0-pre.19",
+    "@feathersjs/authentication-local": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
+    "@feathersjs/tests": "5.0.0-pre.19",
     "@types/koa-compose": "^3.2.5",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -47,14 +47,14 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@feathersjs/adapter-commons": "^5.0.0-pre.19",
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
+    "@feathersjs/adapter-commons": "5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
     "sift": "^16.0.0"
   },
   "devDependencies": {
-    "@feathersjs/adapter-tests": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
+    "@feathersjs/adapter-tests": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "mocha": "^10.0.0",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -50,16 +50,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/adapter-commons": "^5.0.0-pre.19",
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19"
+    "@feathersjs/adapter-commons": "5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19"
   },
   "peerDependencies": {
     "mongodb": "^4.5.0"
   },
   "devDependencies": {
-    "@feathersjs/adapter-tests": "^5.0.0-pre.19",
+    "@feathersjs/adapter-tests": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "mocha": "^10.0.0",

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -52,17 +52,17 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
     "@types/node-fetch": "^3.0.2",
     "@types/superagent": "^4.1.15",
     "qs": "^6.10.3"
   },
   "devDependencies": {
-    "@feathersjs/express": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/memory": "^5.0.0-pre.19",
-    "@feathersjs/tests": "^5.0.0-pre.19",
+    "@feathersjs/express": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
+    "@feathersjs/tests": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "@types/qs": "^6.9.7",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -53,15 +53,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
     "@types/json-schema": "^7.0.11",
     "ajv": "^8.11.0",
     "json-schema": "^0.4.0",
     "json-schema-to-ts": "^2.3.0"
   },
   "devDependencies": {
-    "@feathersjs/memory": "^5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "ajv-formats": "^2.1.1",

--- a/packages/socketio-client/package.json
+++ b/packages/socketio-client/package.json
@@ -53,14 +53,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/transport-commons": "^5.0.0-pre.19"
+    "@feathersjs/transport-commons": "5.0.0-pre.19"
   },
   "devDependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/memory": "^5.0.0-pre.19",
-    "@feathersjs/socketio": "^5.0.0-pre.19",
-    "@feathersjs/tests": "^5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
+    "@feathersjs/socketio": "5.0.0-pre.19",
+    "@feathersjs/tests": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "mocha": "^10.0.0",

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -52,15 +52,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
-    "@feathersjs/transport-commons": "^5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
+    "@feathersjs/transport-commons": "5.0.0-pre.19",
     "socket.io": "^4.5.0"
   },
   "devDependencies": {
-    "@feathersjs/express": "^5.0.0-pre.19",
-    "@feathersjs/memory": "^5.0.0-pre.19",
-    "@feathersjs/tests": "^5.0.0-pre.19",
+    "@feathersjs/express": "5.0.0-pre.19",
+    "@feathersjs/memory": "5.0.0-pre.19",
+    "@feathersjs/tests": "5.0.0-pre.19",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",
     "lodash": "^4.17.21",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -48,7 +48,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@feathersjs/feathers": "^5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
     "@types/axios": "^0.14.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.31",

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -53,9 +53,9 @@
     "*.js"
   ],
   "dependencies": {
-    "@feathersjs/commons": "^5.0.0-pre.19",
-    "@feathersjs/errors": "^5.0.0-pre.19",
-    "@feathersjs/feathers": "^5.0.0-pre.19",
+    "@feathersjs/commons": "5.0.0-pre.19",
+    "@feathersjs/errors": "5.0.0-pre.19",
+    "@feathersjs/feathers": "5.0.0-pre.19",
     "encodeurl": "^1.0.2",
     "lodash": "^4.17.21"
   },


### PR DESCRIPTION
Also previously reported by @idaho - since there are still potentially breaking changes in the prereleases we should lock the actual version number.

Closes https://github.com/feathersjs/feathers/issues/2618