### PR TITLE
fix(generators): Add main schema to all validators

### DIFF
--- a/docs/api/schema/validators.md
+++ b/docs/api/schema/validators.md
@@ -49,7 +49,7 @@ export const queryValidator = addFormats(
 
 ## Validation functions
 
-A validation function takes data and validates them against a schema using a validator. They can be used with any validation library. Currently the `getDataValidator` and `getValidator` functions are available for:
+A validation function takes data and validates them against a schema using a validator. They can be used with any validation library. Currently the `getValidator` functions are available for:
 
 - [TypeBox schema](./typebox.md#validators) to validate a TypeBox definition using an Ajv validator instance
 - [JSON schema](./schema.md#validators) to validate a JSON schema object using an Ajv validator instance
@@ -64,7 +64,7 @@ The following hooks take a [validation function](#validation-functions) and vali
 
 ```ts
 import { Ajv, schemaHooks } from '@feathersjs/schema'
-import { Type, getDataValidator } from '@feathersjs/typebox'
+import { Type, getValidator } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
 import { dataValidator } from '../validators'
 
@@ -82,7 +82,7 @@ type User = Static<typeof userSchema>
 const userDataSchema = Type.Pick(userSchema, ['email', 'password'])
 
 // Returns validation functions for `create`, `update` and `patch`
-const userDataValidator = getDataValidator(userDataSchema, dataValidator)
+const userDataValidator = getValidator(userDataSchema, dataValidator)
 
 app.service('users').hooks({
   before: {

--- a/docs/guides/basics/schemas.md
+++ b/docs/guides/basics/schemas.md
@@ -50,11 +50,11 @@ First we need to update the `src/services/users/users.schema.js` file with the s
 
 <DatabaseBlock global-id="sql">
 
-```ts{2,17-18,33,43-53,81-85}
+```ts{2,17-18,34,44-54,82-86}
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import crypto from 'crypto'
 import { resolve } from '@feathersjs/schema'
-import { Type, getDataValidator, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
 import { passwordHash } from '@feathersjs/authentication-local'
 
@@ -73,6 +73,7 @@ export const userSchema = Type.Object(
   { $id: 'User', additionalProperties: false }
 )
 export type User = Static<typeof userSchema>
+export const userValidator = getValidator(userSchema, dataValidator)
 export const userResolver = resolve<User, HookContext>({})
 
 export const userExternalResolver = resolve<User, HookContext>({
@@ -90,7 +91,7 @@ export const userDataSchema = Type.Pick(
   }
 )
 export type UserData = Static<typeof userDataSchema>
-export const userDataValidator = getDataValidator(userDataSchema, dataValidator)
+export const userDataValidator = getValidator(userDataSchema, dataValidator)
 export const userDataResolver = resolve<User, HookContext>({
   password: passwordHash({ strategy: 'local' }),
   avatar: async (value, user) => {
@@ -111,7 +112,7 @@ export const userPatchSchema = Type.Partial(userSchema, {
   $id: 'UserPatch'
 })
 export type UserPatch = Static<typeof userPatchSchema>
-export const userPatchValidator = getDataValidator(userPatchSchema, dataValidator)
+export const userPatchValidator = getValidator(userPatchSchema, dataValidator)
 export const userPatchResolver = resolve<User, HookContext>({
   password: passwordHash({ strategy: 'local' })
 })
@@ -146,11 +147,11 @@ export const userQueryResolver = resolve<UserQuery, HookContext>({
 
 <DatabaseBlock global-id="mongodb">
 
-```ts{2,17-18,33,43-53,81-85}
+```ts{2,17-18,34,44-54,82-86}
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import crypto from 'crypto'
 import { resolve } from '@feathersjs/schema'
-import { Type, getDataValidator, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
 import { passwordHash } from '@feathersjs/authentication-local'
 
@@ -169,6 +170,7 @@ export const userSchema = Type.Object(
   { $id: 'User', additionalProperties: false }
 )
 export type User = Static<typeof userSchema>
+export const userValidator = getValidator(userSchema, dataValidator)
 export const userResolver = resolve<User, HookContext>({})
 
 export const userExternalResolver = resolve<User, HookContext>({
@@ -186,7 +188,7 @@ export const userDataSchema = Type.Pick(
   }
 )
 export type UserData = Static<typeof userDataSchema>
-export const userDataValidator = getDataValidator(userDataSchema, dataValidator)
+export const userDataValidator = getValidator(userDataSchema, dataValidator)
 export const userDataResolver = resolve<User, HookContext>({
   password: passwordHash({ strategy: 'local' }),
   avatar: async (value, user) => {
@@ -207,13 +209,13 @@ export const userPatchSchema = Type.Partial(userSchema, {
   $id: 'UserPatch'
 })
 export type UserPatch = Static<typeof userPatchSchema>
-export const userPatchValidator = getDataValidator(userPatchSchema, dataValidator)
+export const userPatchValidator = getValidator(userPatchSchema, dataValidator)
 export const userPatchResolver = resolve<User, HookContext>({
   password: passwordHash({ strategy: 'local' })
 })
 
 // Schema for allowed query properties
-export const userQueryProperties = Type.Pick(userSchema, ['id', 'email', 'githubId'])
+export const userQueryProperties = Type.Pick(userSchema, ['_id', 'email', 'githubId'])
 export const userQuerySchema = Type.Intersect(
   [
     querySyntax(userQueryProperties),
@@ -257,10 +259,10 @@ Update the `src/services/messages/messages.schema.js` file like this:
 
 <DatabaseBlock global-id="sql">
 
-```ts{2,8,15-17,23-26,38-44,48,57-60}
+```ts{2,8,15-17,24-27,39-45,58-61}
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { Type, getDataValidator, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
 
 import type { HookContext } from '../../declarations'
@@ -279,6 +281,7 @@ export const messageSchema = Type.Object(
   { $id: 'Message', additionalProperties: false }
 )
 export type Message = Static<typeof messageSchema>
+export const messageValidator = getValidator(messageSchema, dataValidator)
 export const messageResolver = resolve<Message, HookContext>({
   user: virtual(async (message, context) => {
     // Associate the user that sent the message
@@ -293,7 +296,7 @@ export const messageDataSchema = Type.Pick(messageSchema, ['text'], {
   $id: 'MessageData'
 })
 export type MessageData = Static<typeof messageDataSchema>
-export const messageDataValidator = getDataValidator(messageDataSchema, dataValidator)
+export const messageDataValidator = getValidator(messageDataSchema, dataValidator)
 export const messageDataResolver = resolve<Message, HookContext>({
   userId: async (_value, _message, context) => {
     // Associate the record with the id of the authenticated user
@@ -305,11 +308,11 @@ export const messageDataResolver = resolve<Message, HookContext>({
 })
 
 // Schema for updating existing entries
-export const messagePatchSchema = Type.Partial(messageDataSchema, {
+export const messagePatchSchema = Type.Partial(messageSchema, {
   $id: 'MessagePatch'
 })
 export type MessagePatch = Static<typeof messagePatchSchema>
-export const messagePatchValidator = getDataValidator(messagePatchSchema, dataValidator)
+export const messagePatchValidator = getValidator(messagePatchSchema, dataValidator)
 export const messagePatchResolver = resolve<Message, HookContext>({})
 
 // Schema for allowed query properties
@@ -336,10 +339,10 @@ export const messageQueryResolver = resolve<MessageQuery, HookContext>({})
 
 <DatabaseBlock global-id="mongodb">
 
-```ts{2,8,15-17,23-26,38-44,48,57-60}
+```ts{2,8,15-17,24-27,39-45,58-61}
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve, virtual } from '@feathersjs/schema'
-import { Type, getDataValidator, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
 
 import type { HookContext } from '../../declarations'
@@ -358,6 +361,7 @@ export const messageSchema = Type.Object(
   { $id: 'Message', additionalProperties: false }
 )
 export type Message = Static<typeof messageSchema>
+export const messageValidator = getValidator(messageSchema, dataValidator)
 export const messageResolver = resolve<Message, HookContext>({
   user: virtual(async (message, context) => {
     // Associate the user that sent the message
@@ -372,7 +376,7 @@ export const messageDataSchema = Type.Pick(messageSchema, ['text'], {
   $id: 'MessageData'
 })
 export type MessageData = Static<typeof messageDataSchema>
-export const messageDataValidator = getDataValidator(messageDataSchema, dataValidator)
+export const messageDataValidator = getValidator(messageDataSchema, dataValidator)
 export const messageDataResolver = resolve<Message, HookContext>({
   userId: async (_value, _message, context) => {
     // Associate the record with the id of the authenticated user
@@ -384,16 +388,16 @@ export const messageDataResolver = resolve<Message, HookContext>({
 })
 
 // Schema for updating existing entries
-export const messagePatchSchema = Type.Partial(messageDataSchema, {
+export const messagePatchSchema = Type.Partial(messageSchema, {
   $id: 'MessagePatch'
 })
 export type MessagePatch = Static<typeof messagePatchSchema>
-export const messagePatchValidator = getDataValidator(messagePatchSchema, dataValidator)
+export const messagePatchValidator = getValidator(messagePatchSchema, dataValidator)
 export const messagePatchResolver = resolve<Message, HookContext>({})
 
 // Schema for allowed query properties
 export const messageQueryProperties = Type.Pick(messageSchema,
-['_id', 'text', 'createdAt', 'userId']
+  ['_id', 'text', 'createdAt', 'userId']
 )
 export const messageQuerySchema = Type.Intersect(
   [

--- a/docs/guides/cli/service.schemas.md
+++ b/docs/guides/cli/service.schemas.md
@@ -23,12 +23,12 @@ export const nameSchema = Type.Object({
 })
 // The TypeScript type inferred from the schema
 export type Name = Static<typeof nameSchema>
+// The validator for the schema
+export const nameValidator = getValidator(nameSchema, dataValidator)
 // The resolver for the schema
 export const nameResolver = resolve<Name, HookContext>({
   properties: {}
 })
-// The validator if it is a schema for data
-export const nameValidator = getDataValidator(nameSchema, dataValidator)
 ```
 
 ## Main Schemas and Resolvers
@@ -68,7 +68,7 @@ export const messagesDataSchema = Type.Pick(messagesSchema, ['string'], {
   additionalProperties: false
 })
 export type MessagesData = Static<typeof messagesDataSchema>
-export const messagesDataValidator = getDataValidator(messagesDataSchema, dataValidator)
+export const messagesDataValidator = getValidator(messagesDataSchema, dataValidator)
 export const messagesDataResolver = resolve<Messages, HookContext>({
   properties: {}
 })

--- a/packages/generators/src/authentication/templates/schema.json.tpl.ts
+++ b/packages/generators/src/authentication/templates/schema.json.tpl.ts
@@ -41,6 +41,7 @@ export const ${camelName}Schema = {
   }
 } as const
 export type ${upperName} = FromSchema<typeof ${camelName}Schema>
+export const ${camelName}Validator = getValidator(${camelName}Schema, dataValidator)
 export const ${camelName}Resolver = resolve<${upperName}, HookContext>({})
 
 export const ${camelName}ExternalResolver = resolve<${upperName}, HookContext>({

--- a/packages/generators/src/authentication/templates/schema.typebox.tpl.ts
+++ b/packages/generators/src/authentication/templates/schema.typebox.tpl.ts
@@ -12,7 +12,7 @@ export const template = ({
   relative
 }: AuthenticationGeneratorContext) => /* ts */ `// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve } from '@feathersjs/schema'
-import { Type, getDataValidator, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
 ${localTemplate(authStrategies, `import { passwordHash } from '@feathersjs/authentication-local'`)}
 
@@ -34,6 +34,7 @@ export const ${camelName}Schema = Type.Object({
     .join(',\n')}
 },{ $id: '${upperName}', additionalProperties: false })
 export type ${upperName} = Static<typeof ${camelName}Schema>
+export const ${camelName}Validator = getValidator(${camelName}Schema, dataValidator)
 export const ${camelName}Resolver = resolve<${upperName}, HookContext>({})
 
 export const ${camelName}ExternalResolver = resolve<${upperName}, HookContext>({
@@ -51,7 +52,7 @@ export const ${camelName}DataSchema = Type.Pick(${camelName}Schema, [
   { $id: '${upperName}Data', additionalProperties: false }
 )
 export type ${upperName}Data = Static<typeof ${camelName}DataSchema>
-export const ${camelName}DataValidator = getDataValidator(${camelName}DataSchema, dataValidator)
+export const ${camelName}DataValidator = getValidator(${camelName}DataSchema, dataValidator)
 export const ${camelName}DataResolver = resolve<${upperName}, HookContext>({
   ${localTemplate(authStrategies, `password: passwordHash({ strategy: 'local' })`)}
 })
@@ -61,7 +62,7 @@ export const ${camelName}PatchSchema = Type.Partial(${camelName}Schema, {
   $id: '${upperName}Patch'
 })
 export type ${upperName}Patch = Static<typeof ${camelName}PatchSchema>
-export const ${camelName}PatchValidator = getDataValidator(${camelName}PatchSchema, dataValidator)
+export const ${camelName}PatchValidator = getValidator(${camelName}PatchSchema, dataValidator)
 export const ${camelName}PatchResolver = resolve<${upperName}, HookContext>({
   ${localTemplate(authStrategies, `password: passwordHash({ strategy: 'local' })`)}
 })

--- a/packages/generators/src/service/templates/schema.json.tpl.ts
+++ b/packages/generators/src/service/templates/schema.json.tpl.ts
@@ -34,7 +34,9 @@ export const ${camelName}Schema = {
   }
 } as const
 export type ${upperName} = FromSchema<typeof ${camelName}Schema>
+export const ${camelName}Validator = getValidator(${camelName}Schema, dataValidator)
 export const ${camelName}Resolver = resolve<${upperName}, HookContext>({})
+
 export const ${camelName}ExternalResolver = resolve<${upperName}, HookContext>({})
 
 // Schema for creating new data

--- a/packages/generators/src/service/templates/schema.typebox.tpl.ts
+++ b/packages/generators/src/service/templates/schema.typebox.tpl.ts
@@ -11,7 +11,7 @@ const template = ({
   lib
 }: ServiceGeneratorContext) => /* ts */ `// // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve } from '@feathersjs/schema'
-import { Type, getDataValidator, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
 import type { Static } from '@feathersjs/typebox'
 
 import type { HookContext } from '${relative}/declarations'
@@ -25,6 +25,7 @@ export const ${camelName}Schema = Type.Object({
     text: Type.String()
   }, { $id: '${upperName}', additionalProperties: false })
 export type ${upperName} = Static<typeof ${camelName}Schema>
+export const ${camelName}Validator = getValidator(${camelName}Schema, dataValidator)
 export const ${camelName}Resolver = resolve<${upperName}, HookContext>({})
 
 export const ${camelName}ExternalResolver = resolve<${upperName}, HookContext>({})
@@ -34,7 +35,7 @@ export const ${camelName}DataSchema = Type.Pick(${camelName}Schema, ['text'], {
   $id: '${upperName}Data'
 })
 export type ${upperName}Data = Static<typeof ${camelName}DataSchema>
-export const ${camelName}DataValidator = getDataValidator(${camelName}DataSchema, dataValidator)
+export const ${camelName}DataValidator = getValidator(${camelName}DataSchema, dataValidator)
 export const ${camelName}DataResolver = resolve<${upperName}, HookContext>({})
 
 // Schema for updating existing entries
@@ -42,7 +43,7 @@ export const ${camelName}PatchSchema = Type.Partial(${camelName}DataSchema, {
   $id: '${upperName}Patch'
 })
 export type ${upperName}Patch = Static<typeof ${camelName}PatchSchema>
-export const ${camelName}PatchValidator = getDataValidator(${camelName}PatchSchema, dataValidator)
+export const ${camelName}PatchValidator = getValidator(${camelName}PatchSchema, dataValidator)
 export const ${camelName}PatchResolver = resolve<${upperName}, HookContext>({})
 
 // Schema for allowed query properties


### PR DESCRIPTION
This pull request adds the main schema to the validator instance so that references do not throw an error. It also changes all remaining references to the no longer needed `getDataValidator` to `getValidator`.

Closes https://github.com/feathersjs/feathers/issues/2993