### PR TITLE
docs(cli-guide): Bind fetch to window

### DIFF
--- a/docs/guides/cli/client.md
+++ b/docs/guides/cli/client.md
@@ -57,7 +57,7 @@ And like this with a REST client:
 import rest from '@feathersjs/rest-client'
 import { createClient } from 'my-app'
 
-const connection = rest('https://myapp.com').fetch(fetch)
+const connection = rest('https://myapp.com').fetch(window.fetch.bind(window))
 
 const client = createClient(connection)
 ```


### PR DESCRIPTION
Got a strange console error `Error: 'fetch' called on an object that does not implement interface Window.`

Then I found this : https://feathersjs.com/api/client/rest.html#rest-baseurl -> the fetch function must have `this` be the same as `window`
