### PR TITLE
docs allow copying Typebox example code

### DIFF
--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -6,6 +6,8 @@ outline: deep
 
 `@feathersjs/typebox` allows to define JSON schemas with [TypeBox](https://github.com/sinclairzx81/typebox), a JSON schema type builder with static type resolution for TypeScript.
 
+[[toc]]
+
 <BlockQuote type="info" label="Note">
 
 For additional information also see the [TypeBox documentation](https://github.com/sinclairzx81/typebox/blob/master/readme.md#contents).
@@ -39,249 +41,575 @@ TypeBox provides a set of functions that allow you to compose JSON Schema simila
 
 ### Standard
 
-The following table lists the standard TypeBox types.
+These are the standard TypeBox types. Each section shows equivalent code in three formats:
+
+- TypeBox
+- TypeScript type
+- JSON Schema
+
+#### Primitive Types
+
+##### Any
 
 ```js
-┌────────────────────────────────┬─────────────────────────────┬────────────────────────────────┐
-│ TypeBox                        │ TypeScript                  │ JSON Schema                    │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Any()           │ type T = any                │ const T = { }                  │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Unknown()       │ type T = unknown            │ const T = { }                  │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.String()        │ type T = string             │ const T = {                    │
-│                                │                             │   type: 'string'               │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Number()        │ type T = number             │ const T = {                    │
-│                                │                             │   type: 'number'               │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Integer()       │ type T = number             │ const T = {                    │
-│                                │                             │   type: 'integer'              │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Boolean()       │ type T = boolean            │ const T = {                    │
-│                                │                             │   type: 'boolean'              │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Null()          │ type T = null               │ const T = {                    │
-│                                │                             │    type: 'null'                │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.RegEx(/foo/)    │ type T = string             │ const T = {                    │
-│                                │                             │    type: 'string',             │
-│                                │                             │    pattern: 'foo'              │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Literal(42)     │ type T = 42                 │ const T = {                    │
-│                                │                             │    const: 42,                  │
-│                                │                             │    type: 'number'              │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Array(          │ type T = number[]           │ const T = {                    │
-│   Type.Number()                │                             │   type: 'array',               │
-│ )                              │                             │   items: {                     │
-│                                │                             │     type: 'number'             │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
-│   x: Type.Number(),            │   x: number,                │   type: 'object',              │
-│   y: Type.Number()             │   y: number                 │   properties: {                │
-│ })                             │ }                           │      x: {                      │
-│                                │                             │        type: 'number'          │
-│                                │                             │      },                        │
-│                                │                             │      y: {                      │
-│                                │                             │        type: 'number'          │
-│                                │                             │      }                         │
-│                                │                             │   },                           │
-│                                │                             │   required: ['x', 'y']         │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Tuple([         │ type T = [number, number]   │ const T = {                    │
-│   Type.Number(),               │                             │   type: 'array',               │
-│   Type.Number()                │                             │   items: [{                    │
-│ ])                             │                             │      type: 'number'            │
-│                                │                             │    }, {                        │
-│                                │                             │      type: 'number'            │
-│                                │                             │    }],                         │
-│                                │                             │    additionalItems: false,     │
-│                                │                             │    minItems: 2,                │
-│                                │                             │    maxItems: 2                 │
-│                                │                             │ }                              │
-│                                │                             │                                │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ enum Foo {                     │ enum Foo {                  │ const T = {                    │
-│   A,                           │   A,                        │   anyOf: [{                    │
-│   B                            │   B                         │     type: 'number',            │
-│ }                              │ }                           │     const: 0                   │
-│                                │                             │   }, {                         │
-│ const T = Type.Enum(Foo)       │ type T = Foo                │     type: 'number',            │
-│                                │                             │     const: 1                   │
-│                                │                             │   }]                           │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.KeyOf(          │ type T = keyof {            │ const T = {                    │
-│   Type.Object({                │   x: number,                │   anyOf: [{                    │
-│     x: Type.Number(),          │   y: number                 │     type: 'string',            │
-│     y: Type.Number()           │ }                           │     const: 'x'                 │
-│   })                           │                             │   }, {                         │
-│ )                              │                             │     type: 'string',            │
-│                                │                             │     const: 'y'                 │
-│                                │                             │   }]                           │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Union([         │ type T = string | number    │ const T = {                    │
-│   Type.String(),               │                             │   anyOf: [{                    │
-│   Type.Number()                │                             │      type: 'string'            │
-│ ])                             │                             │   }, {                         │
-│                                │                             │      type: 'number'            │
-│                                │                             │   }]                           │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Intersect([     │ type T = {                  │ const T = {                    │
-│   Type.Object({                │   x: number                 │   type: 'object',              │
-│     x: Type.Number()           │ } & {                       │   properties: {                │
-│   }),                          │   y: number                 │     x: {                       │
-│   Type.Object({                │ }                           │       type: 'number'           │
-│     y: Type.Number()           │                             │     },                         │
-│   })                           │                             │     y: {                       │
-│ ])                             │                             │       type: 'number'           │
-│                                │                             │     }                          │
-│                                │                             │   },                           │
-│                                │                             │   required: ['x', 'y']         │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Never()         │ type T = never              │ const T = {                    │
-│                                │                             │   allOf: [{                    │
-│                                │                             │     type: 'boolean',           │
-│                                │                             │     const: false               │
-│                                │                             │   }, {                         │
-│                                │                             │     type: 'boolean',           │
-│                                │                             │     const: true                │
-│                                │                             │   }]                           │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Record(         │ type T = Record<            │ const T = {                    │
-│   Type.String(),               │   string,                   │   type: 'object',              │
-│   Type.Number()                │   number,                   │   patternProperties: {         │
-│ )                              │ >                           │     '^.*$': {                  │
-│                                │                             │       type: 'number'           │
-│                                │                             │     }                          │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Partial(        │ type T = Partial<{          │ const T = {                    │
-│   Type.Object({                │   x: number,                │   type: 'object',              │
-│     x: Type.Number(),          │   y: number                 │   properties: {                │
-│     y: Type.Number()           | }>                          │     x: {                       │
-│   })                           │                             │       type: 'number'           │
-│ )                              │                             │     },                         │
-│                                │                             │     y: {                       │
-│                                │                             │       type: 'number'           │
-│                                │                             │     }                          │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Required(       │ type T = Required<{         │ const T = {                    │
-│   Type.Object({                │   x?: number,               │   type: 'object',              │
-│     x: Type.Optional(          │   y?: number                │   properties: {                │
-│       Type.Number()            | }>                          │     x: {                       │
-│     ),                         │                             │       type: 'number'           │
-│     y: Type.Optional(          │                             │     },                         │
-│       Type.Number()            │                             │     y: {                       │
-│     )                          │                             │       type: 'number'           │
-│   })                           │                             │     }                          │
-│ )                              │                             │   },                           │
-│                                │                             │   required: ['x', 'y']         │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Pick(           │ type T = Pick<{             │ const T = {                    │
-│   Type.Object({                │   x: number,                │   type: 'object',              │
-│     x: Type.Number(),          │   y: number                 │   properties: {                │
-│     y: Type.Number()           | }, 'x'>                     │     x: {                       │
-│   }), ['x']                    │                             │       type: 'number'           │
-│ )                              │                             │     }                          │
-│                                │                             │   },                           │
-│                                │                             │   required: ['x']              │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Omit(           │ type T = Omit<{             │ const T = {                    │
-│   Type.Object({                │   x: number,                │   type: 'object',              │
-│     x: Type.Number(),          │   y: number                 │   properties: {                │
-│     y: Type.Number()           | }, 'x'>                     │     y: {                       │
-│   }), ['x']                    │                             │       type: 'number'           │
-│ )                              │                             │     }                          │
-│                                │                             │   },                           │
-│                                │                             │   required: ['y']              │
-│                                │                             │ }                              │
-│                                │                             │                                │
-└────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
+const T = Type.Any()
+```
+
+```js
+type T = any 
+```
+
+```js
+const T = { }
+```
+
+##### Unknown
+
+```js
+const T = Type.Unknown()
+```
+
+```js
+type T = unknown 
+```
+
+```js
+const T = { }
+```
+
+##### String
+
+```js
+const T = Type.String()
+```
+
+```js
+type T = string 
+```
+
+```js
+const T = {
+  type: 'string'
+}
+```
+
+##### Number
+
+```js
+const T = Type.Number()
+```
+
+```js
+type T = number
+```
+
+```js
+const T = {
+  type: 'number'
+}
+```
+
+##### Integer
+
+```js
+const T = Type.Integer()
+```
+
+```js
+type T = number
+```
+
+```js
+const T = {
+  type: 'integer'
+}
+```
+
+##### Boolean
+
+```js
+const T = Type.Boolean()
+```
+
+```js
+type T = boolean
+```
+
+```js
+const T = {
+  type: 'boolean'
+}
+```
+
+##### Null
+
+```js
+const T = Type.Null()
+```
+
+```js
+type T = null
+```
+
+```js
+const T = {
+  type: 'null'
+}
+```
+
+##### Literal
+
+```js
+const T = Type.Literal(42)
+```
+
+```js
+type T = 42
+```
+
+```js
+const T = {
+  const: 42,
+  type: 'number'
+}
+```
+
+#### Object & Array Types
+
+##### RegEx
+
+```js
+const T = Type.RegEx(/foo/)
+```
+
+```js
+type T = string
+```
+
+```js
+const T = {
+  type: 'string',
+  pattern: 'foo'
+}
+```
+
+##### Array
+
+```js
+const T = Type.Array( Type.Number() )
+```
+
+```js
+type T = number[]
+```
+
+```js
+const T = {
+  type: 'array',
+  items: {
+    type: 'number'
+  }
+}
+```
+
+##### Object
+
+```js
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+})
+```
+
+```js
+type T = {
+  x: number,
+  y: number,
+}
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    x: {
+      type: 'number'
+    },
+    y: {
+      type: 'number'
+    },
+  },
+  required: ['x', 'y'],
+}
+```
+
+##### Tuple
+
+```js
+const T = Type.Tuple([
+  Type.Number(),
+  Type.Number(),
+])
+```
+
+```js
+type T = [number, number]
+```
+
+```js
+const T = {
+  type: 'array',
+  items: [
+    { type: 'number' },
+    { type: 'number' },
+  ],
+  additionalItems: false,
+  minItems: 2,
+  maxItems: 2,
+}
+```
+
+##### Enum
+
+```js
+enum Foo {
+  A,
+  B,
+}
+const T = Type.Enum(Foo)
+```
+
+```js
+enum Foo {
+  A,
+  B,
+}
+type T = Foo
+```
+
+```js
+const T = {
+  anyOf: [
+    { type: 'number', const: 0 },
+    { type: 'number', const: 1 },
+  ]
+}
+```
+
+
+#### Utility Types
+
+
+##### KeyOf
+
+```js
+const T = Type.KeyOf(
+  Type.Object({
+    x: Type.Number(),
+    y: Type.Number(),
+  })
+)
+```
+
+```js
+type T = keyof {
+  x: number,
+  y: number,
+}
+```
+
+```js
+const T = {
+  anyOf: [
+    { type: 'string', const: 'x' },
+    { type: 'string', const: 'y' },
+  ]
+}
+```
+
+##### Union
+
+```js
+const T = Type.Union({
+  Type.String(),
+  Type.Number,
+})
+```
+
+```js
+type T = string | number
+```
+
+```js
+const T = {
+  anyOf: [
+    { type: 'string' },
+    { type: 'string' },
+  ]
+}
+```
+
+##### Intersect
+
+```js
+const T = Type.Intersect([
+  Type.Object({
+    x: Type.Number()
+  }),
+  Type.Object({
+    y: Type.Number()
+  }),
+])
+```
+
+```js
+type T = { x: number } & { y: number }
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    x: { type: 'number' },
+    y: { type: 'number' },
+  },
+  required: ['x', 'y'],
+}
+```
+
+##### Never
+
+```js
+const T = Type.Never()
+```
+
+```js
+type T = never
+```
+
+```js
+const T = {
+  allOf: [
+    { type: 'boolean', const: false },
+    { type: 'boolean', const: true },
+  ]
+}
+```
+
+##### Record
+
+```js
+const T = Type.Record( Type.String(), Type.Number() )
+```
+
+```js
+type T = Record<string, number>
+```
+
+```js
+const T = {
+  type: 'object',
+  patternProperties: {
+    '^.*$': {
+      type: 'number',
+    }
+  },
+}
+```
+
+##### Partial
+
+```js
+const T = Type.Partial(
+  Type.Object({
+    x: Type.Number(),
+    y: Type.Number(),
+  })
+)
+```
+
+```js
+type T = Partial<{
+  x: number,
+  y: number,
+}>
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    x: { type: 'number' },
+    y: { type: 'number' },
+  }
+}
+```
+
+##### Required
+
+```js
+const T = Type.Required(
+  Type.Object({
+    x: Type.Optional( Type.Number() ),
+    y: Type.Optional( Type.Number() ),
+  })
+)
+```
+
+```js
+type T = Required<{
+  x?: number,
+  y?: number,
+}>
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    x: { type: 'number' },
+    y: { type: 'number' },
+  },
+  required: ['x', 'y'],
+}
+```
+
+##### Pick
+
+```js
+const T = Type.Pick(
+  Type.Object({
+    x: Type.Number(),
+    y: Type.Number(),
+  }),
+  ['x']
+)
+```
+
+```js
+type T = Pick<{
+  x: number,
+  y: number,
+}, 'x'>
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    x: { type: 'number' },
+  },
+  required: ['x'],
+}
+```
+
+##### Omit
+
+```js
+const T = Type.Omit(
+  Type.Object({
+    x: Type.Number(),
+    y: Type.Number(),
+  }),
+  ['x']
+)
+```
+
+```js
+type T = Omit<{
+  x: number,
+  y: number,
+}, 'x'>
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    y: { type: 'number' },
+  },
+  required: ['y'],
+}
 ```
 
 ### Modifiers
 
 TypeBox provides modifiers that can be applied to an objects properties. This allows for `optional` and `readonly` to be applied to that property. The following table illustates how they map between TypeScript and JSON Schema.
 
+#### Optional
+
 ```js
-┌────────────────────────────────┬─────────────────────────────┬────────────────────────────────┐
-│ TypeBox                        │ TypeScript                  │ JSON Schema                    │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
-│   name: Type.Optional(         │   name?: string             │   type: 'object',              │
-│     Type.String()              │ }                           │   properties: {                │
-│   )                            │                             │      name: {                   │
-│ })  	                         │                             │        type: 'string'          │
-│                                │                             │      }                         │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
-│   name: Type.Readonly(         │   readonly name: string     │   type: 'object',              │
-│     Type.String()              │ }                           │   properties: {                │
-│   )                            │                             │     name: {                    │
-│ })  	                         │                             │       type: 'string'           │
-│                                │                             │     }                          │
-│                                │                             │   },                           │
-│                                │                             │   required: ['name']           │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
-│   name: Type.ReadonlyOptional( │   readonly name?: string    │   type: 'object',              │
-│     Type.String()              │ }                           │   properties: {                │
-│   )                            │                             │     name: {                    │
-│ })  	                         │                             │       type: 'string'           │
-│                                │                             │     }                          │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-└────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
+const T = Type.Object({
+  name: Type.Optional( Type.String() )
+})
+```
+
+```js
+type T = {
+  name?: string
+}
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string'
+    },
+  },
+}
+```
+
+#### Readonly
+
+```js
+const T = Type.Object({
+  name: Type.Readonly( Type.String() )
+})
+```
+
+```js
+type T = {
+  readonly name: string
+}
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+    },
+  },
+  required: ['name'],
+}
+```
+
+#### ReadonlyOptional
+
+```js
+const T = Type.Object({
+  name: Type.ReadonlyOptional( Type.String() )
+})
+```
+
+```js
+type T = {
+  readonly name?: string
+}
+```
+
+```js
+const T = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+    },
+  },
+}
 ```
 
 ### Options
@@ -303,62 +631,129 @@ const T = Type.Array(Type.Integer(), { minItems: 5 })
 
 In addition to JSON schema types, TypeBox provides several extended types that allow for the composition of `function` and `constructor` types. These additional types are not valid JSON Schema and will not validate using typical JSON Schema validation. However, these types can be used to frame JSON schema and describe callable interfaces that may receive JSON validated data. These types are as follows.
 
+#### Constructor
+
 ```js
-┌────────────────────────────────┬─────────────────────────────┬────────────────────────────────┐
-│ TypeBox                        │ TypeScript                  │ Extended Schema                │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Constructor([   │ type T = new (              │ const T = {                    │
-│   Type.String(),               │  arg0: string,              │   type: 'constructor'          │
-│   Type.Number()                │  arg1: number               │   parameters: [{               │
-│ ], Type.Boolean())             │ ) => boolean                │     type: 'string'             │
-│                                │                             │   }, {                         │
-│                                │                             │     type: 'number'             │
-│                                │                             │   }],                          │
-│                                │                             │   return: {                    │
-│                                │                             │     type: 'boolean'            │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Function([      │ type T = (                  │ const T = {                    │
-|   Type.String(),               │  arg0: string,              │   type : 'function',           │
-│   Type.Number()                │  arg1: number               │   parameters: [{               │
-│ ], Type.Boolean())             │ ) => boolean                │     type: 'string'             │
-│                                │                             │   }, {                         │
-│                                │                             │     type: 'number'             │
-│                                │                             │   }],                          │
-│                                │                             │   return: {                    │
-│                                │                             │     type: 'boolean'            │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Uint8Array()    │ type T = Uint8Array         │ const T = {                    │
-│                                │                             │   type: 'object',              │
-│                                │                             │   specialized: 'Uint8Array'    │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Promise(        │ type T = Promise<string>    │ const T = {                    │
-│   Type.String()                │                             │   type: 'promise',             │
-│ )                              │                             │   item: {                      │
-│                                │                             │     type: 'string'             │
-│                                │                             │   }                            │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Undefined()     │ type T = undefined          │ const T = {                    │
-│                                │                             │   type: 'object',              │
-│                                │                             │   specialized: 'Undefined'     │
-│                                │                             │ }                              │
-│                                │                             │                                │
-├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Void()          │ type T = void               │ const T = {                    │
-│                                │                             │   type: 'null'                 │
-│                                │                             │ }                              │
-│                                │                             │                                │
-└────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
+const T = Type.Constructor([
+  Type.String(),
+  Type.Number(),
+], Type.Boolean())
+```
+
+```js
+type T = new (
+  arg0: string,
+  arg1: number,
+) => boolean
+```
+
+```js
+const T = {
+  type: 'constructor',
+  parameters: [
+    { type: 'string' },
+    { type: 'number' },
+  ],
+  return {
+    type: 'boolean',
+  },
+}
+```
+
+#### Function
+
+```js
+const T = Type.Function([
+  Type.String(),
+  Type.Number(),
+], Type.Boolean())
+```
+
+```js
+type T = {
+  arg0: string,
+  arg1: number,
+} => boolean
+```
+
+```js
+const T = {
+  type: 'function',
+  parameters: [
+    { type: 'string' },
+    { type: 'number' },
+  ],
+  return {
+    type: 'boolean',
+  },
+}
+```
+
+#### Uint8Array
+
+```js
+const T = Type.Uint8Array()
+```
+
+```js
+type T = Uint8Array
+```
+
+```js
+const T = {
+  type: 'object',
+  specialized: 'Uint8Array',
+}
+```
+
+#### Promise
+
+```js
+const T = Type.Promise( Type.String() )
+```
+
+```js
+type T = Promise<string>
+```
+
+```js
+const T = {
+  type: 'promise',
+  item: { type: 'string' },
+}
+```
+
+#### Undefined
+
+```js
+const T = Type.Undefined()
+```
+
+```js
+type T = undefined
+```
+
+```js
+const T = {
+  type: 'object',
+  specialized: 'Undefined',
+}
+```
+
+#### Void
+
+```js
+const T = Type.Void()
+```
+
+```js
+type T = void
+```
+
+```js
+const T = {
+  type: 'null'
+}
 ```
 
 ### Reference


### PR DESCRIPTION
Instead of the wonky table, this organizes the code into sections that can be navigated in the table of contents and sidebar.  It was impossible to copy text out of the other table, before.

Since this is a long doc, I've added the table of contents for mobile devices at the to of the page:

![Screen Shot 2022-10-21 at 1 07 49 AM](https://user-images.githubusercontent.com/128857/197134437-345a7750-6b46-465d-a031-960507b8f2cd.jpg)

Here's what the code sections look like:

![Screen Shot 2022-10-21 at 1 08 51 AM](https://user-images.githubusercontent.com/128857/197134644-8ac373d8-7510-42d4-ae00-c5e72b079af4.jpg)
