### PR TITLE
chore(docs): Fix a few typos

### DIFF
--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -975,7 +975,7 @@ const T = {
 
 ### Modifiers
 
-TypeBox provides modifiers that can be applied to an objects properties. This allows for `optional` and `readonly` to be applied to that property. The following table illustates how they map between TypeScript and JSON Schema.
+TypeBox provides modifiers that can be applied to an objects properties. This allows for `optional` and `readonly` to be applied to that property. The following table illustrates how they map between TypeScript and JSON Schema.
 
 #### Optional
 

--- a/docs/cookbook/authentication/revoke-jwt.md
+++ b/docs/cookbook/authentication/revoke-jwt.md
@@ -6,7 +6,7 @@ outline: deep
 
 By default a valid JWT can be used for as long as it is valid. To do a normal logout the client just "forgets" their JWT (usually by removing it from localStorage).
 
-To add the ability to revoke an access token so that it can be no longer used even if it is still valid [the authentication service](../../api/authentication/service.md) can be customized as folllows.
+To add the ability to revoke an access token so that it can be no longer used even if it is still valid [the authentication service](../../api/authentication/service.md) can be customized as follows.
 
 ## Basic example
 

--- a/docs/cookbook/general/client-test.md
+++ b/docs/cookbook/general/client-test.md
@@ -119,4 +119,4 @@ We first make a call on the *server* to create a new user. We then start up a se
 
 The individual tests remain unchanged except that the service calls are now made on the client (`client.service(...).create`) instead of on the server (`app.service(...).create`).
 
-The `describe('Run tests using client and server',` statement stops a new server and client from being created for each test. This results in the test module running noticeably faster, though the tests are now exposed to potential iteractions. You can remove the statement to isolate the tests from one another.
+The `describe('Run tests using client and server',` statement stops a new server and client from being created for each test. This results in the test module running noticeably faster, though the tests are now exposed to potential interactions. You can remove the statement to isolate the tests from one another.

--- a/docs/guides/cli/databases.md
+++ b/docs/guides/cli/databases.md
@@ -11,7 +11,7 @@ outline: deep
 
 <DatabaseBlock global-id="sql">
 
-Depending on the SQL database you selected, a `src/<database>.ts` file will be created that sets up a connection using [KnexJS](../../api/databases/knex.md). It uses the connection settings from the `<database>` [configuration value](./default.json.md.md) and exports a [configure function](./app.md#configure-functions) that initializes the database connection. The Knex connection object is then acessible wherever you have access to the [app object](./app.md) via
+Depending on the SQL database you selected, a `src/<database>.ts` file will be created that sets up a connection using [KnexJS](../../api/databases/knex.md). It uses the connection settings from the `<database>` [configuration value](./default.json.md.md) and exports a [configure function](./app.md#configure-functions) that initializes the database connection. The Knex connection object is then accessible wherever you have access to the [app object](./app.md) via
 
 ```ts
 const knex = app.get('<database>Client')

--- a/docs/guides/whats-new.md
+++ b/docs/guides/whats-new.md
@@ -313,7 +313,7 @@ When we say "state of the art", it's not hubris. The new Feathers CLI is built o
 - It just works™️ with existing npm packages. There's no need to make an EJS plugin for some custom helper using an obscure API. Just import the module and use it in your template.
 - Integrates with all existing TypeScript tooling. Hover over a variable and inspect the context like you would any TS code.
 
-Now that we have what we consider the best generator on the planet, we have some exciting future plans for the Feathers CLI, whicih we will announce in the future.
+Now that we have what we consider the best generator on the planet, we have some exciting future plans for the Feathers CLI, which we will announce in the future.
 
 You can read more about Pinion, [here](https://github.com/feathershq/pinion)
 
@@ -329,7 +329,7 @@ When you select `JavaScript` to generate an app, the CLI works some magic under 
 
 And we get to smile because the entire process is a work of art, thanks to the TypeScript team.
 
-For Feathers Maintainers, commiting to TypeScript means we only contribute to a single set of templates. and they get magically compiled - on the fly - to plain JavaScript when you want it.
+For Feathers Maintainers, committing to TypeScript means we only contribute to a single set of templates. and they get magically compiled - on the fly - to plain JavaScript when you want it.
 
 ### Shared Types
 


### PR DESCRIPTION
There are small typos in:
- docs/api/schema/typebox.md
- docs/cookbook/authentication/revoke-jwt.md
- docs/cookbook/general/client-test.md
- docs/guides/cli/databases.md
- docs/guides/whats-new.md

Fixes:
- Should read `which` rather than `whicih`.
- Should read `interactions` rather than `iteractions`.
- Should read `illustrates` rather than `illustates`.
- Should read `follows` rather than `folllows`.
- Should read `committing` rather than `commiting`.
- Should read `accessible` rather than `acessible`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md