### PR TITLE
fix(schema): Allow query schemas with no properties, error on unsupported types

### DIFF
--- a/packages/schema/test/json-schema.test.ts
+++ b/packages/schema/test/json-schema.test.ts
@@ -1,0 +1,42 @@
+import Ajv from 'ajv'
+import assert from 'assert'
+import { queryProperties, querySyntax } from '../src/json-schema'
+
+describe('@feathersjs/schema/json-schema', () => {
+  it('queryProperties errors for unsupported query types', () => {
+    assert.throws(
+      () =>
+        queryProperties({
+          something: {
+            type: 'object'
+          }
+        }),
+      {
+        message:
+          "Can not create query syntax schema for property 'something'. Only types string, number, integer, boolean, null are allowed."
+      }
+    )
+
+    assert.throws(
+      () =>
+        queryProperties({
+          otherThing: {
+            type: 'array'
+          }
+        }),
+      {
+        message:
+          "Can not create query syntax schema for property 'otherThing'. Only types string, number, integer, boolean, null are allowed."
+      }
+    )
+  })
+
+  it('querySyntax works with no properties', async () => {
+    const schema = {
+      type: 'object',
+      properties: querySyntax({})
+    }
+
+    new Ajv().compile(schema)
+  })
+})

--- a/packages/typebox/src/index.ts
+++ b/packages/typebox/src/index.ts
@@ -46,6 +46,7 @@ const arrayOfKeys = <T extends TObject>(type: T) => {
   const keys = Object.keys(type.properties)
   return Type.Unsafe<(keyof T['properties'])[]>({
     type: 'array',
+    maxItems: keys.length,
     items: {
       type: 'string',
       ...(keys.length > 0 ? { enum: keys } : {})

--- a/packages/typebox/src/index.ts
+++ b/packages/typebox/src/index.ts
@@ -1,5 +1,5 @@
 import { Type, TObject, TInteger, TOptional, TSchema, TIntersect, ObjectOptions } from '@sinclair/typebox'
-import { jsonSchema, Validator, DataValidatorMap, Ajv } from '@feathersjs/schema'
+import { jsonSchema, Validator, DataValidatorMap, Ajv, SUPPORTED_TYPES } from '@feathersjs/schema'
 
 export * from '@sinclair/typebox'
 export * from './default-schemas'
@@ -44,7 +44,13 @@ export function StringEnum<T extends string[]>(allowedValues: [...T]) {
 
 const arrayOfKeys = <T extends TObject>(type: T) => {
   const keys = Object.keys(type.properties)
-  return Type.Unsafe<(keyof T['properties'])[]>({ type: 'array', items: { type: 'string', enum: keys } })
+  return Type.Unsafe<(keyof T['properties'])[]>({
+    type: 'array',
+    items: {
+      type: 'string',
+      ...(keys.length > 0 ? { enum: keys } : {})
+    }
+  })
 }
 
 /**
@@ -102,8 +108,17 @@ type QueryProperty<T extends TSchema> = ReturnType<typeof queryProperty<T>>
 export const queryProperties = <T extends TObject>(definition: T) => {
   const properties = Object.keys(definition.properties).reduce((res, key) => {
     const result = res as any
+    const value = definition.properties[key]
 
-    result[key] = queryProperty(definition.properties[key])
+    if (value.$ref || !SUPPORTED_TYPES.includes(value.type)) {
+      throw new Error(
+        `Can not create query syntax schema for property '${key}'. Only types ${SUPPORTED_TYPES.join(
+          ', '
+        )} are allowed.`
+      )
+    }
+
+    result[key] = queryProperty(value)
 
     return result
   }, {} as { [K in keyof T['properties']]: QueryProperty<T['properties'][K]> })

--- a/packages/typebox/test/index.test.ts
+++ b/packages/typebox/test/index.test.ts
@@ -1,33 +1,77 @@
 import assert from 'assert'
 import { Ajv } from '@feathersjs/schema'
-import { querySyntax, Type, Static, defaultAppConfiguration, getDataValidator, getValidator } from '../src'
+import {
+  querySyntax,
+  Type,
+  Static,
+  defaultAppConfiguration,
+  getDataValidator,
+  getValidator,
+  queryProperties
+} from '../src'
 
 describe('@feathersjs/schema/typebox', () => {
-  it('querySyntax', async () => {
-    const schema = Type.Object({
-      name: Type.String(),
-      age: Type.Number()
-    })
-    const querySchema = querySyntax(schema)
+  describe('querySyntax', () => {
+    it('basics', async () => {
+      const schema = Type.Object({
+        name: Type.String(),
+        age: Type.Number()
+      })
+      const querySchema = querySyntax(schema)
 
-    type Query = Static<typeof querySchema>
+      type Query = Static<typeof querySchema>
 
-    const query: Query = {
-      name: 'Dave',
-      age: { $gt: 42, $in: [50, 51] },
-      $select: ['age', 'name'],
-      $sort: {
-        age: 1
+      const query: Query = {
+        name: 'Dave',
+        age: { $gt: 42, $in: [50, 51] },
+        $select: ['age', 'name'],
+        $sort: {
+          age: 1
+        }
       }
-    }
 
-    const validator = new Ajv().compile(querySchema)
-    let validated = (await validator(query)) as any as Query
+      const validator = new Ajv().compile(querySchema)
+      let validated = (await validator(query)) as any as Query
 
-    assert.ok(validated)
+      assert.ok(validated)
 
-    validated = (await validator({ ...query, something: 'wrong' })) as any as Query
-    assert.ok(!validated)
+      validated = (await validator({ ...query, something: 'wrong' })) as any as Query
+      assert.ok(!validated)
+    })
+
+    it('queryProperties errors for unsupported query types', () => {
+      assert.throws(
+        () =>
+          queryProperties(
+            Type.Object({
+              something: Type.Object({})
+            })
+          ),
+        {
+          message:
+            "Can not create query syntax schema for property 'something'. Only types string, number, integer, boolean, null are allowed."
+        }
+      )
+
+      assert.throws(
+        () =>
+          queryProperties(
+            Type.Object({
+              otherThing: Type.Array(Type.String())
+            })
+          ),
+        {
+          message:
+            "Can not create query syntax schema for property 'otherThing'. Only types string, number, integer, boolean, null are allowed."
+        }
+      )
+    })
+
+    it('querySyntax works with no properties', async () => {
+      const schema = querySyntax(Type.Object({}))
+
+      new Ajv().compile(schema)
+    })
   })
 
   it('defaultAppConfiguration', async () => {


### PR DESCRIPTION
This pull request fixes an issue in the `querySyntax` helpers for JSON schema and TypeBox where it threw an error when passing an empty schema (no properties) which should still be possible. It now also throws a more descriptive error when trying to create a query syntax helper for a non-primitive type which is currently not possible.