### PR TITLE
fix(authentication): Add safe dispatch data for authentication requests

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -56,6 +56,7 @@
     "@feathersjs/errors": "^5.0.0-pre.23",
     "@feathersjs/feathers": "^5.0.0-pre.23",
     "@feathersjs/transport-commons": "^5.0.0-pre.23",
+    "@feathersjs/schema": "^5.0.0-pre.23",
     "@types/jsonwebtoken": "^8.5.8",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
@@ -64,7 +65,6 @@
   },
   "devDependencies": {
     "@feathersjs/memory": "^5.0.0-pre.23",
-    "@feathersjs/schema": "^5.0.0-pre.23",
     "@types/lodash": "^4.14.182",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.40",

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -5,6 +5,7 @@ import { connection, event } from './hooks'
 import '@feathersjs/transport-commons'
 import { createDebug } from '@feathersjs/commons'
 import { ServiceMethods, ServiceAddons } from '@feathersjs/feathers'
+import { resolveDispatch } from '@feathersjs/schema'
 import jsonwebtoken from 'jsonwebtoken'
 
 const debug = createDebug('@feathersjs/authentication/service')
@@ -120,12 +121,14 @@ export class AuthenticationService
 
     const accessToken = await this.createAccessToken(payload, jwtOptions, params.secret)
 
-    return merge({ accessToken }, authResult, {
+    return {
+      accessToken,
+      ...authResult,
       authentication: {
-        accessToken,
+        ...authResult.authentication,
         payload: jsonwebtoken.decode(accessToken)
       }
-    })
+    }
   }
 
   /**
@@ -182,8 +185,8 @@ export class AuthenticationService
     }
 
     this.hooks({
-      create: [connection('login'), event('login')],
-      remove: [connection('logout'), event('logout')]
+      create: [resolveDispatch(), connection('login'), event('login')],
+      remove: [resolveDispatch(), connection('logout'), event('logout')]
     } as any)
 
     this.app.on('disconnect', async (connection) => {

--- a/packages/express/test/authentication.test.ts
+++ b/packages/express/test/authentication.test.ts
@@ -67,8 +67,7 @@ describe('@feathersjs/express/authentication', () => {
     it('successful local authentication', () => {
       assert.ok(authResult.accessToken)
       assert.deepStrictEqual(omit(authResult.authentication, 'payload'), {
-        strategy: 'local',
-        accessToken: authResult.accessToken
+        strategy: 'local'
       })
       assert.strictEqual(authResult.user.email, email)
       assert.strictEqual(authResult.user.password, undefined)


### PR DESCRIPTION
This pull request ensures that authentication requests use the safe dispatch version of the sub-properties (like the returned `user`).