### PR TITLE
fix(databases): Ensure that query sanitization is not necessary when using query schemas

### DIFF
--- a/packages/adapter-commons/src/index.ts
+++ b/packages/adapter-commons/src/index.ts
@@ -3,7 +3,7 @@ import { Params } from '@feathersjs/feathers'
 
 export * from './declarations'
 export * from './service'
-export { filterQuery, FILTERS, OPERATORS } from './query'
+export * from './query'
 export * from './sort'
 
 // Return a function that filters a result object or array

--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@feathersjs/adapter-tests": "^5.0.0-pre.35",
+    "@feathersjs/schema": "^5.0.0-pre.35",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.18",
     "knex": "^2.3.0",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@feathersjs/adapter-tests": "^5.0.0-pre.35",
+    "@feathersjs/schema": "^5.0.0-pre.35",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.18",
     "mocha": "^10.2.0",

--- a/packages/schema/src/json-schema.ts
+++ b/packages/schema/src/json-schema.ts
@@ -172,6 +172,25 @@ export const querySyntax = <
 ) => {
   const keys = Object.keys(definition)
   const props = queryProperties(definition, extensions)
+  const $or = {
+    type: 'array',
+    items: {
+      type: 'object',
+      additionalProperties: false,
+      properties: props
+    }
+  } as const
+  const $and = {
+    type: 'array',
+    items: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        ...props,
+        $or
+      }
+    }
+  } as const
 
   return {
     $limit: {
@@ -203,14 +222,8 @@ export const querySyntax = <
         ...(keys.length > 0 ? { enum: keys as any as (keyof T)[] } : {})
       }
     },
-    $or: {
-      type: 'array',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        properties: props
-      }
-    },
+    $or,
+    $and,
     ...props
   } as const
 }


### PR DESCRIPTION
This pull request makes sure that the legacy query sanitization is not used when the query has already been validated against a schema.

Related to https://github.com/feathersjs/feathers/issues/2988