### PR TITLE
chore(knex): Add Knex error handler test

### DIFF
--- a/packages/knex/src/error-handler.ts
+++ b/packages/knex/src/error-handler.ts
@@ -65,7 +65,8 @@ export function errorHandler(error: any) {
     // NOTE: Error codes taken from
     // https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html
     // Omit query information
-    const messages = error.message.split('-')
+    const messages = (error.message || '').split('-')
+
     error.message = messages[messages.length - 1]
 
     switch (error.code.slice(0, 2)) {

--- a/packages/knex/test/error-handler.test.ts
+++ b/packages/knex/test/error-handler.test.ts
@@ -1,0 +1,65 @@
+import assert from 'assert'
+import { errorHandler } from '../src'
+
+describe('Knex Error handler', () => {
+  it('sqlState', () => {
+    assert.throws(
+      () =>
+        errorHandler({
+          sqlState: '#23503'
+        }),
+      {
+        name: 'BadRequest'
+      }
+    )
+  })
+
+  it('sqliteError', () => {
+    assert.throws(
+      () =>
+        errorHandler({
+          code: 'SQLITE_ERROR',
+          errno: 1
+        }),
+      {
+        name: 'BadRequest'
+      }
+    )
+    assert.throws(() => errorHandler({ code: 'SQLITE_ERROR', errno: 2 }), { name: 'Unavailable' })
+    assert.throws(() => errorHandler({ code: 'SQLITE_ERROR', errno: 3 }), { name: 'Forbidden' })
+    assert.throws(() => errorHandler({ code: 'SQLITE_ERROR', errno: 12 }), { name: 'NotFound' })
+    assert.throws(() => errorHandler({ code: 'SQLITE_ERROR', errno: 13 }), { name: 'GeneralError' })
+  })
+
+  it('postgresqlError', () => {
+    assert.throws(
+      () =>
+        errorHandler({
+          code: '22P02',
+          message: 'Key (id)=(1) is not present in table "users".',
+          severity: 'ERROR',
+          routine: 'ExecConstraints'
+        }),
+      {
+        name: 'NotFound'
+      }
+    )
+    assert.throws(
+      () =>
+        errorHandler({ code: '2874', message: 'Something', severity: 'ERROR', routine: 'ExecConstraints' }),
+      {
+        name: 'Forbidden'
+      }
+    )
+    assert.throws(
+      () =>
+        errorHandler({ code: '3D74', message: 'Something', severity: 'ERROR', routine: 'ExecConstraints' }),
+      {
+        name: 'Unprocessable'
+      }
+    )
+    assert.throws(() => errorHandler({ code: 'XYZ', severity: 'ERROR', routine: 'ExecConstraints' }), {
+      name: 'GeneralError'
+    })
+  })
+})


### PR DESCRIPTION
This adds a basic error handler test for the Knex adapter which was the only thing not covered by tests.