### PR TITLE
feat(schema): Add schema resolver converter functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,20 +121,20 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.12.tgz",
-			"integrity": "sha512-44ODe6O1IVz9s2oJE3rZ4trNNKTX9O7KpQpfAP4t8QII/zwrVRHL7i2pxhqtcY7tqMLrrKfMlBKnm1QlrRFs5w==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.0.tgz",
+			"integrity": "sha512-Xyw74OlJwDijToNi0+6BBI5mLLR5+5R3bcSH80LXzjzEGEUlvNzujEE71BaD/ApEZHAvFI/Mlmp4M5lIkdeeWw==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.12",
+				"@babel/generator": "^7.18.0",
 				"@babel/helper-compilation-targets": "^7.17.10",
-				"@babel/helper-module-transforms": "^7.17.12",
-				"@babel/helpers": "^7.17.9",
-				"@babel/parser": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
+				"@babel/helpers": "^7.18.0",
+				"@babel/parser": "^7.18.0",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.12",
-				"@babel/types": "^7.17.12",
+				"@babel/traverse": "^7.18.0",
+				"@babel/types": "^7.18.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -158,11 +158,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.12.tgz",
-			"integrity": "sha512-V49KtZiiiLjH/CnIW6OjJdrenrGoyh6AmKQ3k2AZFKozC1h846Q4NYlZ5nqAigPDUXfGzC88+LOUuG8yKd2kCw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.0.tgz",
+			"integrity": "sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==",
 			"dependencies": {
-				"@babel/types": "^7.17.12",
+				"@babel/types": "^7.18.0",
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"jsesc": "^2.5.1"
 			},
@@ -232,9 +232,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.12.tgz",
-			"integrity": "sha512-sZoOeUTkFJMyhqCei2+Z+wtH/BehW8NVKQt7IRUQlRiOARuXymJYfN/FCcI8CvVbR0XVyDM6eLFOlR7YtiXnew==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.0.tgz",
+			"integrity": "sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.16.7",
 				"@babel/helper-environment-visitor": "^7.16.7",
@@ -360,9 +360,9 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
-			"integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
+			"integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
@@ -370,8 +370,8 @@
 				"@babel/helper-split-export-declaration": "^7.16.7",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.12",
-				"@babel/types": "^7.17.12"
+				"@babel/traverse": "^7.18.0",
+				"@babel/types": "^7.18.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -488,13 +488,13 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
-			"integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.0.tgz",
+			"integrity": "sha512-AE+HMYhmlMIbho9nbvicHyxFwhrO+xhKB6AhRxzl8w46Yj0VXTZjEsAoBVC7rB2I0jzX+yWyVybnO08qkfx6kg==",
 			"dependencies": {
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.9",
-				"@babel/types": "^7.17.0"
+				"@babel/traverse": "^7.18.0",
+				"@babel/types": "^7.18.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -578,9 +578,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
-			"integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.0.tgz",
+			"integrity": "sha512-AqDccGC+m5O/iUStSJy3DGRIUFu7WbY/CppZYwrEUB4N0tZlnI8CSTsgL7v5fHVFmUbRv2sd+yy27o8Ydt4MGg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -650,11 +650,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-class-static-block": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.12.tgz",
-			"integrity": "sha512-8ILyDG6eL14F8iub97dVc8q35Md0PJYAnA5Kz9NACFOkt6ffCcr0FISyUPKHsvuAy36fkpIitxZ9bVYPFMGQHA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.18.0.tgz",
+			"integrity": "sha512-t+8LsRMMDE74c6sV7KShIw13sqbqd58tlqNrsWoWBTIMw7SVQ0cZ905wLNS/FBCy/3PyooRHLFFlfrUNyyz5lA==",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.17.12",
+				"@babel/helper-create-class-features-plugin": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			},
@@ -756,9 +756,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.12.tgz",
-			"integrity": "sha512-6l9cO3YXXRh4yPCPRA776ZyJ3RobG4ZKJZhp7NDRbKIOeV3dBPG8FXCF7ZtiO2RTCIOkQOph1xDDcc01iWVNjQ==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.18.0.tgz",
+			"integrity": "sha512-nbTv371eTrFabDfHLElkn9oyf9VG+VKK6WMzhY2o4eHKaG19BToD9947zzGMO6I/Irstx9d8CwX6njPNIAR/yw==",
 			"dependencies": {
 				"@babel/compat-data": "^7.17.10",
 				"@babel/helper-compilation-targets": "^7.17.10",
@@ -904,6 +904,20 @@
 			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.3"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-assertions": {
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.17.12.tgz",
+			"integrity": "sha512-n/loy2zkq9ZEM8tEOwON9wTQSTNDTDEz6NujPtJGLU7qObzT1N4c4YZZf8E6ATB2AjNQg/Ib2AIpO03EZaCehw==",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.17.12"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -1116,9 +1130,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.12.tgz",
-			"integrity": "sha512-P8pt0YiKtX5UMUL5Xzsc9Oyij+pJE6JuC+F1k0/brq/OOGs5jDa1If3OY0LRWGvJsJhI+8tsiecL3nJLc0WTlg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.0.tgz",
+			"integrity": "sha512-Mo69klS79z6KEfrLg/1WkmVnB8javh75HX4pi2btjvlIoasuxilEyjtsQW6XPrubNd7AQy0MMaNIaQE4e7+PQw==",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.17.12"
 			},
@@ -1174,9 +1188,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.17.12.tgz",
-			"integrity": "sha512-76lTwYaCxw8ldT7tNmye4LLwSoKDbRCBzu6n/DcK/P3FOR29+38CIIaVIZfwol9By8W/QHORYEnYSLuvcQKrsg==",
+			"version": "7.18.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.1.tgz",
+			"integrity": "sha512-+TTB5XwvJ5hZbO8xvl2H4XaMDOAK57zF4miuC9qQJgysPNEAZZ9Z69rdF5LJkozGdZrjBIUAIyKUWRMmebI7vg==",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.17.12"
 			},
@@ -1232,11 +1246,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.17.12.tgz",
-			"integrity": "sha512-p5rt9tB5Ndcc2Za7CeNxVf7YAjRcUMR6yi8o8tKjb9KhRkEvXwa+C0hj6DA5bVDkKRxB0NYhMUGbVKoFu4+zEA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.18.0.tgz",
+			"integrity": "sha512-h8FjOlYmdZwl7Xm2Ug4iX2j7Qy63NANI+NQVWQzv6r25fqgg7k2dZl03p95kvqNclglHs4FZ+isv4p1uXMA+QA==",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			},
@@ -1248,11 +1262,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.12.tgz",
-			"integrity": "sha512-tVPs6MImAJz+DiX8Y1xXEMdTk5Lwxu9jiPjlS+nv5M2A59R7+/d1+9A8C/sbuY0b3QjIxqClkj6KAplEtRvzaA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.0.tgz",
+			"integrity": "sha512-cCeR0VZWtfxWS4YueAK2qtHtBPJRSaJcMlbS8jhSIm/A3E2Kpro4W1Dn4cqJtp59dtWfXjQwK7SPKF8ghs7rlw==",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"@babel/helper-simple-access": "^7.17.7",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
@@ -1265,12 +1279,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.12.tgz",
-			"integrity": "sha512-NVhDb0q00hqZcuLduUf/kMzbOQHiocmPbIxIvk23HLiEqaTKC/l4eRxeC7lO63M72BmACoiKOcb9AkOAJRerpw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.18.0.tgz",
+			"integrity": "sha512-vwKpxdHnlM5tIrRt/eA0bzfbi7gUBLN08vLu38np1nZevlPySRe6yvuATJB5F/WPJ+ur4OXwpVYq9+BsxqAQuQ==",
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.16.7",
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
@@ -1283,11 +1297,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.17.12.tgz",
-			"integrity": "sha512-BnsPkrUHsjzZGpnrmJeDFkOMMljWFHPjDc9xDcz71/C+ybF3lfC3V4m3dwXPLZrE5b3bgd4V+3/Pj+3620d7IA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.18.0.tgz",
+			"integrity": "sha512-d/zZ8I3BWli1tmROLxXLc9A6YXvGK8egMxHp+E/rRwMh1Kip0AP77VwZae3snEJ33iiWwvNv2+UIIhfalqhzZA==",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12"
 			},
 			"engines": {
@@ -1370,10 +1384,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz",
-			"integrity": "sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.18.0.tgz",
+			"integrity": "sha512-C8YdRw9uzx25HSIzwA7EM7YP0FhCe5wNvJbZzjVNHHPGVcDJ3Aie+qGYYdS1oVQgn+B3eAIJbWFLrJ4Jipv7nw==",
 			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.17.12",
 				"regenerator-transform": "^0.15.0"
 			},
 			"engines": {
@@ -1498,9 +1513,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.17.12.tgz",
-			"integrity": "sha512-Kke30Rj3Lmcx97bVs71LO0s8M6FmJ7tUAQI9fNId62rf0cYG1UAWwdNO9/sE0/pLEahAw1MqMorymoD12bj5Fg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.0.tgz",
+			"integrity": "sha512-cP74OMs7ECLPeG1reiCQ/D/ypyOxgfm8uR6HRYV23vTJ7Lu1nbgj9DQDo/vH59gnn7GOAwtTDPPYV4aXzsMKHA==",
 			"dependencies": {
 				"@babel/compat-data": "^7.17.10",
 				"@babel/helper-compilation-targets": "^7.17.10",
@@ -1510,14 +1525,14 @@
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.17.12",
 				"@babel/plugin-proposal-async-generator-functions": "^7.17.12",
 				"@babel/plugin-proposal-class-properties": "^7.17.12",
-				"@babel/plugin-proposal-class-static-block": "^7.17.12",
+				"@babel/plugin-proposal-class-static-block": "^7.18.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.16.7",
 				"@babel/plugin-proposal-export-namespace-from": "^7.17.12",
 				"@babel/plugin-proposal-json-strings": "^7.17.12",
 				"@babel/plugin-proposal-logical-assignment-operators": "^7.17.12",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.17.12",
 				"@babel/plugin-proposal-numeric-separator": "^7.16.7",
-				"@babel/plugin-proposal-object-rest-spread": "^7.17.12",
+				"@babel/plugin-proposal-object-rest-spread": "^7.18.0",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
 				"@babel/plugin-proposal-optional-chaining": "^7.17.12",
 				"@babel/plugin-proposal-private-methods": "^7.17.12",
@@ -1528,6 +1543,7 @@
 				"@babel/plugin-syntax-class-static-block": "^7.14.5",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-import-assertions": "^7.17.12",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -1543,7 +1559,7 @@
 				"@babel/plugin-transform-block-scoping": "^7.17.12",
 				"@babel/plugin-transform-classes": "^7.17.12",
 				"@babel/plugin-transform-computed-properties": "^7.17.12",
-				"@babel/plugin-transform-destructuring": "^7.17.12",
+				"@babel/plugin-transform-destructuring": "^7.18.0",
 				"@babel/plugin-transform-dotall-regex": "^7.16.7",
 				"@babel/plugin-transform-duplicate-keys": "^7.17.12",
 				"@babel/plugin-transform-exponentiation-operator": "^7.16.7",
@@ -1551,16 +1567,16 @@
 				"@babel/plugin-transform-function-name": "^7.16.7",
 				"@babel/plugin-transform-literals": "^7.17.12",
 				"@babel/plugin-transform-member-expression-literals": "^7.16.7",
-				"@babel/plugin-transform-modules-amd": "^7.17.12",
-				"@babel/plugin-transform-modules-commonjs": "^7.17.12",
-				"@babel/plugin-transform-modules-systemjs": "^7.17.12",
-				"@babel/plugin-transform-modules-umd": "^7.17.12",
+				"@babel/plugin-transform-modules-amd": "^7.18.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.18.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.18.0",
+				"@babel/plugin-transform-modules-umd": "^7.18.0",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.17.12",
 				"@babel/plugin-transform-new-target": "^7.17.12",
 				"@babel/plugin-transform-object-super": "^7.16.7",
 				"@babel/plugin-transform-parameters": "^7.17.12",
 				"@babel/plugin-transform-property-literals": "^7.16.7",
-				"@babel/plugin-transform-regenerator": "^7.17.9",
+				"@babel/plugin-transform-regenerator": "^7.18.0",
 				"@babel/plugin-transform-reserved-words": "^7.17.12",
 				"@babel/plugin-transform-shorthand-properties": "^7.16.7",
 				"@babel/plugin-transform-spread": "^7.17.12",
@@ -1570,7 +1586,7 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.16.7",
 				"@babel/plugin-transform-unicode-regex": "^7.16.7",
 				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.17.12",
+				"@babel/types": "^7.18.0",
 				"babel-plugin-polyfill-corejs2": "^0.3.0",
 				"babel-plugin-polyfill-corejs3": "^0.5.0",
 				"babel-plugin-polyfill-regenerator": "^0.3.0",
@@ -1608,9 +1624,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-			"integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz",
+			"integrity": "sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -1637,18 +1653,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.12.tgz",
-			"integrity": "sha512-zULPs+TbCvOkIFd4FrG53xrpxvCBwLIgo6tO0tJorY7YV2IWFxUfS/lXDJbGgfyYt9ery/Gxj2niwttNnB0gIw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.0.tgz",
+			"integrity": "sha512-oNOO4vaoIQoGjDQ84LgtF/IAlxlyqL4TUuoQ7xLkQETFaHkY1F7yazhB4Kt3VcZGL0ZF/jhrEpnXqUb0M7V3sw==",
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.12",
+				"@babel/generator": "^7.18.0",
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-function-name": "^7.17.9",
 				"@babel/helper-hoist-variables": "^7.16.7",
 				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/parser": "^7.17.12",
-				"@babel/types": "^7.17.12",
+				"@babel/parser": "^7.18.0",
+				"@babel/types": "^7.18.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1665,9 +1681,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.12.tgz",
-			"integrity": "sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.0.tgz",
+			"integrity": "sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"to-fast-properties": "^2.0.0"
@@ -3447,9 +3463,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.34",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
-			"integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA=="
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "3.0.2",
@@ -5864,9 +5880,9 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "4.6.3",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.3.tgz",
-			"integrity": "sha512-rAqP5hcUVJhXP2MCSNVsf0oM2OGU1So6A9pVRDYayvJ5+hygXHQApf87wd5NlhPM1J9RJnbqxIG/f8QTzRoQ4A==",
+			"version": "4.6.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
+			"integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
 			"dependencies": {
 				"buffer": "^5.6.0"
 			},
@@ -10682,9 +10698,9 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"node_modules/json-schema-to-ts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.4.0.tgz",
-			"integrity": "sha512-q1AHdOUDAvs+vp+E4UlENJWXyRFBuMSQyg61/nVFYWBInTBxQZOqsyR4QZiBs0qiOpO9fXlMrSgcExJRkcBkNw==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.5.1.tgz",
+			"integrity": "sha512-0+SWFvC9aauIsFQ75vMPAVS9R6HvGP025amJx+BWYMPve3t8F8zn24ekvMHBtZEMSTbY41kwjhrFRj/6SJCApw==",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ts-algebra": "^1.1.1",
@@ -16549,9 +16565,9 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
-			"integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
+			"integrity": "sha512-0y9pnIso5a9i+lJmsCdtmTTgJFFSvNQKDnPQRz28mGNnxbmqYg2QPtJTLFxhymFZhAIn50eHAKzJeiNaKr+yUQ==",
 			"dependencies": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
@@ -16570,9 +16586,9 @@
 			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
 		},
 		"node_modules/socket.io-client": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.0.tgz",
-			"integrity": "sha512-HW61c1G7OrYGxaI79WRn17+b03iBCdvhBj4iqyXHBoL5M8w2MSO/vChsjA93knG4GYEai1/vbXWJna9dzxXtSg==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
+			"integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.2",
@@ -18637,20 +18653,20 @@
 			"integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw=="
 		},
 		"@babel/core": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.12.tgz",
-			"integrity": "sha512-44ODe6O1IVz9s2oJE3rZ4trNNKTX9O7KpQpfAP4t8QII/zwrVRHL7i2pxhqtcY7tqMLrrKfMlBKnm1QlrRFs5w==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.0.tgz",
+			"integrity": "sha512-Xyw74OlJwDijToNi0+6BBI5mLLR5+5R3bcSH80LXzjzEGEUlvNzujEE71BaD/ApEZHAvFI/Mlmp4M5lIkdeeWw==",
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.12",
+				"@babel/generator": "^7.18.0",
 				"@babel/helper-compilation-targets": "^7.17.10",
-				"@babel/helper-module-transforms": "^7.17.12",
-				"@babel/helpers": "^7.17.9",
-				"@babel/parser": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
+				"@babel/helpers": "^7.18.0",
+				"@babel/parser": "^7.18.0",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.12",
-				"@babel/types": "^7.17.12",
+				"@babel/traverse": "^7.18.0",
+				"@babel/types": "^7.18.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -18666,11 +18682,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.12.tgz",
-			"integrity": "sha512-V49KtZiiiLjH/CnIW6OjJdrenrGoyh6AmKQ3k2AZFKozC1h846Q4NYlZ5nqAigPDUXfGzC88+LOUuG8yKd2kCw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.0.tgz",
+			"integrity": "sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==",
 			"requires": {
-				"@babel/types": "^7.17.12",
+				"@babel/types": "^7.18.0",
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"jsesc": "^2.5.1"
 			},
@@ -18723,9 +18739,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.12.tgz",
-			"integrity": "sha512-sZoOeUTkFJMyhqCei2+Z+wtH/BehW8NVKQt7IRUQlRiOARuXymJYfN/FCcI8CvVbR0XVyDM6eLFOlR7YtiXnew==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.0.tgz",
+			"integrity": "sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.16.7",
 				"@babel/helper-environment-visitor": "^7.16.7",
@@ -18817,9 +18833,9 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
-			"integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
+			"integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
@@ -18827,8 +18843,8 @@
 				"@babel/helper-split-export-declaration": "^7.16.7",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.12",
-				"@babel/types": "^7.17.12"
+				"@babel/traverse": "^7.18.0",
+				"@babel/types": "^7.18.0"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -18912,13 +18928,13 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
-			"integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.0.tgz",
+			"integrity": "sha512-AE+HMYhmlMIbho9nbvicHyxFwhrO+xhKB6AhRxzl8w46Yj0VXTZjEsAoBVC7rB2I0jzX+yWyVybnO08qkfx6kg==",
 			"requires": {
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.9",
-				"@babel/types": "^7.17.0"
+				"@babel/traverse": "^7.18.0",
+				"@babel/types": "^7.18.0"
 			}
 		},
 		"@babel/highlight": {
@@ -18983,9 +18999,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
-			"integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA=="
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.0.tgz",
+			"integrity": "sha512-AqDccGC+m5O/iUStSJy3DGRIUFu7WbY/CppZYwrEUB4N0tZlnI8CSTsgL7v5fHVFmUbRv2sd+yy27o8Ydt4MGg=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.17.12",
@@ -19025,11 +19041,11 @@
 			}
 		},
 		"@babel/plugin-proposal-class-static-block": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.12.tgz",
-			"integrity": "sha512-8ILyDG6eL14F8iub97dVc8q35Md0PJYAnA5Kz9NACFOkt6ffCcr0FISyUPKHsvuAy36fkpIitxZ9bVYPFMGQHA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.18.0.tgz",
+			"integrity": "sha512-t+8LsRMMDE74c6sV7KShIw13sqbqd58tlqNrsWoWBTIMw7SVQ0cZ905wLNS/FBCy/3PyooRHLFFlfrUNyyz5lA==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.17.12",
+				"@babel/helper-create-class-features-plugin": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			}
@@ -19089,9 +19105,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.12.tgz",
-			"integrity": "sha512-6l9cO3YXXRh4yPCPRA776ZyJ3RobG4ZKJZhp7NDRbKIOeV3dBPG8FXCF7ZtiO2RTCIOkQOph1xDDcc01iWVNjQ==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.18.0.tgz",
+			"integrity": "sha512-nbTv371eTrFabDfHLElkn9oyf9VG+VKK6WMzhY2o4eHKaG19BToD9947zzGMO6I/Irstx9d8CwX6njPNIAR/yw==",
 			"requires": {
 				"@babel/compat-data": "^7.17.10",
 				"@babel/helper-compilation-targets": "^7.17.10",
@@ -19186,6 +19202,14 @@
 			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-import-assertions": {
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.17.12.tgz",
+			"integrity": "sha512-n/loy2zkq9ZEM8tEOwON9wTQSTNDTDEz6NujPtJGLU7qObzT1N4c4YZZf8E6ATB2AjNQg/Ib2AIpO03EZaCehw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.17.12"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
@@ -19325,9 +19349,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.12.tgz",
-			"integrity": "sha512-P8pt0YiKtX5UMUL5Xzsc9Oyij+pJE6JuC+F1k0/brq/OOGs5jDa1If3OY0LRWGvJsJhI+8tsiecL3nJLc0WTlg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.0.tgz",
+			"integrity": "sha512-Mo69klS79z6KEfrLg/1WkmVnB8javh75HX4pi2btjvlIoasuxilEyjtsQW6XPrubNd7AQy0MMaNIaQE4e7+PQw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.17.12"
 			}
@@ -19359,9 +19383,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.17.12.tgz",
-			"integrity": "sha512-76lTwYaCxw8ldT7tNmye4LLwSoKDbRCBzu6n/DcK/P3FOR29+38CIIaVIZfwol9By8W/QHORYEnYSLuvcQKrsg==",
+			"version": "7.18.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.1.tgz",
+			"integrity": "sha512-+TTB5XwvJ5hZbO8xvl2H4XaMDOAK57zF4miuC9qQJgysPNEAZZ9Z69rdF5LJkozGdZrjBIUAIyKUWRMmebI7vg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.17.12"
 			}
@@ -19393,44 +19417,44 @@
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.17.12.tgz",
-			"integrity": "sha512-p5rt9tB5Ndcc2Za7CeNxVf7YAjRcUMR6yi8o8tKjb9KhRkEvXwa+C0hj6DA5bVDkKRxB0NYhMUGbVKoFu4+zEA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.18.0.tgz",
+			"integrity": "sha512-h8FjOlYmdZwl7Xm2Ug4iX2j7Qy63NANI+NQVWQzv6r25fqgg7k2dZl03p95kvqNclglHs4FZ+isv4p1uXMA+QA==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.12.tgz",
-			"integrity": "sha512-tVPs6MImAJz+DiX8Y1xXEMdTk5Lwxu9jiPjlS+nv5M2A59R7+/d1+9A8C/sbuY0b3QjIxqClkj6KAplEtRvzaA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.0.tgz",
+			"integrity": "sha512-cCeR0VZWtfxWS4YueAK2qtHtBPJRSaJcMlbS8jhSIm/A3E2Kpro4W1Dn4cqJtp59dtWfXjQwK7SPKF8ghs7rlw==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"@babel/helper-simple-access": "^7.17.7",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.12.tgz",
-			"integrity": "sha512-NVhDb0q00hqZcuLduUf/kMzbOQHiocmPbIxIvk23HLiEqaTKC/l4eRxeC7lO63M72BmACoiKOcb9AkOAJRerpw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.18.0.tgz",
+			"integrity": "sha512-vwKpxdHnlM5tIrRt/eA0bzfbi7gUBLN08vLu38np1nZevlPySRe6yvuATJB5F/WPJ+ur4OXwpVYq9+BsxqAQuQ==",
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.16.7",
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.17.12.tgz",
-			"integrity": "sha512-BnsPkrUHsjzZGpnrmJeDFkOMMljWFHPjDc9xDcz71/C+ybF3lfC3V4m3dwXPLZrE5b3bgd4V+3/Pj+3620d7IA==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.18.0.tgz",
+			"integrity": "sha512-d/zZ8I3BWli1tmROLxXLc9A6YXvGK8egMxHp+E/rRwMh1Kip0AP77VwZae3snEJ33iiWwvNv2+UIIhfalqhzZA==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.17.12",
+				"@babel/helper-module-transforms": "^7.18.0",
 				"@babel/helper-plugin-utils": "^7.17.12"
 			}
 		},
@@ -19477,10 +19501,11 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz",
-			"integrity": "sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.18.0.tgz",
+			"integrity": "sha512-C8YdRw9uzx25HSIzwA7EM7YP0FhCe5wNvJbZzjVNHHPGVcDJ3Aie+qGYYdS1oVQgn+B3eAIJbWFLrJ4Jipv7nw==",
 			"requires": {
+				"@babel/helper-plugin-utils": "^7.17.12",
 				"regenerator-transform": "^0.15.0"
 			}
 		},
@@ -19551,9 +19576,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.17.12.tgz",
-			"integrity": "sha512-Kke30Rj3Lmcx97bVs71LO0s8M6FmJ7tUAQI9fNId62rf0cYG1UAWwdNO9/sE0/pLEahAw1MqMorymoD12bj5Fg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.0.tgz",
+			"integrity": "sha512-cP74OMs7ECLPeG1reiCQ/D/ypyOxgfm8uR6HRYV23vTJ7Lu1nbgj9DQDo/vH59gnn7GOAwtTDPPYV4aXzsMKHA==",
 			"requires": {
 				"@babel/compat-data": "^7.17.10",
 				"@babel/helper-compilation-targets": "^7.17.10",
@@ -19563,14 +19588,14 @@
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.17.12",
 				"@babel/plugin-proposal-async-generator-functions": "^7.17.12",
 				"@babel/plugin-proposal-class-properties": "^7.17.12",
-				"@babel/plugin-proposal-class-static-block": "^7.17.12",
+				"@babel/plugin-proposal-class-static-block": "^7.18.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.16.7",
 				"@babel/plugin-proposal-export-namespace-from": "^7.17.12",
 				"@babel/plugin-proposal-json-strings": "^7.17.12",
 				"@babel/plugin-proposal-logical-assignment-operators": "^7.17.12",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.17.12",
 				"@babel/plugin-proposal-numeric-separator": "^7.16.7",
-				"@babel/plugin-proposal-object-rest-spread": "^7.17.12",
+				"@babel/plugin-proposal-object-rest-spread": "^7.18.0",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
 				"@babel/plugin-proposal-optional-chaining": "^7.17.12",
 				"@babel/plugin-proposal-private-methods": "^7.17.12",
@@ -19581,6 +19606,7 @@
 				"@babel/plugin-syntax-class-static-block": "^7.14.5",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-import-assertions": "^7.17.12",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -19596,7 +19622,7 @@
 				"@babel/plugin-transform-block-scoping": "^7.17.12",
 				"@babel/plugin-transform-classes": "^7.17.12",
 				"@babel/plugin-transform-computed-properties": "^7.17.12",
-				"@babel/plugin-transform-destructuring": "^7.17.12",
+				"@babel/plugin-transform-destructuring": "^7.18.0",
 				"@babel/plugin-transform-dotall-regex": "^7.16.7",
 				"@babel/plugin-transform-duplicate-keys": "^7.17.12",
 				"@babel/plugin-transform-exponentiation-operator": "^7.16.7",
@@ -19604,16 +19630,16 @@
 				"@babel/plugin-transform-function-name": "^7.16.7",
 				"@babel/plugin-transform-literals": "^7.17.12",
 				"@babel/plugin-transform-member-expression-literals": "^7.16.7",
-				"@babel/plugin-transform-modules-amd": "^7.17.12",
-				"@babel/plugin-transform-modules-commonjs": "^7.17.12",
-				"@babel/plugin-transform-modules-systemjs": "^7.17.12",
-				"@babel/plugin-transform-modules-umd": "^7.17.12",
+				"@babel/plugin-transform-modules-amd": "^7.18.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.18.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.18.0",
+				"@babel/plugin-transform-modules-umd": "^7.18.0",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.17.12",
 				"@babel/plugin-transform-new-target": "^7.17.12",
 				"@babel/plugin-transform-object-super": "^7.16.7",
 				"@babel/plugin-transform-parameters": "^7.17.12",
 				"@babel/plugin-transform-property-literals": "^7.16.7",
-				"@babel/plugin-transform-regenerator": "^7.17.9",
+				"@babel/plugin-transform-regenerator": "^7.18.0",
 				"@babel/plugin-transform-reserved-words": "^7.17.12",
 				"@babel/plugin-transform-shorthand-properties": "^7.16.7",
 				"@babel/plugin-transform-spread": "^7.17.12",
@@ -19623,7 +19649,7 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.16.7",
 				"@babel/plugin-transform-unicode-regex": "^7.16.7",
 				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.17.12",
+				"@babel/types": "^7.18.0",
 				"babel-plugin-polyfill-corejs2": "^0.3.0",
 				"babel-plugin-polyfill-corejs3": "^0.5.0",
 				"babel-plugin-polyfill-regenerator": "^0.3.0",
@@ -19651,9 +19677,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-			"integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz",
+			"integrity": "sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -19676,18 +19702,18 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.12.tgz",
-			"integrity": "sha512-zULPs+TbCvOkIFd4FrG53xrpxvCBwLIgo6tO0tJorY7YV2IWFxUfS/lXDJbGgfyYt9ery/Gxj2niwttNnB0gIw==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.0.tgz",
+			"integrity": "sha512-oNOO4vaoIQoGjDQ84LgtF/IAlxlyqL4TUuoQ7xLkQETFaHkY1F7yazhB4Kt3VcZGL0ZF/jhrEpnXqUb0M7V3sw==",
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.12",
+				"@babel/generator": "^7.18.0",
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-function-name": "^7.17.9",
 				"@babel/helper-hoist-variables": "^7.16.7",
 				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/parser": "^7.17.12",
-				"@babel/types": "^7.17.12",
+				"@babel/parser": "^7.18.0",
+				"@babel/types": "^7.18.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -19700,9 +19726,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.12.tgz",
-			"integrity": "sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.0.tgz",
+			"integrity": "sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"to-fast-properties": "^2.0.0"
@@ -21215,9 +21241,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "17.0.34",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
-			"integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA=="
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
 		},
 		"@types/node-fetch": {
 			"version": "3.0.2",
@@ -23250,9 +23276,9 @@
 			}
 		},
 		"bson": {
-			"version": "4.6.3",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.3.tgz",
-			"integrity": "sha512-rAqP5hcUVJhXP2MCSNVsf0oM2OGU1So6A9pVRDYayvJ5+hygXHQApf87wd5NlhPM1J9RJnbqxIG/f8QTzRoQ4A==",
+			"version": "4.6.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
+			"integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
 			"requires": {
 				"buffer": "^5.6.0"
 			}
@@ -26958,9 +26984,9 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-to-ts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.4.0.tgz",
-			"integrity": "sha512-q1AHdOUDAvs+vp+E4UlENJWXyRFBuMSQyg61/nVFYWBInTBxQZOqsyR4QZiBs0qiOpO9fXlMrSgcExJRkcBkNw==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.5.1.tgz",
+			"integrity": "sha512-0+SWFvC9aauIsFQ75vMPAVS9R6HvGP025amJx+BWYMPve3t8F8zn24ekvMHBtZEMSTbY41kwjhrFRj/6SJCApw==",
 			"requires": {
 				"@types/json-schema": "^7.0.9",
 				"ts-algebra": "^1.1.1",
@@ -31624,9 +31650,9 @@
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
 		},
 		"socket.io": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
-			"integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.1.tgz",
+			"integrity": "sha512-0y9pnIso5a9i+lJmsCdtmTTgJFFSvNQKDnPQRz28mGNnxbmqYg2QPtJTLFxhymFZhAIn50eHAKzJeiNaKr+yUQ==",
 			"requires": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
@@ -31642,9 +31668,9 @@
 			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
 		},
 		"socket.io-client": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.0.tgz",
-			"integrity": "sha512-HW61c1G7OrYGxaI79WRn17+b03iBCdvhBj4iqyXHBoL5M8w2MSO/vChsjA93knG4GYEai1/vbXWJna9dzxXtSg==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
+			"integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
 			"requires": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.2",

--- a/packages/schema/test/resolver.test.ts
+++ b/packages/schema/test/resolver.test.ts
@@ -91,6 +91,29 @@ describe('@feathersjs/schema/resolver', () => {
     });
   });
 
+  it('simple resolver with converter', async () => {
+    const userConverterResolver = resolve<User, typeof context>({
+      schema: userSchema,
+      validate: 'before',
+      converter: async data => ({
+        firstName: 'Default',
+        lastName: 'Name',
+        ...data
+      }),
+      properties: {
+        name: async (_name, user) => `${user.firstName} ${user.lastName}`
+      }
+    });
+
+    const u = await userConverterResolver.resolve({}, context);
+
+    assert.deepStrictEqual(u, {
+      firstName: 'Default',
+      lastName: 'Name',
+      name: 'Default Name'
+    });
+  });
+
   it('resolving with errors', async () => {
     const dummyResolver = resolve({
       properties: {


### PR DESCRIPTION
This pull request adds a `converter` option to schema resolvers which allow to convert existing data into a completely different format. Converters always run before validation and property resolvers.

```ts
    const userConverterResolver = resolve<User, typeof context>({
      schema: userSchema,
      validate: 'before',
      converter: async data => ({
        firstName: 'Default',
        lastName: 'Name',
        ...data
      }),
      properties: {
        name: async (_name, user) => `${user.firstName} ${user.lastName}`
      }
    });
```