### PR TITLE
fix: Freeze the resolver context

### DIFF
--- a/packages/schema/src/hooks/resolve.ts
+++ b/packages/schema/src/hooks/resolve.ts
@@ -3,13 +3,13 @@ import { compose } from '@feathersjs/hooks'
 import { Resolver, ResolverStatus } from '../resolver'
 
 const getContext = <H extends HookContext>(context: H) => {
-  return {
+  return Object.freeze({
     ...context,
-    params: {
+    params: Object.freeze({
       ...context.params,
-      query: {}
-    }
-  }
+      query: Object.freeze({})
+    })
+  })
 }
 
 const getData = <H extends HookContext>(context: H) => {


### PR DESCRIPTION
Since editing the resolver context is a side effect that will likely cause race conditions and bugs, this PR freezes the resolver context.  This means that by design it is not possible to edit `context.params` the same way you can do in a hook.  With the new `around` hooks, it's less likely that people actually need to edit `context.params`.