### PR TITLE
fix(generators): Do not removeAdditional in queries

### DIFF
--- a/packages/generators/src/app/templates/validators.tpl.ts
+++ b/packages/generators/src/app/templates/validators.tpl.ts
@@ -26,8 +26,7 @@ const formats: FormatsPluginOptions = [
 export const dataValidator: Ajv = addFormats(new Ajv({}), formats)
 
 export const queryValidator: Ajv = addFormats(new Ajv({
-  coerceTypes: true,
-  removeAdditional: true
+  coerceTypes: true
 }), formats)
 `
 


### PR DESCRIPTION
This was originally added to avoid unsafe queries being made but the solution is to always set `additionalProperties: false` which is already happening in a generated application.

Related to https://github.com/feathersjs/feathers/issues/2995