### PR TITLE
fix(schema): Always resolve dispatch in resolveAll and add getDispatch method

### DIFF
--- a/packages/schema/src/hooks/resolve.ts
+++ b/packages/schema/src/hooks/resolve.ts
@@ -28,7 +28,9 @@ const runResolvers = async <T, H extends HookContext>(
   let current: any = data
 
   for (const resolver of resolvers) {
-    current = await resolver.resolve(current, ctx, status)
+    if (resolver && typeof resolver.resolve === 'function') {
+      current = await resolver.resolve(current, ctx, status)
+    }
   }
 
   return current as T
@@ -169,9 +171,7 @@ export const resolveDispatch =
 export const resolveAll = <H extends HookContext>(map: ResolveAllSettings<H>) => {
   const middleware = []
 
-  if (map.dispatch) {
-    middleware.push(resolveDispatch(map.dispatch))
-  }
+  middleware.push(resolveDispatch(map.dispatch))
 
   if (map.result) {
     middleware.push(resolveResult(map.result))

--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -81,8 +81,7 @@ export const messageSchema = schema({
   required: ['text', 'userId'],
   properties: {
     text: { type: 'string' },
-    userId: { type: 'number' },
-    secret: { type: 'boolean' }
+    userId: { type: 'number' }
   }
 } as const)
 
@@ -118,12 +117,6 @@ export const messageResultResolver = resolve<MessageResult, HookContext<Applicat
 
       return context.app.service('users').get(userId, context.params)
     }
-  }
-})
-
-export const messageDispatchResolver = resolve<MessageResult, HookContext<Application>>({
-  properties: {
-    secret: () => undefined
   }
 })
 
@@ -182,7 +175,6 @@ app.use('paginatedMessages', memory({ paginate: { default: 10 } }))
 
 app.service('messages').hooks([
   resolveAll({
-    dispatch: messageDispatchResolver,
     result: messageResultResolver,
     query: messageQueryResolver
   }),

--- a/packages/schema/test/hooks.test.ts
+++ b/packages/schema/test/hooks.test.ts
@@ -20,8 +20,7 @@ describe('@feathersjs/schema/hooks', () => {
     )[0]
     message = await app.service('messages').create({
       text,
-      userId: user.id,
-      secret: true
+      userId: user.id
     })
     messageOnPaginatedService = await app.service('paginatedMessages').create({
       text,
@@ -42,7 +41,6 @@ describe('@feathersjs/schema/hooks', () => {
   it('resolves results and handles resolver errors (#2534)', async () => {
     const payload = {
       userId: user.id,
-      secret: true,
       text
     }
 
@@ -92,7 +90,6 @@ describe('@feathersjs/schema/hooks', () => {
   it('resolves get result with the object on result', async () => {
     const payload = {
       userId: user.id,
-      secret: true,
       text
     }
 
@@ -155,7 +152,6 @@ describe('@feathersjs/schema/hooks', () => {
     const service = app.service('messages')
     const context = await service.get(0, {}, createContext(service as any, 'get'))
 
-    assert.ok(context.result.secret)
     assert.strictEqual(context.result.user.password, 'hashed')
 
     assert.deepStrictEqual(context.dispatch, {


### PR DESCRIPTION
This ensures that recursive resolvers will still send the safe data to external clients even if there is no explicit dispatch resolver.