### PR TITLE
refactor: Knexfile no longer relies on app

### DIFF
--- a/docs/guides/cli/knexfile.md
+++ b/docs/guides/cli/knexfile.md
@@ -2,10 +2,16 @@
 
 ## Migrations
 
-Migrations are a best practise for SQL databases to roll out and undo changes to the data model and are set up automatically with an SQL database connection. The generated `knexfile.ts` imports the [app object](./app.md) to establish the connection to the database. To run migration scripts for the connection from the [configuration environment](./configuration.md#environment-variables) use:
+Migrations are a best practise for SQL databases to roll out and undo changes to the data model and are set up automatically with an SQL database connection. The generated `knexfile.ts` imports the relevant [configuration](./default.json.md) to establish the connection to the database. To run migration scripts for the connection from the default [configuration environment](./configuration.md#environment-variables) use:
 
 ```
 npm run migrate
+```
+
+To run migration scripts for a specific environment add `NODE_ENV` to your environment variables. The following will use the values available in `config/default.json` merged with `config/prod.json`
+
+```
+NODE_ENV=prod npm run migrate
 ```
 
 To create a new migration, run

--- a/packages/cli/src/connection/templates/knex.tpl.ts
+++ b/packages/cli/src/connection/templates/knex.tpl.ts
@@ -28,12 +28,12 @@ const knexfile = ({
   language,
   database
 }: ConnectionGeneratorContext) => /* ts */ `// For more information about this file see https://dove.feathersjs.com/guides/cli/databases.html
-import { app } from './${lib}/app'
+import config from 'config'
 
 // Load our database connection info from the app configuration
-const config = app.get('${database}')
+const dbConfig = config.get('${database}') as Object
 
-${language === 'js' ? 'export default config' : 'module.exports = config'}
+${language === 'js' ? 'export default { ...dbConfig }' : 'module.exports = { ...dbConfig }'}
 `
 
 const importTemplate = ({ database }: ConnectionGeneratorContext) =>


### PR DESCRIPTION
### Summary

This PR comes after this [Discord thread](https://discord.com/channels/509848480760725514/1052720785132879893)

This solves the issue of Knex migrations relying on the Feathers app to load it's configuration. Currently any errors in the Feathers app will prevent Knex from running it's migrations. 