### PR TITLE
feat(schema): Add resolver for safe external data dispatching

### DIFF
--- a/packages/schema/src/hooks.ts
+++ b/packages/schema/src/hooks.ts
@@ -13,6 +13,13 @@ const getContext = <H extends HookContext> (context: H) => {
   }
 }
 
+const getData = <H extends HookContext> (context: H) => {
+  const isPaginated = context.method === 'find' && context.result.data;
+  const data = isPaginated ? context.result.data : context.result;
+
+  return { isPaginated, data };
+}
+
 const runResolvers = async <T, H extends HookContext> (
   resolvers: Resolver<T, H>[],
   data: any,
@@ -88,9 +95,7 @@ export const resolveResult = <T, H extends HookContext> (...resolvers: Resolver<
 
     const ctx = getContext(context);
     const status = context.params.resolve;
-
-    const isPaginated = context.method === 'find' && context.result.data;
-    const data = isPaginated ? context.result.data : context.result;
+    const { isPaginated, data } = getData(context);
 
     const result = Array.isArray(data) ?
       await Promise.all(data.map(async current => runResolvers(resolvers, current, ctx, status))) :
@@ -111,9 +116,7 @@ export const resolveDispatch = <T, H extends HookContext> (...resolvers: Resolve
 
     const ctx = getContext(context);
     const status = context.params.resolve;
-
-    const isPaginated = context.method === 'find' && context.result.data;
-    const data = isPaginated ? context.result.data : context.result;
+    const { isPaginated, data } = getData(context);
     const resolveDispatch = async (current: any) => {
       const resolved = await runResolvers(resolvers, current, ctx, status)
 


### PR DESCRIPTION
This pull request adds a `resolveDispatch` hook which makes sure that only a safe version of the data ever gets sent to the client. This includes real-time events from internal calls and properties populated in nested resolvers. For example, the following resolver:

```ts
export const userDispatchResolver = resolve<UserResult, HookContext<Application>>({
  schema: userResultSchema,
  properties: {
    password: () => undefined
  }
});

service.hooks([
  resolveDispatch(userDispatchResolver)
]);
```

Will make sure that the user password never gets sent to a client. This replaces the `protect` hook and addresses its shortcomings (and closing https://github.com/feathersjs/feathers/issues/1809)