### PR TITLE
chore(docs): Small fixes to schema documentation

### DIFF
--- a/docs/api/schema/schema.md
+++ b/docs/api/schema/schema.md
@@ -283,7 +283,7 @@ const dataValidator = getDataValidator(userDataSchema, dataValidator)
 
 ### getValidator
 
-`getValidator(definition, validator)` returns a single validator function for a TypeBox schema.
+`getValidator(definition, validator)` returns a single validator function for a JSON schema.
 
 ```ts
 import { querySyntax, Ajv, getValidator } from '@feathersjs/schema'

--- a/docs/api/schema/validators.md
+++ b/docs/api/schema/validators.md
@@ -14,7 +14,7 @@ Ajv and most other validation libraries are only used for ensuring data is valid
 
 ## Usage
 
-The following is the standard `validators.ts` file that sets up a validator for data and querys (for which string types will be coerced automatically). It also sets up a collection of additional formats using [ajv-formats](https://ajv.js.org/packages/ajv-formats.html). The validators in this file can be customized according to the [Ajv documentation](https://ajv.js.org/) and [its plugins](https://ajv.js.org/packages/). You can find the available Ajv options in the [Ajv class API docs](https://ajv.js.org/options.html).
+The following is the standard `validators.ts` file that sets up a validator for data and queries (for which string types will be coerced automatically). It also sets up a collection of additional formats using [ajv-formats](https://ajv.js.org/packages/ajv-formats.html). The validators in this file can be customized according to the [Ajv documentation](https://ajv.js.org/) and [its plugins](https://ajv.js.org/packages/). You can find the available Ajv options in the [Ajv class API docs](https://ajv.js.org/options.html).
 
 ```ts
 import { Ajv, addFormats } from '@feathersjs/schema'


### PR DESCRIPTION
### Summary

I spotted a couple of small issues when following the documentation so wanted to contribute with a PR to suggest fixes here:

Change typo `querys` to `queries`
Change validator reference from `TypeBox` to `JSON ` Schema on JSON Schema page

