### PR TITLE
chore(build): Move npm package tarball folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,5 @@ dist/
 
 # TypeScript compiled files
 packages/**/lib
-packages/cli/test/*.tgz
+packages/cli/test/build/*.tgz
 *.sqlite

--- a/packages/adapter-commons/package.json
+++ b/packages/adapter-commons/package.json
@@ -32,7 +32,7 @@
   "types": "lib/",
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -32,7 +32,7 @@
   "types": "lib/",
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/authentication-client/package.json
+++ b/packages/authentication-client/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/authentication-local/package.json
+++ b/packages/authentication-local/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/authentication-oauth/package.json
+++ b/packages/authentication-oauth/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "start": "ts-node test/app",
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -24,7 +24,7 @@ export const dependencyVersions = Object.keys(pkg.devDependencies as any)
   .reduce((acc, dep) => {
     const [, name] = dep.split('/')
 
-    acc[dep] = path.join(__dirname, `feathersjs-${name}-${lernaConfig.version}.tgz`)
+    acc[dep] = path.join(__dirname, 'build', `feathersjs-${name}-${lernaConfig.version}.tgz`)
 
     return acc
   }, {} as DependencyVersions)

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "NODE_CONFIG_DIR=./test/config mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -47,7 +47,7 @@
     "prepublish": "npm run compile",
     "version": "npm run write-version",
     "publish": "npm run reset-version",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/"
   },

--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -40,7 +40,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**/*.test.ts"
   },

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -40,7 +40,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts",
     "test": "npm run compile && npm run mocha"

--- a/packages/socketio-client/package.json
+++ b/packages/socketio-client/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts",
     "test": "npm run mocha"

--- a/packages/socketio/package.json
+++ b/packages/socketio/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"
   },

--- a/packages/transport-commons/package.json
+++ b/packages/transport-commons/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "prepublish": "npm run compile",
-    "pack": "npm pack --pack-destination ../cli/test",
+    "pack": "npm pack --pack-destination ../cli/test/build",
     "compile": "shx rm -rf lib/ && tsc && npm run pack",
     "test": "npm run mocha",
     "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts"


### PR DESCRIPTION
The package tarballs that are being tested were cluttering the `test/` folder. Moving them to `test/build/`.