### PR TITLE
fix(authentication-oauth): Prefix handling in OAuth

### DIFF
--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -33,9 +33,9 @@ export const oauth =
 
     const grantConfig = getGrantConfig(authService)
     const serviceOptions = getServiceOptions(authService, oauthOptions)
-    const servicePath = grantConfig.defaults?.prefix ?
-      `${grantConfig.defaults.prefix}/oauth/:provider` :
-      'oauth/:provider'
+    const servicePath = grantConfig.defaults?.prefix
+      ? `${grantConfig.defaults.prefix}/oauth/:provider`
+      : 'oauth/:provider'
 
     app.use(servicePath, new OAuthService(authService, oauthOptions), serviceOptions)
 

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -4,7 +4,7 @@ import { resolveDispatch } from '@feathersjs/schema'
 
 import { OAuthStrategy, OAuthProfile } from './strategy'
 import { redirectHook, OAuthService } from './service'
-import { getServiceOptions, OauthSetupSettings } from './utils'
+import { getGrantConfig, getServiceOptions, OauthSetupSettings } from './utils'
 
 const debug = createDebug('@feathersjs/authentication-oauth')
 
@@ -30,17 +30,22 @@ export const oauth =
       linkStrategy: 'jwt',
       ...settings
     }
+
+    const grantConfig = getGrantConfig(authService)
     const serviceOptions = getServiceOptions(authService, oauthOptions)
+    const servicePath = grantConfig.defaults?.prefix ?
+      `${grantConfig.defaults.prefix}/oauth/:provider` :
+      'oauth/:provider'
 
-    app.use('oauth/:provider', new OAuthService(authService, oauthOptions), serviceOptions)
+    app.use(servicePath, new OAuthService(authService, oauthOptions), serviceOptions)
 
-    const oauthService = app.service('oauth/:provider')
+    const oauthService = app.service(servicePath)
 
     oauthService.hooks({
       around: { all: [resolveDispatch(), redirectHook()] }
     })
 
     if (typeof oauthService.publish === 'function') {
-      app.service('oauth/:provider').publish(() => null)
+      app.service(servicePath).publish(() => null)
     }
   }

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -34,7 +34,7 @@ export const oauth =
     const grantConfig = getGrantConfig(authService)
     const serviceOptions = getServiceOptions(authService, oauthOptions)
     const servicePath = grantConfig.defaults?.prefix
-      ? `${grantConfig.defaults.prefix}/oauth/:provider`
+      ? `${grantConfig.defaults.prefix}/:provider`
       : 'oauth/:provider'
 
     app.use(servicePath, new OAuthService(authService, oauthOptions), serviceOptions)

--- a/packages/authentication-oauth/src/index.ts
+++ b/packages/authentication-oauth/src/index.ts
@@ -33,9 +33,7 @@ export const oauth =
 
     const grantConfig = getGrantConfig(authService)
     const serviceOptions = getServiceOptions(authService, oauthOptions)
-    const servicePath = grantConfig.defaults?.prefix
-      ? `${grantConfig.defaults.prefix}/:provider`
-      : 'oauth/:provider'
+    const servicePath = `${grantConfig.defaults.prefix || 'oauth'}/:provider`
 
     app.use(servicePath, new OAuthService(authService, oauthOptions), serviceOptions)
 


### PR DESCRIPTION
### Summary
OAuth service path ignores grant `default.prefix`. I am not sure if this is intentional but here's a proposed PR to fix it.

The issue is described here: https://github.com/feathersjs/feathers/issues/2031#issuecomment-1266538838