### PR TITLE
docs(theme): show DatabaseSelect on all pages

### DIFF
--- a/docs/.vitepress/components/DatabaseBlock.vue
+++ b/docs/.vitepress/components/DatabaseBlock.vue
@@ -6,11 +6,11 @@ defineProps({
   inline: String
 })
 
-const activeGlobalId = useGlobalDb()
+const activeGlobalDb = useGlobalDb()
 </script>
 
 <template>
-  <component :is="inline ? 'span' : 'div'" :class="{ hidden: globalId !== activeGlobalId }">
+  <component :is="inline ? 'span' : 'div'" :class="{ hidden: globalId !== activeGlobalDb }">
     <slot />
   </component>
 </template>

--- a/docs/.vitepress/theme/FeathersLayout.vue
+++ b/docs/.vitepress/theme/FeathersLayout.vue
@@ -40,11 +40,9 @@ onMounted(() => {
                 if (activeGlobalDb.value !== val) {
                   activeGlobalDb.value = val
                   document.body.setAttribute('data-db', val)
-                  // works around an SSR bug where the select resets to its SSR-hydrated state after a route change.
-                  window.location = window.location
                 }
               },
-              showOnRoutePrefix: ['/guides/basics'],
+              // showOnRoutePrefix: ['/guides'],
               options: [
                 { value: 'sql', text: 'SQL' },
                 { value: 'mongodb', text: 'MongoDB' }


### PR DESCRIPTION
- Always shows the DatabaseSelect.  
- Fixes bugs in production with content not changing when the selected database is changed.