### PR TITLE
fix(cli): Fix MongoDB connection database name parsing

### DIFF
--- a/packages/cli/src/connection/templates/mongodb.tpl.ts
+++ b/packages/cli/src/connection/templates/mongodb.tpl.ts
@@ -14,7 +14,7 @@ declare module './declarations' {
 
 export const mongodb = (app: Application) => {
   const connection = app.get('mongodb') as string
-  const database = connection.substring(connection.lastIndexOf('/') + 1)
+  const database = new URL("mongodb://localhost").pathname.substring(1)
   const mongoClient = MongoClient.connect(connection)
     .then(client => client.db(database))
 


### PR DESCRIPTION
From the feathers discord:

The current parsing method fails the following MongoDB connection string:
```
mongodb://user:P%40ss@localhost:27017/databaseName?authSource=admin
```

Where it parses `databaseName?authSource=admin` as the database name instead of just `databaseName`.

The following change should parse all database connection strings correctly.

There don't seem to be any open issues related to this, and it isn't dependent on PRs in other repos.