### PR TITLE
fix(generators): Fix Knex migration generated filename

### DIFF
--- a/packages/generators/src/authentication/templates/knex.tpl.ts
+++ b/packages/generators/src/authentication/templates/knex.tpl.ts
@@ -46,11 +46,10 @@ export const generate = (ctx: AuthenticationGeneratorContext) =>
       renderSource(
         migrationTemplate,
         toFile(
-          toFile<AuthenticationGeneratorContext>('migrations', async () => {
-            await new Promise((resolve) => setTimeout(resolve, 1200))
-
-            return `${yyyymmddhhmmss()}_authentication`
-          })
+          toFile<AuthenticationGeneratorContext>(
+            'migrations',
+            async () => `${yyyymmddhhmmss(1200)}_authentication`
+          )
         )
       )
     )

--- a/packages/generators/src/authentication/templates/knex.tpl.ts
+++ b/packages/generators/src/authentication/templates/knex.tpl.ts
@@ -1,5 +1,5 @@
 import { generator, when, toFile } from '@feathershq/pinion'
-import { getDatabaseAdapter, renderSource } from '../../commons'
+import { getDatabaseAdapter, renderSource, yyyymmddhhmmss } from '../../commons'
 import { AuthenticationGeneratorContext } from '../index'
 
 const migrationTemplate = ({
@@ -46,15 +46,10 @@ export const generate = (ctx: AuthenticationGeneratorContext) =>
       renderSource(
         migrationTemplate,
         toFile(
-          toFile<AuthenticationGeneratorContext>('migrations', () => {
-            // Probably not great but it works to align with the Knex migration file format
-            // We add a few seconds so that the migrations run in the correct order
-            const migrationDate = new Date(Date.now() + 10000)
-              .toISOString()
-              .replace(/\D/g, '')
-              .substring(0, 14)
+          toFile<AuthenticationGeneratorContext>('migrations', async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1200))
 
-            return `${migrationDate}_authentication`
+            return `${yyyymmddhhmmss()}_authentication`
           })
         )
       )

--- a/packages/generators/src/commons.ts
+++ b/packages/generators/src/commons.ts
@@ -282,3 +282,20 @@ export const injectSource =
  * @returns Wether the file exists or not
  */
 export const fileExists = (...filenames: string[]) => fs.existsSync(join(...filenames))
+
+/**
+ * The helper used by Knex to create migration names
+ * @returns The current date and time in the format `YYYYMMDDHHMMSS`
+ */
+export const yyyymmddhhmmss = () => {
+  const now = new Date()
+
+  return (
+    now.getUTCFullYear().toString() +
+    (now.getUTCMonth() + 1).toString().padStart(2, '0') +
+    now.getUTCDate().toString().padStart(2, '0') +
+    now.getUTCHours().toString().padStart(2, '0') +
+    now.getUTCMinutes().toString().padStart(2, '0') +
+    now.getUTCSeconds().toString().padStart(2, '0')
+  )
+}

--- a/packages/generators/src/commons.ts
+++ b/packages/generators/src/commons.ts
@@ -287,8 +287,8 @@ export const fileExists = (...filenames: string[]) => fs.existsSync(join(...file
  * The helper used by Knex to create migration names
  * @returns The current date and time in the format `YYYYMMDDHHMMSS`
  */
-export const yyyymmddhhmmss = () => {
-  const now = new Date()
+export const yyyymmddhhmmss = (offset = 0) => {
+  const now = new Date(Date.now() + offset)
 
   return (
     now.getUTCFullYear().toString() +

--- a/packages/generators/src/service/type/knex.tpl.ts
+++ b/packages/generators/src/service/type/knex.tpl.ts
@@ -1,5 +1,5 @@
 import { generator, toFile } from '@feathershq/pinion'
-import { renderSource } from '../../commons'
+import { renderSource, yyyymmddhhmmss } from '../../commons'
 import { ServiceGeneratorContext } from '../index'
 
 const migrationTemplate = ({
@@ -84,11 +84,6 @@ export const generate = (ctx: ServiceGeneratorContext) =>
     .then(
       renderSource(
         migrationTemplate,
-        toFile<ServiceGeneratorContext>('migrations', ({ kebabName }) => {
-          // Probably not great but it works to align with the Knex migration file format
-          const migrationDate = new Date().toISOString().replace(/\D/g, '').substring(0, 14)
-
-          return `${migrationDate}_${kebabName}`
-        })
+        toFile<ServiceGeneratorContext>('migrations', ({ kebabName }) => `${yyyymmddhhmmss()}_${kebabName}`)
       )
     )


### PR DESCRIPTION
The workaround for generating Knex migration filenames was causing flaky tests. This PR uses the same function that is used in Knex itself to hopefully avoid those issues.