### PR TITLE
fix(authentication): Improve logout and disconnect connection handling

### DIFF
--- a/packages/authentication/src/hooks/connection.ts
+++ b/packages/authentication/src/hooks/connection.ts
@@ -1,5 +1,4 @@
 import { HookContext, NextFunction } from '@feathersjs/feathers'
-import omit from 'lodash/omit'
 import { AuthenticationBase, ConnectionEvent } from '../core'
 
 export default (event: ConnectionEvent) => async (context: HookContext, next: NextFunction) => {
@@ -12,8 +11,6 @@ export default (event: ConnectionEvent) => async (context: HookContext, next: Ne
 
   if (connection) {
     const service = context.service as unknown as AuthenticationBase
-
-    Object.assign(connection, omit(result, 'accessToken', 'authentication'))
 
     await service.handleConnection(event, connection, result)
   }

--- a/packages/socketio/src/middleware.ts
+++ b/packages/socketio/src/middleware.ts
@@ -12,7 +12,7 @@ export interface FeathersSocket extends Socket {
 
 export const disconnect =
   (app: Application, getParams: ParamsGetter) => (socket: FeathersSocket, next: NextFunction) => {
-    socket.once('disconnect', () => app.emit('disconnect', getParams(socket)))
+    socket.on('disconnect', () => app.emit('disconnect', getParams(socket)))
     next()
   }
 


### PR DESCRIPTION
This pull request improves the connection handling to only assign and delete the `[entity]` and `authentication` properties to a connection and ensures that the entity and authentication information is removed on disconnect but still available in the `app.on('disconnect')` event handler.

Closes https://github.com/feathersjs/feathers/issues/2446
Closes https://github.com/feathersjs/feathers/issues/1995