### PR TITLE
fix(authentication-client): Do not cache authentication errors

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -134,7 +134,7 @@ export class AuthenticationClient {
       return type === 'logout' ? promise : promise.then(() => Promise.reject(error))
     }
 
-    return Promise.reject(error)
+    return this.reset().then(() => Promise.reject(error))
   }
 
   reAuthenticate(force = false, strategy?: string): Promise<AuthenticationResult> {


### PR DESCRIPTION
The problem was that anything other than `NotAuthenticated` errors did not reset the authentication promise so all subsequent requests would get the cached error and never get sent to the server.

Closes https://github.com/feathersjs/feathers/issues/1947
Closes https://github.com/feathersjs/feathers/issues/1787