### PR TITLE
fix(socketio-client): Make Socket.io client event target compatible

### DIFF
--- a/packages/socketio-client/test/index.test.ts
+++ b/packages/socketio-client/test/index.test.ts
@@ -88,6 +88,10 @@ describe('@feathersjs/socketio-client', () => {
     }
   })
 
+  it('is event target compatible', async () => {
+    app.service('todo').addEventListener('created', (data: any) => assert.ok(data))
+  })
+
   it('calls .customMethod', async () => {
     const service = app.service('todos')
     const result = await service.customMethod({ message: 'hi' })

--- a/packages/transport-commons/src/client.ts
+++ b/packages/transport-commons/src/client.ts
@@ -7,6 +7,7 @@ const debug = createDebug('@feathersjs/transport-commons/client')
 
 const namespacedEmitterMethods = [
   'addListener',
+  'addEventListener',
   'emit',
   'listenerCount',
   'listeners',
@@ -15,6 +16,7 @@ const namespacedEmitterMethods = [
   'prependListener',
   'prependOnceListener',
   'removeAllListeners',
+  'removeEventListener',
   'removeListener'
 ]
 const otherEmitterMethods = ['eventNames', 'getMaxListeners', 'setMaxListeners']


### PR DESCRIPTION
This fix is related to https://github.com/feathersjs-ecosystem/feathers-reactive/issues/190 and makes sure that RxJS `fromEvent` can use the proper `addEventListener` method on a client service.