### PR TITLE
docs: use deep outline for typebox sidebar

### DIFF
--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -1,3 +1,7 @@
+---
+outline: deep
+---
+
 # TypeBox
 
 `@feathersjs/typebox` allows to define JSON schemas with [TypeBox](https://github.com/sinclairzx81/typebox), a JSON schema type builder with static type resolution for TypeScript.


### PR DESCRIPTION
Having the deep outline makes it much easier to navigate the massive TypeBox API. Mobile devices only see a short table of contents, but for larger screens, it’s much easier to see what’s available when the sidebar shows the full tree. Also, there’s so much in the document that it’s easy to get lost.  The deep outline solves that.

![Screenshot 2022-12-29 at 7 38 37 PM](https://user-images.githubusercontent.com/128857/210028976-0a2b7bb6-4839-4a3f-85ce-321a7ba1c65d.jpg)
