### PR TITLE
fix: remove `default` from queryProperty schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,8 +76,6 @@
 				"c8": "^7.11.2",
 				"eslint": "^8.14.0",
 				"eslint-config-prettier": "^8.5.0",
-				"eslint-plugin-import": "^2.26.0",
-				"eslint-plugin-prefer-arrow": "^1.2.3",
 				"eslint-plugin-prettier": "^4.0.0",
 				"lerna": "^4.0.0",
 				"npm-check-updates": "^12.5.11",
@@ -3369,12 +3367,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
 		},
-		"node_modules/@types/json5": {
-			"version": "0.0.29",
-			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-			"dev": true
-		},
 		"node_modules/@types/jsonwebtoken": {
 			"version": "8.5.8",
 			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
@@ -3464,9 +3456,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
+			"version": "17.0.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
+			"integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA=="
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "3.0.2",
@@ -4243,25 +4235,6 @@
 			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true
 		},
-		"node_modules/array-includes": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-			"integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5",
-				"get-intrinsic": "^1.1.1",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -4277,24 +4250,6 @@
 			"integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/array.prototype.flat": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-			"integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.2",
-				"es-shim-unscopables": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/array.prototype.reduce": {
@@ -4507,7 +4462,7 @@
 		"node_modules/babel-code-frame/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -4617,7 +4572,7 @@
 		"node_modules/babel-generator/node_modules/detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"integrity": "sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==",
 			"dependencies": {
 				"repeating": "^2.0.0"
 			},
@@ -4835,7 +4790,7 @@
 		"node_modules/babel-plugin-istanbul/node_modules/find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 			"dependencies": {
 				"locate-path": "^2.0.0"
 			},
@@ -5040,7 +4995,7 @@
 		"node_modules/babel-plugin-istanbul/node_modules/read-pkg-up/node_modules/find-up": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
 			"dependencies": {
 				"path-exists": "^2.0.0",
 				"pinkie-promise": "^2.0.0"
@@ -7138,7 +7093,7 @@
 		"node_modules/deresolve": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
-			"integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
+			"integrity": "sha512-rf9dY1yNiDLeAbZuo8/EP2cGMRYfuOBvPacxFpxQf4CNA7VF4QxmSc5zTrvFY14k9jtE4r2XcF96Z6MBO6VYpA==",
 			"dependencies": {
 				"lasso-package-root": "^1.0.0",
 				"raptor-polyfill": "^1.0.2",
@@ -7204,7 +7159,7 @@
 		"node_modules/dissolve": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/dissolve/-/dissolve-0.3.3.tgz",
-			"integrity": "sha1-uX7x/ymJx4nOz7AxB+F0EfqL5uU=",
+			"integrity": "sha512-rvfi673cuHiiAmJvtedphnzzcGpqiSmQor4Plz0nU2rrB6Dt3ZjbRBBLPBQeqoci6AqmVXwhlujVOB8IMZ3S3Q==",
 			"dependencies": {
 				"bl": "^0.7.0",
 				"readable-stream": "^1.0.26"
@@ -7294,12 +7249,12 @@
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.140",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.140.tgz",
-			"integrity": "sha512-NLz5va823QfJBYOO/hLV4AfU4Crmkl/6Hl2pH3qdJcmi0ySZ3YTWHxOlDm3uJOFBEPy3pIhu8gKQo6prQTWKKA=="
+			"version": "1.4.141",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
+			"integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -7332,7 +7287,7 @@
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -7556,15 +7511,6 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
 		},
-		"node_modules/es-shim-unscopables": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-			"dev": true,
-			"dependencies": {
-				"has": "^1.0.3"
-			}
-		},
 		"node_modules/es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -7590,7 +7536,7 @@
 		"node_modules/es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
 			"dependencies": {
 				"es6-promise": "^4.0.3"
 			}
@@ -7615,7 +7561,7 @@
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -7758,168 +7704,6 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
-			}
-		},
-		"node_modules/eslint-import-resolver-node": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-			"integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^3.2.7",
-				"resolve": "^1.20.0"
-			}
-		},
-		"node_modules/eslint-import-resolver-node/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/eslint-module-utils": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-			"integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^3.2.7",
-				"find-up": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-			"dev": true,
-			"dependencies": {
-				"p-try": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-plugin-import": {
-			"version": "2.26.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-			"integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
-			"dev": true,
-			"dependencies": {
-				"array-includes": "^3.1.4",
-				"array.prototype.flat": "^1.2.5",
-				"debug": "^2.6.9",
-				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.6",
-				"eslint-module-utils": "^2.7.3",
-				"has": "^1.0.3",
-				"is-core-module": "^2.8.1",
-				"is-glob": "^4.0.3",
-				"minimatch": "^3.1.2",
-				"object.values": "^1.1.5",
-				"resolve": "^1.22.0",
-				"tsconfig-paths": "^3.14.1"
-			},
-			"engines": {
-				"node": ">=4"
-			},
-			"peerDependencies": {
-				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/doctrine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"dev": true,
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"node_modules/eslint-plugin-prefer-arrow": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-			"integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-			"dev": true,
-			"peerDependencies": {
-				"eslint": ">=2.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
@@ -8120,7 +7904,7 @@
 		"node_modules/etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -8142,7 +7926,7 @@
 		"node_modules/events-light": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
-			"integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
+			"integrity": "sha512-jF51LJzg5W+tkJgfZbjlbFCLcyVFEtOjU+xMCBylrXG13X5XHvfp6lNGfyBLF9u1mRTpUsMVYqSDukvpZff1mQ==",
 			"dependencies": {
 				"chai": "^3.5.0"
 			}
@@ -8172,7 +7956,7 @@
 		"node_modules/expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
 			"dependencies": {
 				"is-posix-bracket": "^0.1.0"
 			},
@@ -8183,7 +7967,7 @@
 		"node_modules/expand-range": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
 			"dependencies": {
 				"fill-range": "^2.1.0"
 			},
@@ -8370,7 +8154,7 @@
 		"node_modules/extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
 			"dependencies": {
 				"is-extglob": "^1.0.0"
 			},
@@ -8551,7 +8335,7 @@
 		"node_modules/fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
 			"dependencies": {
 				"pend": "~1.2.0"
 			}
@@ -8601,7 +8385,7 @@
 		"node_modules/filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8736,7 +8520,7 @@
 		"node_modules/for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8744,7 +8528,7 @@
 		"node_modules/for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
 			"dependencies": {
 				"for-in": "^1.0.1"
 			},
@@ -8804,7 +8588,7 @@
 		"node_modules/formidable/node_modules/dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-			"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+			"integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
 			"dependencies": {
 				"asap": "^2.0.0",
 				"wrappy": "1"
@@ -11180,7 +10964,7 @@
 		"node_modules/lasso-loader/node_modules/events": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+			"integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
 			"engines": {
 				"node": ">=0.4.x"
 			}
@@ -11395,12 +11179,12 @@
 		"node_modules/lasso/node_modules/destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+			"integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
 		},
 		"node_modules/lasso/node_modules/etag": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-			"integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
+			"integrity": "sha512-Mbv5pNpLNPrm1b4rzZlZlfTRpdDr31oiD43N362sIyvSWVNu5Du33EcJGzvEV4YdYLuENB1HzND907cQkFmXNw==",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -12795,7 +12579,7 @@
 		"node_modules/mocha-puppeteer/node_modules/diff": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+			"integrity": "sha512-597ykPFhtJYaXqPq6fF7Vl1fXTKgPdLOntyxpmdzUOKiYGqK7zcnbplj5088+8qJnWdzXhyeau5iVr8HVo9dgg==",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -12803,7 +12587,7 @@
 		"node_modules/mocha-puppeteer/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -14446,23 +14230,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object.values": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-			"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/on-finished": {
@@ -17686,39 +17453,6 @@
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
 			"integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
-		},
-		"node_modules/tsconfig-paths": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-			"integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/json5": "^0.0.29",
-				"json5": "^1.0.1",
-				"minimist": "^1.2.6",
-				"strip-bom": "^3.0.0"
-			}
-		},
-		"node_modules/tsconfig-paths/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/tsconfig-paths/node_modules/strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
@@ -21346,12 +21080,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
 		},
-		"@types/json5": {
-			"version": "0.0.29",
-			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-			"dev": true
-		},
 		"@types/jsonwebtoken": {
 			"version": "8.5.8",
 			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
@@ -21440,9 +21168,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
+			"version": "17.0.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
+			"integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA=="
 		},
 		"@types/node-fetch": {
 			"version": "3.0.2",
@@ -22044,19 +21772,6 @@
 			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true
 		},
-		"array-includes": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-			"integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5",
-				"get-intrinsic": "^1.1.1",
-				"is-string": "^1.0.7"
-			}
-		},
 		"array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -22067,18 +21782,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg=="
-		},
-		"array.prototype.flat": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-			"integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.2",
-				"es-shim-unscopables": "^1.0.0"
-			}
 		},
 		"array.prototype.reduce": {
 			"version": "1.0.4",
@@ -22263,7 +21966,7 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 				},
 				"js-tokens": {
 					"version": "3.0.2",
@@ -22359,7 +22062,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+					"integrity": "sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==",
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -22560,7 +22263,7 @@
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -22717,7 +22420,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -24434,7 +24137,7 @@
 		"deresolve": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
-			"integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
+			"integrity": "sha512-rf9dY1yNiDLeAbZuo8/EP2cGMRYfuOBvPacxFpxQf4CNA7VF4QxmSc5zTrvFY14k9jtE4r2XcF96Z6MBO6VYpA==",
 			"requires": {
 				"lasso-package-root": "^1.0.0",
 				"raptor-polyfill": "^1.0.2",
@@ -24486,7 +24189,7 @@
 		"dissolve": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/dissolve/-/dissolve-0.3.3.tgz",
-			"integrity": "sha1-uX7x/ymJx4nOz7AxB+F0EfqL5uU=",
+			"integrity": "sha512-rvfi673cuHiiAmJvtedphnzzcGpqiSmQor4Plz0nU2rrB6Dt3ZjbRBBLPBQeqoci6AqmVXwhlujVOB8IMZ3S3Q==",
 			"requires": {
 				"bl": "^0.7.0",
 				"readable-stream": "^1.0.26"
@@ -24566,12 +24269,12 @@
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"electron-to-chromium": {
-			"version": "1.4.140",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.140.tgz",
-			"integrity": "sha512-NLz5va823QfJBYOO/hLV4AfU4Crmkl/6Hl2pH3qdJcmi0ySZ3YTWHxOlDm3uJOFBEPy3pIhu8gKQo6prQTWKKA=="
+			"version": "1.4.141",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
+			"integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -24601,7 +24304,7 @@
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
 		},
 		"encoding": {
 			"version": "0.1.13",
@@ -24770,15 +24473,6 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
 		},
-		"es-shim-unscopables": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
 		"es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -24798,7 +24492,7 @@
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -24817,7 +24511,7 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -24959,145 +24653,6 @@
 			"dev": true,
 			"requires": {}
 		},
-		"eslint-import-resolver-node": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-			"integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
-			"dev": true,
-			"requires": {
-				"debug": "^3.2.7",
-				"resolve": "^1.20.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
-		"eslint-module-utils": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-			"integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
-			"dev": true,
-			"requires": {
-				"debug": "^3.2.7",
-				"find-up": "^2.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
-			}
-		},
-		"eslint-plugin-import": {
-			"version": "2.26.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-			"integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
-			"dev": true,
-			"requires": {
-				"array-includes": "^3.1.4",
-				"array.prototype.flat": "^1.2.5",
-				"debug": "^2.6.9",
-				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.6",
-				"eslint-module-utils": "^2.7.3",
-				"has": "^1.0.3",
-				"is-core-module": "^2.8.1",
-				"is-glob": "^4.0.3",
-				"minimatch": "^3.1.2",
-				"object.values": "^1.1.5",
-				"resolve": "^1.22.0",
-				"tsconfig-paths": "^3.14.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"doctrine": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"eslint-plugin-prefer-arrow": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-			"integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-			"dev": true,
-			"requires": {}
-		},
 		"eslint-plugin-prettier": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
@@ -25200,7 +24755,7 @@
 		"etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
 		},
 		"eventemitter3": {
 			"version": "4.0.7",
@@ -25216,7 +24771,7 @@
 		"events-light": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
-			"integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
+			"integrity": "sha512-jF51LJzg5W+tkJgfZbjlbFCLcyVFEtOjU+xMCBylrXG13X5XHvfp6lNGfyBLF9u1mRTpUsMVYqSDukvpZff1mQ==",
 			"requires": {
 				"chai": "^3.5.0"
 			}
@@ -25240,7 +24795,7 @@
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
 			"requires": {
 				"is-posix-bracket": "^0.1.0"
 			}
@@ -25248,7 +24803,7 @@
 		"expand-range": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
 			"requires": {
 				"fill-range": "^2.1.0"
 			},
@@ -25408,7 +24963,7 @@
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
 			"requires": {
 				"is-extglob": "^1.0.0"
 			},
@@ -25571,7 +25126,7 @@
 		"fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
 			"requires": {
 				"pend": "~1.2.0"
 			}
@@ -25611,7 +25166,7 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ=="
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -25704,12 +25259,12 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -25754,7 +25309,7 @@
 				"dezalgo": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-					"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+					"integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
 					"requires": {
 						"asap": "^2.0.0",
 						"wrappy": "1"
@@ -27554,12 +27109,12 @@
 				"destroy": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+					"integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
 				},
 				"etag": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-					"integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+					"integrity": "sha512-Mbv5pNpLNPrm1b4rzZlZlfTRpdDr31oiD43N362sIyvSWVNu5Du33EcJGzvEV4YdYLuENB1HzND907cQkFmXNw=="
 				},
 				"fresh": {
 					"version": "0.3.0",
@@ -27689,7 +27244,7 @@
 				"events": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+					"integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
 				},
 				"raptor-util": {
 					"version": "1.1.2",
@@ -28952,12 +28507,12 @@
 				"diff": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+					"integrity": "sha512-597ykPFhtJYaXqPq6fF7Vl1fXTKgPdLOntyxpmdzUOKiYGqK7zcnbplj5088+8qJnWdzXhyeau5iVr8HVo9dgg=="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 				},
 				"formidable": {
 					"version": "1.2.6",
@@ -30217,17 +29772,6 @@
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
-			}
-		},
-		"object.values": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-			"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1"
 			}
 		},
 		"on-finished": {
@@ -32697,35 +32241,6 @@
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
 			"integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
-		},
-		"tsconfig-paths": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-			"integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-			"dev": true,
-			"requires": {
-				"@types/json5": "^0.0.29",
-				"json5": "^1.0.1",
-				"minimist": "^1.2.6",
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				}
-			}
 		},
 		"tslib": {
 			"version": "1.14.1",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@feathersjs/errors": "^5.0.0-pre.22",
     "@feathersjs/feathers": "^5.0.0-pre.22",
+    "@feathersjs/commons": "^5.0.0-pre.22",
     "@feathersjs/hooks": "^0.7.4",
     "@types/json-schema": "^7.0.11",
     "ajv": "^8.11.0",

--- a/packages/schema/src/query.ts
+++ b/packages/schema/src/query.ts
@@ -1,3 +1,4 @@
+import { _ } from '@feathersjs/commons'
 import { JSONSchema } from 'json-schema-to-ts'
 
 export type PropertyQuery<D extends JSONSchema> = {
@@ -25,8 +26,9 @@ export type PropertyQuery<D extends JSONSchema> = {
   ]
 }
 
-export const queryProperty = <T extends JSONSchema>(definition: T) =>
-  ({
+export const queryProperty = <T extends JSONSchema>(def: T) => {
+  const definition = _.omit(def, 'default')
+  return {
     anyOf: [
       definition,
       {
@@ -49,7 +51,8 @@ export const queryProperty = <T extends JSONSchema>(definition: T) =>
         }
       }
     ]
-  } as const)
+  } as const
+}
 
 export const queryProperties = <T extends { [key: string]: JSONSchema }>(definition: T) =>
   Object.keys(definition).reduce((res, key) => {

--- a/packages/schema/test/schema.test.ts
+++ b/packages/schema/test/schema.test.ts
@@ -311,4 +311,26 @@ describe('@feathersjs/schema/schema', () => {
       assert.ok(error.data?.length > 0)
     }
   })
+
+  it('removes default from queryProperty schemas like $gt', async () => {
+    const validator = schema(
+      {
+        $id: 'noDefault$gt',
+        type: 'object',
+        required: [],
+        additionalProperties: false,
+        properties: {
+          someDate: queryProperty({ default: '0000-00-00', type: 'string' })
+        }
+      } as const,
+      customAjv
+    )
+
+    assert.equal(
+      validator.definition.properties.someDate.anyOf[1].properties.$gt.type,
+      'string',
+      'type is found under $gt'
+    )
+    assert(!validator.definition.properties.someDate.anyOf[1].properties.$gt.default, 'no default under $gt')
+  })
 })


### PR DESCRIPTION
This PR prevents the `default` JSON Schema keyword from being copied into the query sub-schemas like `$gt`.  I looked through the schema [here](https://json-schema.org/draft/2020-12/json-schema-validation.html) and there doesn’t seem to be another potential conflict.
