### PR TITLE
fix(cli): Ensure code injection points are not code style dependent

### DIFF
--- a/packages/cli/src/authentication/templates/client.tpl.ts
+++ b/packages/cli/src/authentication/templates/client.tpl.ts
@@ -10,7 +10,7 @@ const toClientFile = toFile<ServiceGeneratorContext>(({ lib }) => [lib, 'client'
 
 export const generate = async (ctx: ServiceGeneratorContext) =>
   generator(ctx)
-    .then(injectSource(importTemplate, after("from '@feathersjs/feathers'"), toClientFile))
+    .then(injectSource(importTemplate, after('import authenticationClient'), toClientFile))
     .then(
       when(
         ({ language }) => language === 'ts',

--- a/packages/cli/src/service/templates/client.tpl.ts
+++ b/packages/cli/src/service/templates/client.tpl.ts
@@ -50,7 +50,7 @@ export const generate = async (ctx: ServiceGeneratorContext) =>
     .then(
       when(
         (ctx) => ctx.language === 'ts',
-        injectSource(importTemplate, after("from '@feathersjs/feathers'"), toClientFile),
+        injectSource(importTemplate, after('import authenticationClient'), toClientFile),
         injectSource(methodsTemplate, before('\nexport interface ServiceTypes'), toClientFile),
         injectSource(declarationTemplate, after('export interface ServiceTypes'), toClientFile)
       )


### PR DESCRIPTION
So that if you e.g. change your Prettier configuration or add ESLint code injection will still continue to work in most cases.

Closes https://github.com/feathersjs/feathers/issues/2829