### PR TITLE
chore(docs): Add note about `methods` option

### DIFF
--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -107,6 +107,12 @@ app.use('messages', new MessageService(), {
 })
 ```
 
+<BlockQuote type="warning" label="Important">
+
+If the `methods` property is `undefined`, all standard methods will be enabled and accessibly externally.
+
+</BlockQuote>
+
 ## .unuse(path)
 
 `app.unuse(path)` unregisters an existing service on `path` and calls the services [.teardown method](./services.md#teardownapp-path) if it is implemented.

--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -109,7 +109,7 @@ app.use('messages', new MessageService(), {
 
 <BlockQuote type="warning" label="Important">
 
-If the `methods` property is `undefined`, all standard methods will be enabled and accessibly externally.
+If the `methods` property is `undefined`, all standard methods will be enabled and accessible externally.
 
 </BlockQuote>
 


### PR DESCRIPTION
Add warning that `undefined` `methods` property will enable all standard methods.
