### PR TITLE
fix(authentication-client): Properly handle missing token error

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -145,7 +145,7 @@ export class AuthenticationClient {
     if (!authPromise || force === true) {
       authPromise = this.getAccessToken().then((accessToken) => {
         if (!accessToken) {
-          throw new NotAuthenticated('No accessToken found in storage')
+          return this.handleError(new NotAuthenticated('No accessToken found in storage'), 'authenticate')
         }
 
         return this.authenticate({

--- a/packages/authentication-client/test/index.test.ts
+++ b/packages/authentication-client/test/index.test.ts
@@ -154,10 +154,11 @@ describe('@feathersjs/authentication-client', () => {
   })
 
   describe('reauthenticate', () => {
-    it('fails when no token in storage', async () => {
+    it('fails when no token in storage and resets authentication state', async () => {
       await assert.rejects(() => app.authentication.reAuthenticate(), {
         message: 'No accessToken found in storage'
       })
+      assert.ok(!app.get('authentication'), 'Reset authentication')
     })
 
     it('reauthenticates when token is in storage', async () => {


### PR DESCRIPTION
This fixes a regression from #2690 where missing token errors no longer reset the client side authentication state.