### PR TITLE
fix(express): Ensure Express options can be set before configuring REST transport

### DIFF
--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -122,10 +122,6 @@ export default function feathersExpress<S = any, C = any>(
   })
 
   app.configure(routing() as any)
-  app.use((req, _res, next) => {
-    req.feathers = { ...req.feathers, provider: 'rest' }
-    return next()
-  })
 
   return app
 }

--- a/packages/express/src/rest.ts
+++ b/packages/express/src/rest.ts
@@ -96,6 +96,10 @@ export const rest = (options?: RestOptions | RequestHandler) => {
       throw new Error('@feathersjs/express/rest needs an Express compatible app.')
     }
 
+    app.use((req, _res, next) => {
+      req.feathers = { ...req.feathers, provider: 'rest' }
+      return next()
+    })
     app.use(parseAuthentication(authenticationOptions))
     app.use(servicesMiddleware())
 

--- a/packages/express/test/rest.test.ts
+++ b/packages/express/test/rest.test.ts
@@ -290,8 +290,10 @@ describe('@feathersjs/express/rest provider', () => {
 
       const app = expressify(feathers())
         .use(function (req: Request, _res: Response, next: NextFunction) {
-          assert.ok(req.feathers, 'Feathers object initialized')
-          req.feathers.test = 'Happy'
+          req.feathers = {
+            ...req.feathers,
+            test: 'Happy'
+          }
           next()
         })
         .configure(rest(express.formatter))

--- a/packages/rest-client/test/server.ts
+++ b/packages/rest-client/test/server.ts
@@ -85,7 +85,10 @@ export default (configurer?: any) => {
     .use(function (req, res, next) {
       res.header('Access-Control-Allow-Origin', '*')
       res.header('Access-Control-Allow-Headers', 'Authorization')
-      req.feathers.authorization = req.headers.authorization
+      req.feathers = {
+        ...req.feathers,
+        authorization: req.headers.authorization
+      }
       next()
     })
     // Parse HTTP bodies


### PR DESCRIPTION
Fixes https://github.com/feathersjs/feathers/issues/2629