### PR TITLE
chore(tests): Add tracing information to debug flaky CLI test

### DIFF
--- a/packages/cli/src/authentication/templates/knex.tpl.ts
+++ b/packages/cli/src/authentication/templates/knex.tpl.ts
@@ -48,8 +48,8 @@ export const generate = (ctx: AuthenticationGeneratorContext) =>
         toFile(
           toFile<AuthenticationGeneratorContext>('migrations', () => {
             // Probably not great but it works to align with the Knex migration file format
-            // We add 2 seconds so that the migrations run in the correct order
-            const migrationDate = new Date(Date.now() + 2000)
+            // We add a few seconds so that the migrations run in the correct order
+            const migrationDate = new Date(Date.now() + 10000)
               .toISOString()
               .replace(/\D/g, '')
               .substring(0, 14)

--- a/packages/cli/test/generators.test.ts
+++ b/packages/cli/test/generators.test.ts
@@ -14,6 +14,7 @@ import { combinate, dependencyVersions } from './utils'
 import { generate as generateApp } from '../lib/app'
 import { generate as generateConnection } from '../lib/connection'
 import { generate as generateService } from '../lib/service'
+import { listAllFiles } from '@feathershq/pinion/lib/utils'
 
 const matrix = {
   language: ['js', 'ts'] as const,
@@ -39,25 +40,32 @@ describe('@feathersjs/cli', () => {
       before(async () => {
         cwd = await mkdtemp(path.join(os.tmpdir(), name + '-'))
         console.log(`\nGenerating test application to\n${cwd}\n\n`)
-        context = await generateApp(
-          getContext<AppGeneratorContext>(
-            {
-              name,
-              framework,
-              language,
-              dependencyVersions,
-              lib: 'src',
-              description: 'A Feathers test app',
-              packager: 'npm',
-              database: 'sqlite',
-              connectionString: `${name}.sqlite`,
-              transports: ['rest', 'websockets'],
-              authStrategies: ['local', 'github'],
-              schema: 'typebox'
-            },
-            { cwd }
+
+        try {
+          context = await generateApp(
+            getContext<AppGeneratorContext>(
+              {
+                name,
+                framework,
+                language,
+                dependencyVersions,
+                lib: 'src',
+                description: 'A Feathers test app',
+                packager: 'npm',
+                database: 'sqlite',
+                connectionString: `${name}.sqlite`,
+                transports: ['rest', 'websockets'],
+                authStrategies: ['local', 'github'],
+                schema: 'typebox'
+              },
+              { cwd }
+            )
           )
-        )
+        } catch (error) {
+          console.error(error.stack)
+          console.error((await listAllFiles(cwd)).join('\n'))
+          throw error
+        }
       })
 
       it('generated app with SQLite and passes tests', async () => {

--- a/packages/cli/test/generators.test.ts
+++ b/packages/cli/test/generators.test.ts
@@ -61,7 +61,7 @@ describe('@feathersjs/cli', () => {
               { cwd }
             )
           )
-        } catch (error) {
+        } catch (error: any) {
           console.error(error.stack)
           console.error((await listAllFiles(cwd)).join('\n'))
           throw error


### PR DESCRIPTION
For what they do the CLI tests are fairly solid but for some reason on GitHub actions it occasionally errors with an error related to the authentication migration file. My suspicion is that it is some weird timing issue so this pull request tries to fix that.