### PR TITLE
fix(cli): Use correct package manager when installing an app

### DIFF
--- a/packages/cli/src/app/index.ts
+++ b/packages/cli/src/app/index.ts
@@ -200,7 +200,7 @@ export const generate = (ctx: AppGeneratorArguments) =>
           return addVersions(dependencies, dependencyVersions)
         },
         false,
-        ctx.packager
+        ({ packager }) => packager
       )
     )
     .then(
@@ -223,6 +223,6 @@ export const generate = (ctx: AppGeneratorArguments) =>
           return addVersions(devDependencies, dependencyVersions)
         },
         true,
-        ctx.packager
+        ({ packager }) => packager
       )
     )


### PR DESCRIPTION
The package manager name needs to be returned dynamically from the current, not the initial context.

Closes https://github.com/feathersjs/feathers/issues/2955