### PR TITLE
fix(schema): Allows resolveData with different resolvers based on method

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "install": "lerna bootstrap",
     "publish": "lerna publish && git commit -am \"chore: Update changelog\" && git push origin",
     "publish:premajor": "lerna publish premajor --preid pre --pre-dist-tag pre && git commit -am \"chore: Update version and changelog\" && git push origin",
-    "publish:prerelease": "lerna publish prerelease --preid pre --pre-dist-tag pre --dist-tag pre && git commit -am \"chore: Update version and changelog\" && git push origin",
+    "publish:prerelease": "lerna publish prerelease --preid pre --pre-dist-tag pre --dist-tag pre --force-publish && git commit -am \"chore: Update version and changelog\" && git push origin",
     "lint": "eslint packages/**/src/**/*.ts packages/**/test/**/*.ts --fix",
     "update-dependencies": "ncu -u && lerna exec -- ncu -u -x node-fetch",
     "clean": "find . -name node_modules -exec rm -rf '{}' + && find . -name package-lock.json -exec rm -rf '{}' +",

--- a/packages/feathers/tsconfig.json
+++ b/packages/feathers/tsconfig.json
@@ -4,6 +4,6 @@
     "src/**/*.ts"
   ],
   "compilerOptions": {
-    "outDir": "lib"    
+    "outDir": "lib"
   }
 }

--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -189,7 +189,11 @@ app.service('users').hooks([
 app.service('users').hooks({
   create: [
     validateData(userSchema),
-    resolveData(userDataResolver)
+    resolveData({
+      create: userDataResolver,
+      patch: userDataResolver,
+      update: userDataResolver
+    })
   ]
 });
 


### PR DESCRIPTION
So that the `resolveData` hook can use different resolvers and schemas for `create`, `update` and `patch`.