### PR TITLE
fix(cli): Update MongoDB connection string for node 17+

### DIFF
--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -32,7 +32,7 @@ There are two typical setup steps for using `@feathersjs/mongodb` in an applicat
 
 ### Connect to the Database
 
-Before using `@feathersjs/mongodb`, you'll need to create a connection to the database. This example connects to a MongoDB database similar to how the CLI-generated app connects. It uses `app.get('mongodb')` to read the connection string from `@feathersjs/configuration`. The connection string would be something similar to `mongodb://localhost:27017/my-app-dev` for local development or one provided by your database host.
+Before using `@feathersjs/mongodb`, you'll need to create a connection to the database. This example connects to a MongoDB database similar to how the CLI-generated app connects. It uses `app.get('mongodb')` to read the connection string from `@feathersjs/configuration`. The connection string would be something similar to `mongodb://127.0.0.1:27017/my-app-dev` for local development or one provided by your database host.
 
 Once the connection attempt has been started, the code uses `app.set('monodbClient', mongoClient)` to store the connection promise back into the config, which allows it to be looked up when initializing individual services.
 

--- a/packages/cli/src/connection/index.ts
+++ b/packages/cli/src/connection/index.ts
@@ -21,7 +21,7 @@ export type ConnectionGeneratorArguments = FeathersBaseContext &
 
 export const defaultConnectionString = (type: DatabaseType, name: string) => {
   const connectionStrings = {
-    mongodb: `mongodb://localhost:27017/${name}`,
+    mongodb: `mongodb://127.0.0.1:27017/${name}`,
     mysql: `mysql://root:@localhost:3306/${name}`,
     postgresql: `postgres://postgres:@localhost:5432/${name}`,
     sqlite: `${name}.sqlite`,

--- a/packages/cli/test/generators.test.ts
+++ b/packages/cli/test/generators.test.ts
@@ -73,7 +73,7 @@ describe('@feathersjs/cli', () => {
             {
               dependencyVersions,
               database: 'mongodb' as const,
-              connectionString: `mongodb://localhost:27017/${name}`
+              connectionString: `mongodb://127.0.0.1:27017/${name}`
             },
             { cwd }
           )


### PR DESCRIPTION
On Node version 17+, `localhost` gets converted to the IPV6 version `:::1`.  The MongoDB database doesn’t receive the connection.

This PR updates the default MongoDB connection string to use the IPV4 loopback address `127.0.0.1`, which restores the ability to connect to the MongoDB server.

One line in the docs was also updated.