### PR TITLE
fix(authentication-oauth): Fix oAuth origin and error handling

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -71,11 +71,11 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     const { redirect, origins = this.app.get('origins') } = this.authentication.configuration.oauth
 
     if (Array.isArray(origins)) {
-      const referer = params?.headers?.referer || ''
+      const referer = params?.headers?.referer || origins[0]
       const allowedOrigin = origins.find((current) => referer.toLowerCase().startsWith(current.toLowerCase()))
 
       if (!allowedOrigin) {
-        throw new NotAuthenticated(`Referer "${referer || '[header not available]'}" not allowed.`)
+        throw new NotAuthenticated(`Referer "${referer}" is not allowed.`)
       }
 
       return allowedOrigin

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -78,6 +78,9 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
     )
     assert.equal(redirect, 'https://feathersjs.com#access_token=testing')
 
+    redirect = await strategy.getRedirect({ accessToken: 'testing' }, {})
+    assert.equal(redirect, 'https://feathersjs.com#access_token=testing')
+
     redirect = await strategy.getRedirect(
       { accessToken: 'testing' },
       {
@@ -110,7 +113,7 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
           }
         ),
       {
-        message: 'Referer "https://example.com" not allowed.'
+        message: 'Referer "https://example.com" is not allowed.'
       }
     )
   })


### PR DESCRIPTION
This pull request fixes the oAuth `origins` handling when no `Referer` header is set and setting the redirect properly when an oAuth error happens.