### PR TITLE
Set types to `"./lib/index.d.ts"`

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -3,8 +3,8 @@
   "description": "A common data schema definition format",
   "version": "5.0.0-pre.23",
   "homepage": "https://feathersjs.com",
-  "main": "lib/",
-  "types": "lib/index.d.ts",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -4,7 +4,7 @@
   "version": "5.0.0-pre.23",
   "homepage": "https://feathersjs.com",
   "main": "lib/",
-  "types": "lib/",
+  "types": "lib/index.d.ts",
   "keywords": [
     "feathers",
     "feathers-plugin"


### PR DESCRIPTION
Here's the recommended most compatible way to do it...
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

The way it is in some of our modules causes compatibility problems. The do is how Node ESM module resolution expects it. Deno does not support defaulting to index.js due to a community wide move away from problematic magic. Specifically this has caused problems with CodeSandbox Cloud IDE, StackBlitz and would probably cause problems in Deno, integrations, CI tools that check integrity, tools that automatically transform code and other environments. There is no downside to the PR approach and no substantial benefit to the current approach.

What users currently see:
![Screenshot (15)](https://user-images.githubusercontent.com/876076/174457845-448238e1-90d1-47b8-9c45-4c79435c5926.png)

We stray three steps away from the recommended way.

![{2546598D-DF23-42FF-ADE6-D10E11B359CD}](https://user-images.githubusercontent.com/876076/174456148-d16fb033-6cd9-49ad-a11a-ef5fb7a4c2a7.png)

Our way: https://unpkg.com/browse/@feathersjs/schema@5.0.0-pre.23/lib/

