### PR TITLE
fix(socketio): Disconnect socket on app disconnect event

### DIFF
--- a/packages/socketio/src/index.ts
+++ b/packages/socketio/src/index.ts
@@ -1,7 +1,7 @@
 import http from 'http'
 import { Server, ServerOptions } from 'socket.io'
 import { createDebug } from '@feathersjs/commons'
-import { Application } from '@feathersjs/feathers'
+import { Application, RealTimeConnection } from '@feathersjs/feathers'
 import { socket } from '@feathersjs/transport-commons'
 
 import { disconnect, params, authentication, FeathersSocket } from './middleware'
@@ -42,7 +42,7 @@ function configureSocketio(port?: any, options?: any, config?: any) {
     // Function that gets the connection
     const getParams = (socket: FeathersSocket) => socket.feathers
     // A mapping from connection to socket instance
-    const socketMap = new WeakMap()
+    const socketMap = new WeakMap<RealTimeConnection, FeathersSocket>()
     // Promise that resolves with the Socket.io `io` instance
     // when `setup` has been called (with a server)
     const done = new Promise((resolve) => {
@@ -67,7 +67,7 @@ function configureSocketio(port?: any, options?: any, config?: any) {
           if (!this.io) {
             const io = (this.io = new Server(port || server, options))
 
-            io.use(disconnect(app, getParams))
+            io.use(disconnect(app, getParams, socketMap))
             io.use(params(app, socketMap))
             io.use(authentication(app, getParams))
 

--- a/packages/socketio/test/index.test.ts
+++ b/packages/socketio/test/index.test.ts
@@ -241,6 +241,21 @@ describe('@feathersjs/socketio', () => {
     assert.ok(mySocket)
   })
 
+  it('app `disconnect` event disconnects socket (#2754)', (done) => {
+    const mySocket = io('http://localhost:7886?channel=dctest')
+
+    app.once('connection', (connection) => {
+      assert.strictEqual(connection.channel, 'dctest')
+      app.once('disconnect', (disconnection) => {
+        assert.strictEqual(disconnection.channel, 'dctest')
+        done()
+      })
+      app.emit('disconnect', connection)
+    })
+
+    assert.ok(mySocket)
+  })
+
   it('missing parameters in socket call works (#88)', (done) => {
     socket.emit('find', 'verify', (error: any, data: any) => {
       assert.ok(!error)

--- a/packages/socketio/test/index.test.ts
+++ b/packages/socketio/test/index.test.ts
@@ -246,10 +246,7 @@ describe('@feathersjs/socketio', () => {
 
     app.once('connection', (connection) => {
       assert.strictEqual(connection.channel, 'dctest')
-      app.once('disconnect', (disconnection) => {
-        assert.strictEqual(disconnection.channel, 'dctest')
-        done()
-      })
+      mySocket.once('disconnect', () => done())
       app.emit('disconnect', connection)
     })
 


### PR DESCRIPTION
This pull request ensures that a socket that is still connected will be disconnected on `app.emit('disconnect', connection)`. This is the case when e.g. a client token expires while they are still connected.

Closes https://github.com/feathersjs/feathers/issues/2754