### PR TITLE
fix(schema): Ensure that resolveResult and resolveExternal are run as around hooks

### DIFF
--- a/docs/api/schema/resolvers.md
+++ b/docs/api/schema/resolvers.md
@@ -315,7 +315,7 @@ app.service('users').hooks({
 
 <BlockQuote type="warning" label="important">
 
-In order to get the safe data from resolved associations **all services** involved need the `schemaHooks.resolveExternal` (or `resolveAll`) hook registered even if it does not need a resolver (`schemaHooks.resolveExternal()`).
+In order to get the safe data from resolved associations **all services** involved need the `schemaHooks.resolveExternal` hook registered even if it does not need a resolver (`schemaHooks.resolveExternal()`).
 
 `schemaHooks.resolveExternal` should be registered first when used as an `around` hook or last when used as an `after` hook so that it gets the final result data.
 


### PR DESCRIPTION
#3004 introduced a change in the hook order to fix a regression in compatibility with v4. However, this breaks some app generated with v5 pre releases where `resolveResult` and `resolveExternal` were registered as `after` hooks. Since `resolveResult` should be used as an `around` hook anyway for proper virtual property support, they will now throw an error if they are used as `after` hooks.