### PR TITLE
Fix authentication-oauth regression using incorrect callback and redirect_uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1810,9 +1810,9 @@
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
-			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3230,9 +3230,9 @@
 			}
 		},
 		"node_modules/@types/content-disposition": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.4.tgz",
-			"integrity": "sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ=="
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
+			"integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
 		},
 		"node_modules/@types/cookie": {
 			"version": "0.4.1",
@@ -3433,9 +3433,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.31",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
+			"version": "17.0.32",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
+			"integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw=="
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "3.0.2",
@@ -6098,9 +6098,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001335",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-			"integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+			"version": "1.0.30001339",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
+			"integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6790,9 +6790,9 @@
 			"hasInstallScript": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.22.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz",
-			"integrity": "sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==",
+			"version": "3.22.5",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.5.tgz",
+			"integrity": "sha512-rEF75n3QtInrYICvJjrAgV03HwKiYvtKHdPtaba1KucG+cNZ4NJnH9isqt979e67KZlhpbCOTwnsvnIr+CVeOg==",
 			"dependencies": {
 				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
@@ -7247,9 +7247,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.132",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz",
-			"integrity": "sha512-JYdZUw/1068NWN+SwXQ7w6Ue0bWYGihvSUNNQwurvcDV/SM7vSiGZ3NuFvFgoEiCs4kB8xs3cX2an3wB7d4TBw=="
+			"version": "1.4.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+			"integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -10615,13 +10615,13 @@
 		"node_modules/json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"node_modules/json-parse-helpfulerror": {
 			"version": "1.0.3",
@@ -10638,9 +10638,9 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"node_modules/json-schema-to-ts": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.3.0.tgz",
-			"integrity": "sha512-qBE94lvOfcVmedIgHkKNhDxTG1gPZW8pPIUpRtbPee54jGF2RZnyEOpDdowCU219sXCJ8SDVEMUCG4oMFw7pgA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.4.0.tgz",
+			"integrity": "sha512-q1AHdOUDAvs+vp+E4UlENJWXyRFBuMSQyg61/nVFYWBInTBxQZOqsyR4QZiBs0qiOpO9fXlMrSgcExJRkcBkNw==",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ts-algebra": "^1.1.1",
@@ -17914,9 +17914,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.72.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
-			"integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
+			"version": "5.72.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.1.tgz",
+			"integrity": "sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
 				"@types/estree": "^0.0.51",
@@ -17927,13 +17927,13 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.9.2",
+				"enhanced-resolve": "^5.9.3",
 				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.9",
-				"json-parse-better-errors": "^1.0.2",
+				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
@@ -19722,9 +19722,9 @@
 			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw=="
 		},
 		"@jridgewell/set-array": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
-			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.12",
@@ -20911,9 +20911,9 @@
 			}
 		},
 		"@types/content-disposition": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.4.tgz",
-			"integrity": "sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ=="
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
+			"integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
 		},
 		"@types/cookie": {
 			"version": "0.4.1",
@@ -21113,9 +21113,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "17.0.31",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
+			"version": "17.0.32",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
+			"integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw=="
 		},
 		"@types/node-fetch": {
 			"version": "3.0.2",
@@ -23327,9 +23327,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001335",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-			"integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w=="
+			"version": "1.0.30001339",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
+			"integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -23868,9 +23868,9 @@
 			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
 		},
 		"core-js-compat": {
-			"version": "3.22.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz",
-			"integrity": "sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==",
+			"version": "3.22.5",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.5.tgz",
+			"integrity": "sha512-rEF75n3QtInrYICvJjrAgV03HwKiYvtKHdPtaba1KucG+cNZ4NJnH9isqt979e67KZlhpbCOTwnsvnIr+CVeOg==",
 			"requires": {
 				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
@@ -24229,9 +24229,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.4.132",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz",
-			"integrity": "sha512-JYdZUw/1068NWN+SwXQ7w6Ue0bWYGihvSUNNQwurvcDV/SM7vSiGZ3NuFvFgoEiCs4kB8xs3cX2an3wB7d4TBw=="
+			"version": "1.4.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+			"integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -26812,13 +26812,13 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"json-parse-helpfulerror": {
 			"version": "1.0.3",
@@ -26835,9 +26835,9 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-to-ts": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.3.0.tgz",
-			"integrity": "sha512-qBE94lvOfcVmedIgHkKNhDxTG1gPZW8pPIUpRtbPee54jGF2RZnyEOpDdowCU219sXCJ8SDVEMUCG4oMFw7pgA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.4.0.tgz",
+			"integrity": "sha512-q1AHdOUDAvs+vp+E4UlENJWXyRFBuMSQyg61/nVFYWBInTBxQZOqsyR4QZiBs0qiOpO9fXlMrSgcExJRkcBkNw==",
 			"requires": {
 				"@types/json-schema": "^7.0.9",
 				"ts-algebra": "^1.1.1",
@@ -32589,9 +32589,9 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.72.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
-			"integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
+			"version": "5.72.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.1.tgz",
+			"integrity": "sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==",
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
 				"@types/estree": "^0.0.51",
@@ -32602,13 +32602,13 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.9.2",
+				"enhanced-resolve": "^5.9.3",
 				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.9",
-				"json-parse-better-errors": "^1.0.2",
+				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1810,9 +1810,9 @@
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3230,9 +3230,9 @@
 			}
 		},
 		"node_modules/@types/content-disposition": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
-			"integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ=="
 		},
 		"node_modules/@types/cookie": {
 			"version": "0.4.1",
@@ -3433,9 +3433,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
-			"integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw=="
+			"version": "17.0.31",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "3.0.2",
@@ -6098,9 +6098,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001339",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
-			"integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
+			"version": "1.0.30001335",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
+			"integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6790,9 +6790,9 @@
 			"hasInstallScript": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.22.5",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.5.tgz",
-			"integrity": "sha512-rEF75n3QtInrYICvJjrAgV03HwKiYvtKHdPtaba1KucG+cNZ4NJnH9isqt979e67KZlhpbCOTwnsvnIr+CVeOg==",
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz",
+			"integrity": "sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==",
 			"dependencies": {
 				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
@@ -7247,9 +7247,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.137",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-			"integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
+			"version": "1.4.132",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz",
+			"integrity": "sha512-JYdZUw/1068NWN+SwXQ7w6Ue0bWYGihvSUNNQwurvcDV/SM7vSiGZ3NuFvFgoEiCs4kB8xs3cX2an3wB7d4TBw=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -10615,13 +10615,13 @@
 		"node_modules/json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
 		},
 		"node_modules/json-parse-helpfulerror": {
 			"version": "1.0.3",
@@ -10638,9 +10638,9 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"node_modules/json-schema-to-ts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.4.0.tgz",
-			"integrity": "sha512-q1AHdOUDAvs+vp+E4UlENJWXyRFBuMSQyg61/nVFYWBInTBxQZOqsyR4QZiBs0qiOpO9fXlMrSgcExJRkcBkNw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.3.0.tgz",
+			"integrity": "sha512-qBE94lvOfcVmedIgHkKNhDxTG1gPZW8pPIUpRtbPee54jGF2RZnyEOpDdowCU219sXCJ8SDVEMUCG4oMFw7pgA==",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ts-algebra": "^1.1.1",
@@ -17914,9 +17914,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.72.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.1.tgz",
-			"integrity": "sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==",
+			"version": "5.72.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+			"integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
 				"@types/estree": "^0.0.51",
@@ -17927,13 +17927,13 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.9.3",
+				"enhanced-resolve": "^5.9.2",
 				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.9",
-				"json-parse-even-better-errors": "^2.3.1",
+				"json-parse-better-errors": "^1.0.2",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
@@ -19722,9 +19722,9 @@
 			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw=="
 		},
 		"@jridgewell/set-array": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg=="
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.12",
@@ -20911,9 +20911,9 @@
 			}
 		},
 		"@types/content-disposition": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
-			"integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ=="
 		},
 		"@types/cookie": {
 			"version": "0.4.1",
@@ -21113,9 +21113,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.32.tgz",
-			"integrity": "sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw=="
+			"version": "17.0.31",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
 		},
 		"@types/node-fetch": {
 			"version": "3.0.2",
@@ -23327,9 +23327,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001339",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
-			"integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ=="
+			"version": "1.0.30001335",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
+			"integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -23868,9 +23868,9 @@
 			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
 		},
 		"core-js-compat": {
-			"version": "3.22.5",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.5.tgz",
-			"integrity": "sha512-rEF75n3QtInrYICvJjrAgV03HwKiYvtKHdPtaba1KucG+cNZ4NJnH9isqt979e67KZlhpbCOTwnsvnIr+CVeOg==",
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz",
+			"integrity": "sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==",
 			"requires": {
 				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
@@ -24229,9 +24229,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.4.137",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-			"integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
+			"version": "1.4.132",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz",
+			"integrity": "sha512-JYdZUw/1068NWN+SwXQ7w6Ue0bWYGihvSUNNQwurvcDV/SM7vSiGZ3NuFvFgoEiCs4kB8xs3cX2an3wB7d4TBw=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -26812,13 +26812,13 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
 		},
 		"json-parse-helpfulerror": {
 			"version": "1.0.3",
@@ -26835,9 +26835,9 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-to-ts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.4.0.tgz",
-			"integrity": "sha512-q1AHdOUDAvs+vp+E4UlENJWXyRFBuMSQyg61/nVFYWBInTBxQZOqsyR4QZiBs0qiOpO9fXlMrSgcExJRkcBkNw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.3.0.tgz",
+			"integrity": "sha512-qBE94lvOfcVmedIgHkKNhDxTG1gPZW8pPIUpRtbPee54jGF2RZnyEOpDdowCU219sXCJ8SDVEMUCG4oMFw7pgA==",
 			"requires": {
 				"@types/json-schema": "^7.0.9",
 				"ts-algebra": "^1.1.1",
@@ -32589,9 +32589,9 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.72.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.1.tgz",
-			"integrity": "sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==",
+			"version": "5.72.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+			"integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
 				"@types/estree": "^0.0.51",
@@ -32602,13 +32602,13 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.9.3",
+				"enhanced-resolve": "^5.9.2",
 				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.9",
-				"json-parse-even-better-errors": "^2.3.1",
+				"json-parse-better-errors": "^1.0.2",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -45,7 +45,7 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
     defaults: {
       prefix,
       origin: `${oauth?.defaults?.protocol ?? protocol}://${oauth?.defaults?.host ?? host}`,
-      transport: 'session',
+      transport:  oauth?.defaults?.transport ?? 'session',
       response: ['tokens', 'raw', 'profile']
     }
   }, omit(oauth, ['redirect', 'origins']));

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -41,14 +41,14 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
     }
   }
 
-  const grant = defaultsDeep({}, omit(oauth, ['redirect', 'origins']), {
+  const grant = defaultsDeep({
     defaults: {
       prefix,
-      origin: `${protocol}://${host}`,
+      origin: `${oauth?.defaults?.protocol ?? protocol}://${oauth?.defaults?.host ?? host}`,
       transport: 'session',
       response: ['tokens', 'raw', 'profile']
     }
-  });
+  }, omit(oauth, ['redirect', 'origins']));
 
   const getUrl = (url: string) => {
     const { defaults } = grant;

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -44,8 +44,8 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   const grant = defaultsDeep({
     defaults: {
       prefix,
-      origin: `${oauth?.defaults?.protocol ?? protocol}://${oauth?.defaults?.host ?? host}`,
-      transport:  oauth?.defaults?.transport ?? 'session',
+      origin: `${protocol}://${host}`,
+      transport: 'session',
       response: ['tokens', 'raw', 'profile']
     }
   }, omit(oauth, ['redirect', 'origins']));

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -44,8 +44,8 @@ export const setup = (options: OauthSetupSettings) => (app: Application) => {
   const grant = defaultsDeep({
     defaults: {
       prefix,
-      origin: `${protocol}://${host}`,
-      transport: 'session',
+      origin: `${oauth?.defaults?.protocol ?? protocol}://${oauth?.defaults?.host ?? host}`,
+      transport:  oauth?.defaults?.transport ?? 'session',
       response: ['tokens', 'raw', 'profile']
     }
   }, omit(oauth, ['redirect', 'origins']));


### PR DESCRIPTION
## Fix authentication-oauth regression: authentication callback and redirect_uri were using incorrect protocol and host from configuration

### Summary

Please see https://github.com/feathersjs/feathers/issues/2630

Call to defaultsDeep parameters reordered to ensure protocol and host values from both both oauth.defaults and from local variable can be distinguished, with local values as fallback.

Previous version was coding local values instead of oauth.default values. This matters if they are not the same, such as when using reverse proxy server. The local host value is from top host value of configuration file defualt.json.
