### PR TITLE
fix(docs) fix ecosystem page ssr mismatch

### DIFF
--- a/docs/ecosystem/index.md
+++ b/docs/ecosystem/index.md
@@ -20,6 +20,8 @@ Watch the [FeathersJS Playlist on YouTube](https://www.youtube.com/playlist?list
 
 This is a curated list of feathers packages. You can sort by various criteria. Core packages are hidden by default.
 
-<Suspense>
-  <Packages class="mt-4" />
-</Suspense>
+<ClientOnly>
+  <Suspense>
+    <Packages class="mt-4" />
+  </Suspense>
+</ClientOnly>


### PR DESCRIPTION
Wraps the `Packages` component in a `ClientOnly` component.  Fixes the problem where if you first-load the Ecosystem page (refresh on the ecosystem page or navigate directly to it from an external site) when you navigate away, the page doesn't update.  Navigation should work as expected once this PR is merged.
