### PR TITLE
feat(cli): Adding ClientService to CLI

### DIFF
--- a/packages/cli/src/app/templates/client.tpl.ts
+++ b/packages/cli/src/app/templates/client.tpl.ts
@@ -4,7 +4,7 @@ import { AppGeneratorContext } from '../index'
 
 const template = ({}: AppGeneratorContext) =>
   `import { feathers } from '@feathersjs/feathers'
-import type { Service, TransportConnection, Params } from '@feathersjs/feathers'
+import type { Paginated, ClientService, TransportConnection, Params } from '@feathersjs/feathers'
 
 export interface ServiceTypes {
   // A mapping of client side services

--- a/packages/cli/src/app/templates/tsconfig.json.tpl.ts
+++ b/packages/cli/src/app/templates/tsconfig.json.tpl.ts
@@ -17,8 +17,7 @@ export const generate = (ctx: AppGeneratorContext) =>
             rootDir: `./${lib}`,
             declaration: true,
             strict: true,
-            esModuleInterop: true,
-            skipLibCheck: true
+            esModuleInterop: true
           },
           include: [lib],
           exclude: ['test']

--- a/packages/cli/src/authentication/templates/knex.tpl.ts
+++ b/packages/cli/src/authentication/templates/knex.tpl.ts
@@ -31,9 +31,10 @@ export async function down(knex: Knex): Promise<void> {
     table.dropColumn('email')
     table.dropColumn('password')`
           : `    
-    table.dropColumn('${name}Id')`
+    table.dropColumn('${name}Id')
+    `
       )
-      .join(',\n')}
+      .join('\n')}
   })
 }
 `

--- a/packages/cli/src/service/templates/client.tpl.ts
+++ b/packages/cli/src/service/templates/client.tpl.ts
@@ -3,14 +3,26 @@ import { ServiceGeneratorContext } from '../index'
 
 const schemaImports = ({ upperName, folder, fileName }: ServiceGeneratorContext) => `import type {
   ${upperName}Data,
+  ${upperName}Patch,
   ${upperName}Result,
   ${upperName}Query,
 } from './services/${folder.join('/')}/${fileName}.schema'
 
-export * from './services/${folder.join('/')}/${fileName}.schema'`
+export type {
+  ${upperName}Data,
+  ${upperName}Patch,
+  ${upperName}Result,
+  ${upperName}Query,
+}`
 
 const declarationTemplate = ({ path, upperName }: ServiceGeneratorContext) =>
-  `  '${path}': Service<${upperName}Result, ${upperName}Data, Params<${upperName}Query>>`
+  `  '${path}': ClientService<
+    ${upperName}Result,
+    ${upperName}Data,
+    ${upperName}Patch,
+    Paginated<${upperName}Result>, 
+    Params<${upperName}Query>
+  >`
 
 const toClientFile = toFile<ServiceGeneratorContext>(({ lib }) => [lib, 'client.ts'])
 

--- a/packages/cli/test/generators.test.ts
+++ b/packages/cli/test/generators.test.ts
@@ -116,6 +116,7 @@ describe('@feathersjs/cli', () => {
       })
 
       it('compiles successfully', async () => {
+        console.log(cwd)
         if (language === 'ts' && framework === 'koa') {
           const testResult = await context.pinion.exec('npm', ['run', 'compile'], { cwd })
 

--- a/packages/cli/test/generators.test.ts
+++ b/packages/cli/test/generators.test.ts
@@ -116,7 +116,6 @@ describe('@feathersjs/cli', () => {
       })
 
       it('compiles successfully', async () => {
-        console.log(cwd)
         if (language === 'ts' && framework === 'koa') {
           const testResult = await context.pinion.exec('npm', ['run', 'compile'], { cwd })
 

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -26,6 +26,33 @@ export interface ServiceOptions {
   routeParams?: { [key: string]: any }
 }
 
+export interface ClientService<
+  Result = any,
+  Data = Partial<Result>,
+  PatchData = Data,
+  FindResult = Paginated<Result>,
+  P = Params
+> {
+  find(params?: P): Promise<FindResult>
+
+  get(id: Id, params?: P): Promise<Result>
+
+  create(data: Data[], params?: P): Promise<Result[]>
+  create(data: Data, params?: P): Promise<Result>
+
+  update(id: Id, data: Data, params?: P): Promise<Result>
+  update(id: NullableId, data: Data, params?: P): Promise<Result | Result[]>
+  update(id: null, data: Data, params?: P): Promise<Result[]>
+
+  patch(id: NullableId, data: PatchData, params?: P): Promise<Result | Result[]>
+  patch(id: Id, data: PatchData, params?: P): Promise<Result>
+  patch(id: null, data: PatchData, params?: P): Promise<Result[]>
+
+  remove(id: NullableId, params?: P): Promise<Result | Result[]>
+  remove(id: Id, params?: P): Promise<Result>
+  remove(id: null, params?: P): Promise<Result[]>
+}
+
 export interface ServiceMethods<T = any, D = Partial<T>, P = Params> {
   find(params?: P): Promise<T | T[]>
 


### PR DESCRIPTION
This pull request adds a `ClientService` interface and to the generated application client.

Also closes https://github.com/feathersjs/feathers/issues/2734