### PR TITLE
fix(core): Allow services with not external methods

### DIFF
--- a/packages/feathers/src/service.ts
+++ b/packages/feathers/src/service.ts
@@ -63,7 +63,10 @@ export function wrapService(location: string, service: any, options: ServiceOpti
   const protoService = Object.create(service)
   const serviceOptions = normalizeServiceOptions(service, options)
 
-  if (Object.keys(serviceOptions.methods).length === 0 && typeof service.setup !== 'function') {
+  if (
+    Object.keys(serviceOptions.methods).length === 0 &&
+    ![...defaultServiceMethods, 'setup', 'teardown'].some((method) => typeof service[method] === 'function')
+  ) {
     throw new Error(`Invalid service object passed for path \`${location}\``)
   }
 

--- a/packages/feathers/test/application.test.ts
+++ b/packages/feathers/test/application.test.ts
@@ -165,6 +165,18 @@ describe('Feathers application', () => {
       )
     })
 
+    it('can register service with no external methods', async () => {
+      const dummyService = {
+        async create(data: any) {
+          return data
+        }
+      }
+
+      feathers().use('dummy', dummyService, {
+        methods: []
+      })
+    })
+
     it('can use a root level service', async () => {
       const app = feathers().use('/', {
         async get(id: string) {


### PR DESCRIPTION
We should be able to register services with no external methods (`methods` option is empty).