### PR TITLE
feat(cli): Add custom environment variable support to generated application

### DIFF
--- a/packages/cli/src/app/templates/config.tpl.ts
+++ b/packages/cli/src/app/templates/config.tpl.ts
@@ -12,6 +12,14 @@ const defaultConfig = ({}: AppGeneratorContext) => ({
   }
 })
 
+const customEnvironment = {
+  port: {
+    __name: 'PORT',
+    __format: 'number'
+  },
+  host: 'HOSTNAME'
+}
+
 const testConfig = {
   port: 8998
 }
@@ -20,3 +28,4 @@ export const generate = (ctx: AppGeneratorContext) =>
   generator(ctx)
     .then(writeJSON(defaultConfig, toFile('config', 'default.json')))
     .then(writeJSON(testConfig, toFile('config', 'test.json')))
+    .then(writeJSON(customEnvironment, toFile('config', 'custom-environment-variables.json')))

--- a/packages/cli/src/authentication/templates/config.tpl.ts
+++ b/packages/cli/src/authentication/templates/config.tpl.ts
@@ -3,44 +3,55 @@ import { generator, toFile, mergeJSON } from '@feathershq/pinion'
 import { AuthenticationGeneratorContext } from '../index'
 
 export const generate = (ctx: AuthenticationGeneratorContext) =>
-  generator(ctx).then(
-    mergeJSON<AuthenticationGeneratorContext>(({ authStrategies }) => {
-      const authentication: any = {
-        entity: ctx.entity,
-        service: ctx.service,
-        secret: crypto.randomBytes(24).toString('base64'),
-        authStrategies: ['jwt'],
-        jwtOptions: {
-          header: {
-            typ: 'access'
-          },
-          audience: 'https://yourdomain.com',
-          algorithm: 'HS256',
-          expiresIn: '1d'
-        }
-      }
-
-      if (authStrategies.includes('local')) {
-        authentication.authStrategies.push('local')
-        authentication.local = {
-          usernameField: 'email',
-          passwordField: 'password'
-        }
-      }
-
-      const oauthStrategies = authStrategies.filter((name) => name !== 'local')
-
-      if (oauthStrategies.length) {
-        authentication.oauth = oauthStrategies.reduce((oauth, name) => {
-          oauth[name] = {
-            key: '<Client ID>',
-            secret: '<Client secret>'
+  generator(ctx)
+    .then(
+      mergeJSON<AuthenticationGeneratorContext>(({ authStrategies }) => {
+        const authentication: any = {
+          entity: ctx.entity,
+          service: ctx.service,
+          secret: crypto.randomBytes(24).toString('base64'),
+          authStrategies: ['jwt'],
+          jwtOptions: {
+            header: {
+              typ: 'access'
+            },
+            audience: 'https://yourdomain.com',
+            algorithm: 'HS256',
+            expiresIn: '1d'
           }
+        }
 
-          return oauth
-        }, {} as any)
-      }
+        if (authStrategies.includes('local')) {
+          authentication.authStrategies.push('local')
+          authentication.local = {
+            usernameField: 'email',
+            passwordField: 'password'
+          }
+        }
 
-      return { authentication }
-    }, toFile('config', 'default.json'))
-  )
+        const oauthStrategies = authStrategies.filter((name) => name !== 'local')
+
+        if (oauthStrategies.length) {
+          authentication.oauth = oauthStrategies.reduce((oauth, name) => {
+            oauth[name] = {
+              key: '<Client ID>',
+              secret: '<Client secret>'
+            }
+
+            return oauth
+          }, {} as any)
+        }
+
+        return { authentication }
+      }, toFile('config', 'default.json'))
+    )
+    .then(
+      mergeJSON<AuthenticationGeneratorContext>(
+        {
+          authentication: {
+            secret: 'FEATHERS_SECRET'
+          }
+        },
+        toFile('config', 'custom-environment-variables.json')
+      )
+    )


### PR DESCRIPTION
This adds a `custom-environment-variables.json` file to the generated application that allows to set environment variables in the app configuration.