### PR TITLE
feat(feathers): add defineHooks utility

### DIFF
--- a/packages/feathers/src/hooks.ts
+++ b/packages/feathers/src/hooks.ts
@@ -14,7 +14,8 @@ import {
   FeathersService,
   HookMap,
   AroundHookFunction,
-  HookFunction
+  HookFunction,
+  Application
 } from './declarations'
 import { defaultServiceArguments, getHookMethods } from './service'
 
@@ -212,4 +213,8 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
   }
 
   return service
+}
+
+export const defineHooks = <A = Application, S = Service>(hooks: HookMap<A, S>) => {
+  return hooks
 }


### PR DESCRIPTION
I love these `define*` utility function so much! Wether it's vues `defineComponent` [feathers-pinia example](https://github.com/marshallswain/feathers-pinia/blob/main/example/components/HelloWorld.vue#L59), vites `defineConfig` [feathers dove docs vitepress example](https://github.com/feathersjs/feathers/blob/dove-docs/docs/.vitepress/config.ts#L47) or other configs.

The implementation seems simple and therefore useless but the DX while using it, is soooo nice!
It's a convenient way to provide type safety and hassle free autocompletion.

### Reasons why they are nice and should be used and promoted extensively:

1. It's nice for anonymous hooks (see screenshot). No explicit `(context: HookContext<A, S>)` needed.
It also captures typos at compile time. Even for named hooks it's pretty useful. Even for a plain javascript implementation, it's an improvement!
See:
<img width="647" alt="Bildschirmfoto 2022-09-23 um 22 07 11" src="https://user-images.githubusercontent.com/22286818/192051047-e32066c3-850d-4263-875f-b6b8f3ffa488.png">
2. With the dove implementation: depending on the `Service` methods, we get autocompletion for custom method names for free:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/22286818/192053647-e725005f-41f6-47e3-bdd2-e0d7770a666d.png">

This is brought to you by:
```ts
// see https://github.com/feathersjs/feathers/blob/dove-docs/packages/feathers/src/declarations.ts#L358
type HookMethodMap<A, S> = {
  [L in keyof S]?: SelfOrArray<HookFunction<A, S>>
} & { all?: SelfOrArray<HookFunction<A, S>> }
```
3. (more like 2.1.) A custom service does only support a few methods (e.g. only `create`). Why should we add hooks for other `NotImpleted` methods of this service? Throw a compilation error and remove these hooks for the custom service!
4. jsdocs. Imagine the builtin types of feathers have jsdoc comments. Something like this:
<img width="464" alt="Bildschirmfoto 2022-09-23 um 22 50 37" src="https://user-images.githubusercontent.com/22286818/192054545-1066045d-79d6-433b-9e77-fddf871138a1.png">
You also get them in the `defineHooks` util for free:
<img width="533" alt="Bildschirmfoto 2022-09-23 um 22 52 21" src="https://user-images.githubusercontent.com/22286818/192054798-92366b6a-e2b8-409c-9fe4-21c83f22e0e8.png">


### Summary

If you ask me, these LOC for `defineHooks` could be spent more wasteful. What do you think? Should we use them all over the place and add them to the cli templates and to the docs?

# ‼️ Last but not least (please read):

On a fresh cli generated project using this utility:
![image](https://user-images.githubusercontent.com/22286818/192055952-d8238a5c-b317-4601-b1c0-0bff4ce61465.png)
Sorry for german error. I think it's clear what it's about even without knowing a german word. Maybe my implementation of `defineHooks` is not quite right? See that it passes for `authenticate` but not for `resolveAll`. Should I open a separate issue?
Used packages:
```
    "@feathersjs/authentication": "^5.0.0-pre.29",
    "@feathersjs/authentication-local": "^5.0.0-pre.29",
    "@feathersjs/authentication-oauth": "^5.0.0-pre.29",
    "@feathersjs/configuration": "^5.0.0-pre.29",
    "@feathersjs/errors": "^5.0.0-pre.29",
    "@feathersjs/feathers": "^5.0.0-pre.29",
    "@feathersjs/knex": "^5.0.0-pre.29",
    "@feathersjs/koa": "^5.0.0-pre.29",
    "@feathersjs/schema": "^5.0.0-pre.29",
    "@feathersjs/socketio": "^5.0.0-pre.29",
    "@feathersjs/transport-commons": "^5.0.0-pre.29",
    "knex": "^2.3.0",
    "koa-static": "^5.0.0",
    "pg": "^8.8.0",
    "winston": "^3.8.2"
```