### PR TITLE
fix(socketio): Reinitialize hooks on overriden setup method

### DIFF
--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@feathersjs/commons": "^5.0.0-pre.28",
     "@feathersjs/feathers": "^5.0.0-pre.28",
+    "@feathersjs/hooks": "^0.7.5",
     "@feathersjs/transport-commons": "^5.0.0-pre.28",
     "socket.io": "^4.5.1"
   },

--- a/packages/socketio/src/index.ts
+++ b/packages/socketio/src/index.ts
@@ -1,7 +1,7 @@
 import http from 'http'
 import { Server, ServerOptions } from 'socket.io'
 import { createDebug } from '@feathersjs/commons'
-import { Application, ApplicationHookContext, NextFunction } from '@feathersjs/feathers'
+import { Application } from '@feathersjs/feathers'
 import { socket } from '@feathersjs/transport-commons'
 
 import { disconnect, params, authentication, FeathersSocket } from './middleware'
@@ -46,7 +46,7 @@ function configureSocketio(port?: any, options?: any, config?: any) {
     // Promise that resolves with the Socket.io `io` instance
     // when `setup` has been called (with a server)
     const done = new Promise((resolve) => {
-      const { listen } = app as any
+      const { listen, setup } = app as any
 
       Object.assign(app, {
         async listen(this: any, ...args: any[]) {
@@ -61,34 +61,31 @@ function configureSocketio(port?: any, options?: any, config?: any) {
           await this.setup(server)
 
           return server.listen(...args)
-        }
-      })
+        },
 
-      app.hooks({
-        setup: [
-          async (context: ApplicationHookContext, next: NextFunction) => {
-            if (!app.io) {
-              const io = (app.io = new Server(port || context.server, options))
+        async setup(this: any, server: http.Server, ...rest: any[]) {
+          if (!this.io) {
+            const io = (this.io = new Server(port || server, options))
 
-              io.use(disconnect(app, getParams))
-              io.use(params(app, socketMap))
-              io.use(authentication(app, getParams))
+            io.use(disconnect(app, getParams))
+            io.use(params(app, socketMap))
+            io.use(authentication(app, getParams))
 
-              // In Feathers it is easy to hit the standard Node warning limit
-              // of event listeners (e.g. by registering 10 services).
-              // So we set it to a higher number. 64 should be enough for everyone.
-              io.sockets.setMaxListeners(64)
-            }
-
-            if (typeof config === 'function') {
-              debug('Calling SocketIO configuration function')
-              config.call(app, app.io)
-            }
-
-            resolve(app.io)
-            await next()
+            // In Feathers it is easy to hit the standard Node warning limit
+            // of event listeners (e.g. by registering 10 services).
+            // So we set it to a higher number. 64 should be enough for everyone.
+            io.sockets.setMaxListeners(64)
           }
-        ]
+
+          if (typeof config === 'function') {
+            debug('Calling SocketIO configuration function')
+            config.call(this, this.io)
+          }
+
+          resolve(this.io)
+
+          return setup.call(this, server, ...rest)
+        }
       })
     })
 

--- a/packages/socketio/src/index.ts
+++ b/packages/socketio/src/index.ts
@@ -3,6 +3,7 @@ import { Server, ServerOptions } from 'socket.io'
 import { createDebug } from '@feathersjs/commons'
 import { Application } from '@feathersjs/feathers'
 import { socket } from '@feathersjs/transport-commons'
+import { hooks, middleware } from '@feathersjs/hooks'
 
 import { disconnect, params, authentication, FeathersSocket } from './middleware'
 
@@ -86,6 +87,10 @@ function configureSocketio(port?: any, options?: any, config?: any) {
 
           return setup.call(this, server, ...rest)
         }
+      })
+
+      hooks(app, {
+        setup: middleware().params('server').props({ app })
       })
     })
 

--- a/packages/socketio/test/index.test.ts
+++ b/packages/socketio/test/index.test.ts
@@ -1,5 +1,12 @@
 import { strict as assert } from 'assert'
-import { feathers, Application, HookContext, NullableId, Params } from '@feathersjs/feathers'
+import {
+  feathers,
+  Application,
+  HookContext,
+  NullableId,
+  Params,
+  ApplicationHookContext
+} from '@feathersjs/feathers'
 import express from '@feathersjs/express'
 import { Request, Response } from 'express'
 import { omit, extend } from 'lodash'
@@ -80,20 +87,32 @@ describe('@feathersjs/socketio', () => {
       }
     })
 
-    app.listen(7886).then((srv) => {
-      server = srv
-      server.once('listening', () => {
-        app.use('/tasks', new Service())
-        app.service('tasks').hooks({
-          before: {
-            get: errorHook
-          }
-        })
-      })
+    app.hooks({
+      setup: [
+        async (context: ApplicationHookContext, next: NextFunction) => {
+          assert.notStrictEqual(context.app, undefined)
+          await next()
+        }
+      ]
     })
 
+    app
+      .listen(7886)
+      .then((srv) => {
+        server = srv
+        server.once('listening', () => {
+          app.use('/tasks', new Service())
+          app.service('tasks').hooks({
+            before: {
+              get: errorHook
+            }
+          })
+        })
+      })
+      .catch(done)
+
     socket = io('http://localhost:7886')
-    socket.on('connect', () => done())
+    socket.once('connect', () => done())
   })
 
   after((done) => {

--- a/packages/socketio/test/index.test.ts
+++ b/packages/socketio/test/index.test.ts
@@ -1,12 +1,5 @@
 import { strict as assert } from 'assert'
-import {
-  feathers,
-  Application,
-  HookContext,
-  NullableId,
-  Params,
-  ApplicationHookContext
-} from '@feathersjs/feathers'
+import { feathers, Application, HookContext, NullableId, Params } from '@feathersjs/feathers'
 import express from '@feathersjs/express'
 import { Request, Response } from 'express'
 import { omit, extend } from 'lodash'
@@ -87,32 +80,20 @@ describe('@feathersjs/socketio', () => {
       }
     })
 
-    app.hooks({
-      setup: [
-        async (context: ApplicationHookContext, next: NextFunction) => {
-          assert.notStrictEqual(context.app, undefined)
-          await next()
-        }
-      ]
-    })
-
-    app
-      .listen(7886)
-      .then((srv) => {
-        server = srv
-        server.once('listening', () => {
-          app.use('/tasks', new Service())
-          app.service('tasks').hooks({
-            before: {
-              get: errorHook
-            }
-          })
+    app.listen(7886).then((srv) => {
+      server = srv
+      server.once('listening', () => {
+        app.use('/tasks', new Service())
+        app.service('tasks').hooks({
+          before: {
+            get: errorHook
+          }
         })
       })
-      .catch(done)
+    })
 
     socket = io('http://localhost:7886')
-    socket.once('connect', () => done())
+    socket.on('connect', () => done())
   })
 
   after((done) => {

--- a/packages/socketio/test/index.test.ts
+++ b/packages/socketio/test/index.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert'
-import { feathers, Application, HookContext, NullableId, Params } from '@feathersjs/feathers'
+import { feathers, Application, HookContext, NullableId, Params, ApplicationHookContext } from '@feathersjs/feathers'
 import express from '@feathersjs/express'
 import { Request, Response } from 'express'
 import { omit, extend } from 'lodash'
@@ -80,6 +80,15 @@ describe('@feathersjs/socketio', () => {
       }
     })
 
+    app.hooks({
+      setup: [
+        async (context: ApplicationHookContext, next: NextFunction) => {
+          assert.notStrictEqual(context.app, undefined)
+          await next()
+        }
+      ]
+    })
+
     app.listen(7886).then((srv) => {
       server = srv
       server.once('listening', () => {
@@ -90,7 +99,7 @@ describe('@feathersjs/socketio', () => {
           }
         })
       })
-    })
+    }).catch(done)
 
     socket = io('http://localhost:7886')
     socket.on('connect', () => done())


### PR DESCRIPTION
This pull request updates `@feathersjs/socketio` to reinitialize `hooks` after overriding the `setup` method.

Closes #2717