### PR TITLE
fix(typebox): Allow nested or in and queries

### DIFF
--- a/packages/typebox/src/index.ts
+++ b/packages/typebox/src/index.ts
@@ -159,6 +159,7 @@ export const querySyntax = <
   options: ObjectOptions = { additionalProperties: false }
 ) => {
   const propertySchema = queryProperties(type, extensions)
+  const $or = Type.Array(propertySchema)
 
   return Type.Intersect(
     [
@@ -169,8 +170,8 @@ export const querySyntax = <
             $skip: Type.Number({ minimum: 0 }),
             $sort: sortDefinition(type),
             $select: arrayOfKeys(type),
-            $or: Type.Array(propertySchema),
-            $and: Type.Array(propertySchema)
+            $or,
+            $and: Type.Array(Type.Union([propertySchema, Type.Object({ $or })]))
           },
           { additionalProperties: false }
         )

--- a/packages/typebox/src/index.ts
+++ b/packages/typebox/src/index.ts
@@ -160,6 +160,7 @@ export const querySyntax = <
 ) => {
   const propertySchema = queryProperties(type, extensions)
   const $or = Type.Array(propertySchema)
+  const $and = Type.Array(Type.Union([propertySchema, Type.Object({ $or })]))
 
   return Type.Intersect(
     [
@@ -170,8 +171,8 @@ export const querySyntax = <
             $skip: Type.Number({ minimum: 0 }),
             $sort: sortDefinition(type),
             $select: arrayOfKeys(type),
-            $or,
-            $and: Type.Array(Type.Union([propertySchema, Type.Object({ $or })]))
+            $and,
+            $or
           },
           { additionalProperties: false }
         )


### PR DESCRIPTION
This is working already for JSON schemas but was an oversight for TypeBox.