### PR TITLE
fix(typescript): Make main type names more discernible

### DIFF
--- a/packages/express/src/authentication.ts
+++ b/packages/express/src/authentication.ts
@@ -3,7 +3,7 @@ import { HookContext } from '@feathersjs/feathers'
 import { createDebug } from '@feathersjs/commons'
 import { authenticate as AuthenticateHook } from '@feathersjs/authentication'
 
-import { Application } from './declarations'
+import { ExpressApplication } from './declarations'
 
 const debug = createDebug('@feathersjs/express/authentication')
 
@@ -20,7 +20,7 @@ export type AuthenticationSettings = {
 
 export function parseAuthentication(settings: AuthenticationSettings = {}): RequestHandler {
   return toHandler(async (req, res, next) => {
-    const app = req.app as any as Application
+    const app = req.app as any as ExpressApplication
     const service = app.defaultAuthentication?.(settings.service)
 
     if (!service) {
@@ -53,7 +53,7 @@ export function authenticate(
   const hook = AuthenticateHook(settings, ...strategies)
 
   return toHandler(async (req, _res, next) => {
-    const app = req.app as any as Application
+    const app = req.app as any as ExpressApplication
     const params = req.feathers
     const context = { app, params } as any as HookContext
 

--- a/packages/express/src/declarations.ts
+++ b/packages/express/src/declarations.ts
@@ -1,7 +1,7 @@
 import http from 'http'
 import express, { Express } from 'express'
 import {
-  Application as FeathersApplication,
+  FeathersApplication,
   Params as FeathersParams,
   HookContext,
   ServiceMethods,
@@ -33,9 +33,21 @@ export interface ExpressOverrides<Services> {
   server?: http.Server
 }
 
-export type Application<Services = any, Settings = any> = Omit<Express, 'listen' | 'use' | 'get' | 'set'> &
+export type ExpressApplication<Services = any, Settings = any> = Omit<
+  Express,
+  'listen' | 'use' | 'get' | 'set'
+> &
   FeathersApplication<Services, Settings> &
   ExpressOverrides<Services>
+
+/**
+ * The combined Express and Feathers application type.
+ *
+ * @deprecated Use the `Application` type from your apps 'declarations' instead to get
+ * the correct service and configuration typings. To get this type,
+ * use `import { ExpressApplication } from '@feathersjs/express'`.
+ */
+export type Application<Services = any, Settings = any> = ExpressApplication<Services, Settings>
 
 declare module '@feathersjs/feathers/lib/declarations' {
   interface ServiceOptions {

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -7,7 +7,7 @@ import compression from 'compression'
 
 import { rest, RestOptions, formatter } from './rest'
 import { errorHandler, notFound, ErrorHandlerOptions } from './handlers'
-import { Application, ExpressOverrides } from './declarations'
+import { ExpressApplication, ExpressOverrides } from './declarations'
 import { AuthenticationSettings, authenticate, parseAuthentication } from './authentication'
 import { default as original, static as serveStatic, json, raw, text, urlencoded, query } from 'express'
 
@@ -25,7 +25,7 @@ export {
   formatter,
   errorHandler,
   notFound,
-  Application,
+  ExpressApplication as Application,
   ErrorHandlerOptions,
   ExpressOverrides,
   AuthenticationSettings,
@@ -40,7 +40,7 @@ const debug = createDebug('@feathersjs/express')
 export default function feathersExpress<S = any, C = any>(
   feathersApp?: FeathersApplication<S, C>,
   expressApp: Express = express()
-): Application<S, C> {
+): ExpressApplication<S, C> {
   if (!feathersApp) {
     return expressApp as any
   }
@@ -49,7 +49,7 @@ export default function feathersExpress<S = any, C = any>(
     throw new Error('@feathersjs/express requires a valid Feathers application instance')
   }
 
-  const app = expressApp as any as Application<S, C>
+  const app = expressApp as any as ExpressApplication<S, C>
   const { use: expressUse, listen: expressListen } = expressApp as any
   const { use: feathersUse, teardown: feathersTeardown } = feathersApp
 
@@ -105,7 +105,7 @@ export default function feathersExpress<S = any, C = any>(
 
       return server
     }
-  } as Application<S, C>)
+  } as ExpressApplication<S, C>)
 
   const appDescriptors = {
     ...Object.getOwnPropertyDescriptors(Object.getPrototypeOf(app)),

--- a/packages/express/src/rest.ts
+++ b/packages/express/src/rest.ts
@@ -5,7 +5,7 @@ import { http } from '@feathersjs/transport-commons'
 import { createContext, defaultServiceMethods, getServiceOptions } from '@feathersjs/feathers'
 
 import { AuthenticationSettings, parseAuthentication } from './authentication'
-import { Application } from './declarations'
+import { ExpressApplication } from './declarations'
 
 const debug = createDebug('@feathersjs/express/rest')
 
@@ -53,7 +53,7 @@ const serviceMiddleware = (): RequestHandler => {
 
 const servicesMiddleware = (): RequestHandler => {
   return toHandler(async (req, res, next) => {
-    const app = req.app as any as Application
+    const app = req.app as any as ExpressApplication
     const lookup = app.lookup(req.path)
 
     if (!lookup) {
@@ -92,7 +92,7 @@ export const rest = (options?: RestOptions | RequestHandler) => {
   const formatterMiddleware = options.formatter || formatter
   const authenticationOptions = options.authentication
 
-  return (app: Application) => {
+  return (app: ExpressApplication) => {
     if (typeof app.route !== 'function') {
       throw new Error('@feathersjs/express/rest needs an Express compatible app.')
     }

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -6,12 +6,12 @@ import { eventHook, eventMixin } from './events'
 import { hookMixin } from './hooks'
 import { wrapService, getServiceOptions, protectedMethods } from './service'
 import {
-  FeathersApplication,
+  ApplicationInterface,
   ServiceMixin,
   Service,
   ServiceOptions,
   ServiceInterface,
-  Application,
+  FeathersApplication,
   FeathersService,
   ApplicationHookOptions
 } from './declarations'
@@ -21,11 +21,11 @@ const debug = createDebug('@feathersjs/feathers')
 
 export class Feathers<Services, Settings>
   extends EventEmitter
-  implements FeathersApplication<Services, Settings>
+  implements ApplicationInterface<Services, Settings>
 {
   services: Services = {} as Services
   settings: Settings = {} as Settings
-  mixins: ServiceMixin<Application<Services, Settings>>[] = [hookMixin, eventMixin]
+  mixins: ServiceMixin<FeathersApplication<Services, Settings>>[] = [hookMixin, eventMixin]
   version: string = version
   _isSetup = false
 
@@ -144,7 +144,7 @@ export class Feathers<Services, Settings>
 
   use<L extends keyof Services & string>(
     path: L,
-    service: keyof any extends keyof Services ? ServiceInterface | Application : Services[L],
+    service: keyof any extends keyof Services ? ServiceInterface | FeathersApplication : Services[L],
     options?: ServiceOptions<keyof any extends keyof Services ? string : keyof Services[L]>
   ): this {
     if (typeof path !== 'string') {
@@ -152,7 +152,7 @@ export class Feathers<Services, Settings>
     }
 
     const location = (stripSlashes(path) || '/') as L
-    const subApp = service as Application
+    const subApp = service as FeathersApplication
     const isSubApp = typeof subApp.service === 'function' && subApp.services
 
     if (isSubApp) {

--- a/packages/feathers/src/events.ts
+++ b/packages/feathers/src/events.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events'
 import { NextFunction } from '@feathersjs/hooks'
-import { HookContext, FeathersService } from './declarations'
+import { FeathersHookContext, FeathersService } from './declarations'
 import { getServiceOptions, defaultEventMap } from './service'
 
-export function eventHook(context: HookContext, next: NextFunction) {
+export function eventHook(context: FeathersHookContext, next: NextFunction) {
   const { events } = getServiceOptions((context as any).self)
   const defaultEvent = (defaultEventMap as any)[context.method] || null
 

--- a/packages/feathers/src/hooks.ts
+++ b/packages/feathers/src/hooks.ts
@@ -10,7 +10,7 @@ import {
 import {
   Service,
   ServiceOptions,
-  HookContext,
+  FeathersHookContext,
   FeathersService,
   HookMap,
   AroundHookFunction,
@@ -124,7 +124,7 @@ export function createContext(service: Service, method: string, data: HookContex
     throw new Error(`Can not create context for method ${method}`)
   }
 
-  return createContext(data) as HookContext
+  return createContext(data) as FeathersHookContext
 }
 
 export class FeathersHookManager<A> extends HookManager {
@@ -141,7 +141,7 @@ export class FeathersHookManager<A> extends HookManager {
     return [...appHooks, ...middleware, ...methodHooks]
   }
 
-  initializeContext(self: any, args: any[], context: HookContext) {
+  initializeContext(self: any, args: any[], context: FeathersHookContext) {
     const ctx = super.initializeContext(self, args, context)
 
     ctx.params = ctx.params || {}

--- a/packages/feathers/src/index.ts
+++ b/packages/feathers/src/index.ts
@@ -2,10 +2,10 @@ import { setDebug } from '@feathersjs/commons'
 
 import version from './version'
 import { Feathers } from './application'
-import { Application } from './declarations'
+import { FeathersApplication } from './declarations'
 
 export function feathers<T = any, S = any>() {
-  return new Feathers<T, S>() as Application<T, S>
+  return new Feathers<T, S>() as FeathersApplication<T, S>
 }
 
 feathers.setDebug = setDebug

--- a/packages/generators/src/app/templates/declarations.tpl.ts
+++ b/packages/generators/src/app/templates/declarations.tpl.ts
@@ -4,8 +4,12 @@ import { AppGeneratorContext } from '../index'
 const template = ({
   framework
 }: AppGeneratorContext) => /* ts */ `// For more information about this file see https://dove.feathersjs.com/guides/cli/typescript.html
-import { HookContext as FeathersHookContext, NextFunction } from '@feathersjs/feathers'
-import { Application as FeathersApplication } from '@feathersjs/${framework}'
+import { FeathersHookContext, NextFunction } from '@feathersjs/feathers'
+${
+  framework === 'koa'
+    ? `import { KoaApplication } from '@feathersjs/koa'`
+    : `import { ExpressApplication } from '@feathersjs/express'`
+}
 import { ApplicationConfiguration } from './configuration'
 
 export { NextFunction }
@@ -19,7 +23,11 @@ export interface Configuration extends ApplicationConfiguration {}
 export interface ServiceTypes {}
 
 // The application instance type that will be used everywhere else
-export type Application = FeathersApplication<ServiceTypes, Configuration>
+${
+  framework === 'koa'
+    ? `export type Application = KoaApplication<ServiceTypes, Configuration>`
+    : `export type Application = ExpressApplication<ServiceTypes, Configuration>`
+}
 
 // The context for hook functions - can be typed with a service class
 export type HookContext<S = any> = FeathersHookContext<Application, S>

--- a/packages/koa/src/declarations.ts
+++ b/packages/koa/src/declarations.ts
@@ -1,6 +1,6 @@
 import Koa, { Next } from 'koa'
 import { Server } from 'http'
-import { Application as FeathersApplication, HookContext, Params, RouteLookup } from '@feathersjs/feathers'
+import { FeathersApplication, HookContext, Params, RouteLookup } from '@feathersjs/feathers'
 import '@feathersjs/authentication'
 
 export type ApplicationAddons = {
@@ -8,15 +8,24 @@ export type ApplicationAddons = {
   listen(port?: number, ...args: any[]): Promise<Server>
 }
 
-export type Application<T = any, C = any> = Omit<Koa, 'listen'> &
+export type KoaApplication<T = any, C = any> = Omit<Koa, 'listen'> &
   FeathersApplication<T, C> &
   ApplicationAddons
 
-export type FeathersKoaContext<A = Application> = Koa.Context & {
+/**
+ * The combined Koa and Feathers application type.
+ *
+ * @deprecated Use the `Application` type from your apps 'declarations' instead to get
+ * the correct service and configuration typings. To get this type,
+ * use `import { KoaApplication } from '@feathersjs/koa'`.
+ */
+export type Application<T = any, C = any> = KoaApplication<T, C>
+
+export type FeathersKoaContext<A = KoaApplication> = Koa.Context & {
   app: A
 }
 
-export type Middleware<A = Application> = (context: FeathersKoaContext<A>, next: Next) => any
+export type Middleware<A = KoaApplication> = (context: FeathersKoaContext<A>, next: Next) => any
 
 declare module '@feathersjs/feathers/lib/declarations' {
   interface ServiceOptions {

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -7,7 +7,7 @@ import bodyParser from 'koa-bodyparser'
 import cors from '@koa/cors'
 import serveStatic from 'koa-static'
 
-import { Application } from './declarations'
+import { KoaApplication } from './declarations'
 
 export { Koa, bodyParser, cors, serveStatic }
 export * from './authentication'
@@ -20,7 +20,7 @@ const debug = createDebug('@feathersjs/koa')
 export function koa<S = any, C = any>(
   feathersApp?: FeathersApplication<S, C>,
   koaApp: Koa = new Koa()
-): Application<S, C> {
+): KoaApplication<S, C> {
   if (!feathersApp) {
     return koaApp as any
   }
@@ -29,7 +29,7 @@ export function koa<S = any, C = any>(
     throw new Error('@feathersjs/koa requires a valid Feathers application instance')
   }
 
-  const app = feathersApp as any as Application<S, C>
+  const app = feathersApp as any as KoaApplication<S, C>
   const { listen: koaListen, use: koaUse } = koaApp
   const { use: feathersUse, teardown: feathersTeardown } = feathersApp
 
@@ -59,7 +59,7 @@ export function koa<S = any, C = any>(
           () => new Promise((resolve, reject) => this.server.close((e) => (e ? reject(e) : resolve(this))))
         )
     }
-  } as Application)
+  } as KoaApplication)
 
   const appDescriptors = {
     ...Object.getOwnPropertyDescriptors(Object.getPrototypeOf(app)),

--- a/packages/koa/src/rest.ts
+++ b/packages/koa/src/rest.ts
@@ -4,7 +4,7 @@ import { createDebug } from '@feathersjs/commons'
 import { getServiceOptions, defaultServiceMethods, createContext } from '@feathersjs/feathers'
 import { MethodNotAllowed } from '@feathersjs/errors'
 
-import { Application, Middleware } from './declarations'
+import { KoaApplication, Middleware } from './declarations'
 import { AuthenticationSettings, parseAuthentication } from './authentication'
 
 const debug = createDebug('@feathersjs/koa/rest')
@@ -77,7 +77,7 @@ export const rest = (options?: RestOptions | Middleware) => {
   const formatterMiddleware = options.formatter || formatter
   const authenticationOptions = options.authentication
 
-  return (app: Application) => {
+  return (app: KoaApplication) => {
     app.use(parseAuthentication(authenticationOptions))
     app.use(servicesMiddleware())
 


### PR DESCRIPTION
This pull request changes the built in type names so that they are more easily to differentiate from the actual application type names. The problem was that TypeScript IDEs ended up auto importing the generic `Application` and `HookContext` types instead of the application specific ones so you don't get the correct service and configuration types.