### PR TITLE
fix: generated app does not start when choosing JSON schema

### DIFF
--- a/packages/generators/src/app/templates/configuration.tpl.ts
+++ b/packages/generators/src/app/templates/configuration.tpl.ts
@@ -32,6 +32,7 @@ import type { FromSchema } from '@feathersjs/schema'
 import { dataValidator } from './validators'
 
 export const configurationSchema = {
+  $id: 'configuration',
   type: 'object',
   additionalProperties: false,
   required: [ 'host', 'port', 'public' ],

--- a/packages/generators/src/authentication/templates/schema.json.tpl.ts
+++ b/packages/generators/src/authentication/templates/schema.json.tpl.ts
@@ -69,7 +69,7 @@ export const ${camelName}DataResolver = resolve<${upperName}Data, HookContext>({
 })
 
 // Schema for updating existing users
-export const ${camelName}DataSchema = {
+export const ${camelName}PatchSchema = {
   $id: '${upperName}Patch',
   type: 'object',
   additionalProperties: false,


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving.
  - After generating an app with "JSON schema" definition format
  - Error `Property '$id' is missing in type` is thrown for the file `src/configuration.ts`
  - Error `Cannot redeclare block-scoped variable 'userDataSchema'.` is thrown for `src/services/users/users.schema.ts`
- [x] Are there any open issues that are related to this?
  - No
- [x] Is this PR dependent on PRs in other repos?
  - No
