### PR TITLE
fix(core): Do not throw missing method error for regular hook methods

### DIFF
--- a/packages/feathers/src/hooks/regular.ts
+++ b/packages/feathers/src/hooks/regular.ts
@@ -142,7 +142,7 @@ const createMap = (input: RegularHookMap<any, any>, methods: string[]) => {
     const data = convertHookData(input[type]);
 
     Object.keys(data).forEach((method) => {
-      if (method !== 'all' && !methods.includes(method)) {
+      if (method !== 'all' && !methods.includes(method) && !defaultServiceMethods.includes(method)) {
         throw new Error(`'${method}' is not a valid hook method`);
       }
     });

--- a/packages/feathers/test/hooks/before.test.ts
+++ b/packages/feathers/test/hooks/before.test.ts
@@ -38,7 +38,9 @@ describe('`before` hooks', () => {
           return new Promise((_resolve, reject) => {
             reject(new Error('This did not work'));
           });
-        }
+        },
+
+        find: []
       }
     });
 


### PR DESCRIPTION
This is a regression with the regular hook registration format (e.g. `{ before: { find: [] } }`). It should not throw an error in that case but instead just do nothing.

Closes https://github.com/feathersjs-ecosystem/feathers-mailer/issues/31