### PR TITLE
fix(schema): Check for undefined value in resolveQueryObjectId resolver

### DIFF
--- a/packages/mongodb/src/resolvers.ts
+++ b/packages/mongodb/src/resolvers.ts
@@ -19,6 +19,10 @@ export async function resolveQueryObjectId(
 ): Promise<IdQueryObject<ObjectId>>
 export async function resolveQueryObjectId(value: ObjectIdParam): Promise<ObjectId>
 export async function resolveQueryObjectId(value: ObjectIdParam | IdQueryObject<ObjectIdParam>) {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+
   if (typeof value === 'string' || typeof value === 'number' || value instanceof ObjectId) {
     return toObjectId(value)
   }

--- a/packages/mongodb/src/resolvers.ts
+++ b/packages/mongodb/src/resolvers.ts
@@ -19,7 +19,7 @@ export async function resolveQueryObjectId(
 ): Promise<IdQueryObject<ObjectId>>
 export async function resolveQueryObjectId(value: ObjectIdParam): Promise<ObjectId>
 export async function resolveQueryObjectId(value: ObjectIdParam | IdQueryObject<ObjectIdParam>) {
-  if (value === undefined || value === null) {
+  if (!value) {
     return undefined
   }
 

--- a/packages/mongodb/test/resolvers.test.ts
+++ b/packages/mongodb/test/resolvers.test.ts
@@ -25,8 +25,11 @@ describe('ObjectId resolvers', () => {
     assert.ok(oids.$ne instanceof ObjectId)
   })
 
-  it('resolveQueryObjectId with undefined value', async () => {
+  it('resolveQueryObjectId with falsey value', async () => {
     await resolveQueryObjectId(undefined)
-    assert.ok('Undefined value does not throw exception')
+    await resolveQueryObjectId(null)
+    await resolveQueryObjectId(0)
+
+    assert.ok('Falsey value does not throw exception')
   })
 })

--- a/packages/mongodb/test/resolvers.test.ts
+++ b/packages/mongodb/test/resolvers.test.ts
@@ -24,4 +24,9 @@ describe('ObjectId resolvers', () => {
     assert.ok(oids.$in && oids.$in[0] instanceof ObjectId)
     assert.ok(oids.$ne instanceof ObjectId)
   })
+
+  it('resolveQueryObjectId with undefined value', async () => {
+    await resolveQueryObjectId(undefined)
+    assert.ok('Undefined value does not throw exception')
+  })
 })


### PR DESCRIPTION
### Summary

Insures that a undefined or null field within the mongodb objectId resolver (resolveQueryObjectId) doesn't throw an exception and returns undefined. 
