### PR TITLE
fix(cli): Only generate authentication setup when selected

### DIFF
--- a/packages/cli/src/app/templates/declarations.tpl.ts
+++ b/packages/cli/src/app/templates/declarations.tpl.ts
@@ -9,9 +9,12 @@ import { ApplicationConfiguration } from './schemas/configuration'
 
 export { NextFunction }
 
+// The types for app.get(name) and app.set(name)
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Configuration extends ApplicationConfiguration {}
 
 // A mapping of service names to types. Will be extended in service files.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServiceTypes {}
 
 // The application instance type that will be used everywhere else

--- a/packages/cli/src/authentication/index.ts
+++ b/packages/cli/src/authentication/index.ts
@@ -19,6 +19,11 @@ export interface AuthenticationGeneratorContext extends ServiceGeneratorContext 
 export type AuthenticationGeneratorArguments = FeathersBaseContext &
   Partial<Pick<AuthenticationGeneratorContext, 'service' | 'authStrategies' | 'entity' | 'path'>>
 
+export const localTemplate = (authStrategies: string[], content: string) =>
+  authStrategies.includes('local') ? content : ''
+export const oauthTemplate = (authStrategies: string[], content: string) =>
+  authStrategies.filter((s) => s !== 'local').length > 0 ? content : ''
+
 export const prompts = (ctx: AuthenticationGeneratorArguments) => [
   {
     type: 'checkbox',

--- a/packages/cli/src/authentication/templates/authentication.tpl.ts
+++ b/packages/cli/src/authentication/templates/authentication.tpl.ts
@@ -1,13 +1,13 @@
 import { generator, before, toFile } from '@feathershq/pinion'
 import { injectSource, renderSource } from '../../commons'
-import { AuthenticationGeneratorContext } from '../index'
+import { AuthenticationGeneratorContext, localTemplate, oauthTemplate } from '../index'
 
 const template = ({
   authStrategies
 }: AuthenticationGeneratorContext) => /* ts */ `import { AuthenticationService, JWTStrategy } from '@feathersjs/authentication'
-import { LocalStrategy } from '@feathersjs/authentication-local'
-import { OAuthStrategy } from '@feathersjs/authentication-oauth'
-import { oauth } from '@feathersjs/authentication-oauth'
+${localTemplate(authStrategies, `import { LocalStrategy } from '@feathersjs/authentication-local'`)}
+${oauthTemplate(authStrategies, `import { oauth, OAuthStrategy } from '@feathersjs/authentication-oauth'`)}
+
 import type { Application } from './declarations'
 
 declare module './declarations' {
@@ -30,7 +30,7 @@ export const authentication = (app: Application) => {
     .join('\n')}
 
   app.use('authentication', authentication)
-  app.configure(oauth())
+  ${oauthTemplate(authStrategies, `app.configure(oauth())`)}
 }
 `
 

--- a/packages/cli/src/authentication/templates/client.test.tpl.ts
+++ b/packages/cli/src/authentication/templates/client.test.tpl.ts
@@ -1,6 +1,6 @@
 import { generator, toFile } from '@feathershq/pinion'
 import { renderSource } from '../../commons'
-import { AuthenticationGeneratorContext } from '../index'
+import { AuthenticationGeneratorContext, localTemplate } from '../index'
 
 const template = ({
   authStrategies,
@@ -11,14 +11,10 @@ const template = ({
 import axios from 'axios'
 
 import rest from '@feathersjs/rest-client'
-${
-  authStrategies.includes('local')
-    ? `import authenticationClient from '@feathersjs/authentication-client'`
-    : ''
-}
+${localTemplate(authStrategies, `import authenticationClient from '@feathersjs/authentication-client'`)}
 import { app } from '../${lib}/app'
 import { createClient } from '../${lib}/client' 
-${authStrategies.includes('local') ? `import type { ${upperName}Data } from '../${lib}/client'` : ''}
+${localTemplate(authStrategies, `import type { ${upperName}Data } from '../${lib}/client'`)}
 
 const port = app.get('port')
 const appUrl = \`http://\${app.get('host')}:\${port}\`
@@ -38,9 +34,9 @@ describe('application client tests', () => {
     assert.ok(client)
   })
 
-  ${
-    authStrategies.includes('local')
-      ? `
+  ${localTemplate(
+    authStrategies,
+    `
   it('creates and authenticates a user with email and password', async () => {
     const userData: ${upperName}Data = {
       email: 'someone@example.com',
@@ -63,8 +59,7 @@ describe('application client tests', () => {
     // Remove the test user on the server
     await app.service('users').remove(user.${type === 'mongodb' ? '_id' : 'id'})
   })`
-      : ''
-  }
+  )}
 })
 `
 

--- a/packages/cli/src/authentication/templates/schema.json.tpl.ts
+++ b/packages/cli/src/authentication/templates/schema.json.tpl.ts
@@ -1,6 +1,6 @@
 import { generator, toFile, when } from '@feathershq/pinion'
 import { renderSource } from '../../commons'
-import { AuthenticationGeneratorContext } from '../index'
+import { AuthenticationGeneratorContext, localTemplate } from '../index'
 
 const template = ({
   camelName,
@@ -10,7 +10,7 @@ const template = ({
   relative
 }: AuthenticationGeneratorContext) => /* ts */ `import { resolve, querySyntax, getValidator, getDataValidator } from '@feathersjs/schema'
 import type { FromSchema } from '@feathersjs/schema'
-${authStrategies.includes('local') ? `import { passwordHash } from '@feathersjs/authentication-local'` : ''}
+${localTemplate(authStrategies, `import { passwordHash } from '@feathersjs/authentication-local'`)}
 
 import type { HookContext } from '${relative}/declarations'
 import { dataValidator, queryValidator } from '${relative}/schemas/validators'
@@ -20,7 +20,7 @@ export const ${camelName}Schema = {
   $id: '${upperName}',
   type: 'object',
   additionalProperties: false,
-  required: [ '${type === 'mongodb' ? '_id' : 'id'}'${authStrategies.includes('local') ? ", 'email'" : ''} ],
+  required: [ '${type === 'mongodb' ? '_id' : 'id'}'${localTemplate(authStrategies, ", 'email'")} ],
   properties: {
     ${type === 'mongodb' ? '_id' : 'id'}: {
       type: '${type === 'mongodb' ? 'string' : 'number'}'
@@ -54,7 +54,7 @@ export type ${upperName}Data = FromSchema<typeof ${camelName}DataSchema>
 export const ${camelName}DataValidator = getDataValidator(${camelName}DataSchema, dataValidator)
 export const ${camelName}DataResolver = resolve<${upperName}Data, HookContext>({
   properties: {
-    ${authStrategies.includes('local') ? `password: passwordHash({ strategy: 'local' })` : ''}
+    ${localTemplate(authStrategies, `password: passwordHash({ strategy: 'local' })`)}
   }
 })
 

--- a/packages/cli/src/authentication/templates/schema.typebox.tpl.ts
+++ b/packages/cli/src/authentication/templates/schema.typebox.tpl.ts
@@ -1,6 +1,6 @@
 import { generator, toFile, when } from '@feathershq/pinion'
 import { renderSource } from '../../commons'
-import { AuthenticationGeneratorContext } from '../index'
+import { AuthenticationGeneratorContext, localTemplate } from '../index'
 
 export const template = ({
   camelName,
@@ -11,7 +11,7 @@ export const template = ({
 }: AuthenticationGeneratorContext) => /* ts */ `import { resolve } from '@feathersjs/schema'
 import { Type, getDataValidator, getValidator, querySyntax } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
-${authStrategies.includes('local') ? `import { passwordHash } from '@feathersjs/authentication-local'` : ''}
+${localTemplate(authStrategies, `import { passwordHash } from '@feathersjs/authentication-local'`)}
 
 import type { HookContext } from '${relative}/declarations'
 import { dataValidator, queryValidator } from '${relative}/schemas/validators'
@@ -50,7 +50,7 @@ export type ${upperName}Data = Static<typeof ${camelName}DataSchema>
 export const ${camelName}DataValidator = getDataValidator(${camelName}DataSchema, dataValidator)
 export const ${camelName}DataResolver = resolve<${upperName}, HookContext>({
   properties: {
-    ${authStrategies.includes('local') ? `password: passwordHash({ strategy: 'local' })` : ''}
+    ${localTemplate(authStrategies, `password: passwordHash({ strategy: 'local' })`)}
   }
 })
 


### PR DESCRIPTION
Only adds Local and oAuth authentication code when it is selected. Also adds ESLint rules to not blow away empty interfaces in `declarations.ts` so that we can still extend them.

Closes https://github.com/feathersjs/feathers/issues/2810