### PR TITLE
chore(docs): Fix Guides url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ cd my-new-app
 $ npm run dev
 ```
 
-To learn more about Feathers visit the website at [feathersjs.com](http://feathersjs.com) or jump right into [the Feathers guides](http://feathersjs.com/guides).
+To learn more about Feathers visit the website at [feathersjs.com](http://feathersjs.com) or jump right into [the Feathers guides](https://docs.feathersjs.com/guides/).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ cd my-new-app
 $ npm run dev
 ```
 
-To learn more about Feathers visit the website at [feathersjs.com](http://feathersjs.com) or jump right into [the Feathers guides](https://docs.feathersjs.com/guides/).
+To learn more about Feathers visit the website at [feathersjs.com](http://feathersjs.com) or jump right into [the Feathers guides](https://dove.feathersjs.com/guides/).
 
 ## Documentation
 


### PR DESCRIPTION
old url is broken, updating to new one:

https://feathersjs.com/guides/ -> https://docs.feathersjs.com/guides/

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/dove/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
 
Updating broken url

- [ ] Are there any open issues that are related to this?

No

- [ ] Is this PR dependent on PRs in other repos?

No
