### PR TITLE
fix(schema): Fix dispatch resolver hook to convert actually resolved data

### DIFF
--- a/packages/schema/src/hooks/resolve.ts
+++ b/packages/schema/src/hooks/resolve.ts
@@ -143,10 +143,10 @@ export const resolveDispatch =
     const status = context.params.resolve
     const { isPaginated, data } = getData(context)
     const resolveAndGetDispatch = async (current: any) => {
-      const resolved = await runResolvers(resolvers, current, ctx, status)
+      const resolved: any = await runResolvers(resolvers, current, ctx, status)
 
       return Object.keys(resolved).reduce((res, key) => {
-        res[key] = getDispatch(current[key])
+        res[key] = getDispatch(resolved[key])
 
         return res
       }, {} as any)

--- a/packages/schema/test/fixture.ts
+++ b/packages/schema/test/fixture.ts
@@ -63,7 +63,8 @@ export const userResultResolver = resolve<UserResult, HookContext<Application>>(
 export const userDispatchResolver = resolve<UserResult, HookContext<Application>>({
   schema: userResultSchema,
   properties: {
-    password: () => undefined
+    password: async () => undefined,
+    email: async () => '[redacted]'
   }
 })
 

--- a/packages/schema/test/hooks.test.ts
+++ b/packages/schema/test/hooks.test.ts
@@ -159,8 +159,8 @@ describe('@feathersjs/schema/hooks', () => {
       userId: 0,
       id: 0,
       user: {
-        email: 'hello@feathersjs.com',
         id: 0,
+        email: '[redacted]',
         name: 'hello (hello@feathersjs.com)'
       }
     })


### PR DESCRIPTION
There was a bug in the dispatch resolver where it was using the current data instead of the resolved data properities which is not what we want.