### PR TITLE
fix(authentication-client): Improve socket reauthentication handling

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -67,18 +67,12 @@ export class AuthenticationClient {
   }
 
   handleSocket(socket: any) {
-    // Connection events happen on every reconnect
-    const connected = this.app.io ? 'connect' : 'open'
-    const disconnected = this.app.io ? 'disconnect' : 'disconnection'
-
-    socket.on(disconnected, () => {
-      const authPromise = new Promise((resolve) => socket.once(connected, (data: any) => resolve(data)))
-        // Only reconnect when `reAuthenticate()` or `authenticate()`
-        // has been called explicitly first
-        // Force reauthentication with the server
-        .then(() => (this.authenticated ? this.reAuthenticate(true) : null))
-
-      this.app.set('authentication', authPromise)
+    // When the socket disconnects and we are still authenticated, try to reauthenticate right away
+    // the websocket connection will handle timeouts and retries
+    socket.on('disconnect', () => {
+      if (this.authenticated) {
+        this.reAuthenticate(true)
+      }
     })
   }
 

--- a/packages/authentication-client/test/integration/socketio.test.ts
+++ b/packages/authentication-client/test/integration/socketio.test.ts
@@ -7,6 +7,7 @@ import socketioClient from '@feathersjs/socketio-client'
 import authClient from '../../src'
 import getApp from './fixture'
 import commonTests from './commons'
+import { AuthenticationResult } from '@feathersjs/authentication/lib'
 
 describe('@feathersjs/authentication-client Socket.io integration', () => {
   let app: Application
@@ -50,6 +51,35 @@ describe('@feathersjs/authentication-client Socket.io integration', () => {
     assert.strictEqual(dummy.user.email, user.email)
     assert.strictEqual(dummy.authentication.accessToken, accessToken)
     assert.strictEqual(dummy.headers.authorization, `Bearer ${accessToken}`)
+  })
+
+  it('reconnects after socket disconnection', async () => {
+    const user = { email: 'disconnecttest@example.com', password: 'alsosecret' }
+    const socket = io('http://localhost:9777', {
+      timeout: 500,
+      reconnection: true,
+      reconnectionDelay: 100
+    })
+    const client = feathers().configure(socketioClient(socket)).configure(authClient())
+
+    await app.service('users').create(user)
+    await client.authenticate({
+      strategy: 'local',
+      ...user
+    })
+
+    const onLogin = new Promise<AuthenticationResult>((resolve) => app.once('login', (data) => resolve(data)))
+
+    socket.once('disconnect', () => socket.connect())
+    socket.disconnect()
+
+    const {
+      authentication: { strategy }
+    } = await onLogin
+    const dummy = await client.service('dummy').find()
+
+    assert.strictEqual(strategy, 'jwt')
+    assert.strictEqual(dummy.user.email, user.email)
   })
 
   commonTests(


### PR DESCRIPTION
This pull request improves socket authentication handling by reAuthenticating right away when we are authenticated and the socket disconnects. The underlying websocket mechanism will handle timeouts and retries.

Closes https://github.com/feathersjs/feathers/issues/2142