### PR TITLE
Fix the NPM link

### DIFF
--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/databases.git"
+    "url": "https://github.com/feathersjs/feathers.git",
+    "directory": "packages/adapter-commons"
   },
   "author": {
     "name": "Feathers contributor",


### PR DESCRIPTION
### Summary

NPM link is going somewhere 404.

NPM Page: https://www.npmjs.com/package/@feathersjs/adapter-commons
Broken promises: https://github.com/feathersjs/databases

Source: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository