### PR TITLE
fix(knex): The method getModel in the knex adapter

### DIFF
--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -64,7 +64,7 @@ export class KnexAdapter<
   }
 
   getModel(params?: ServiceParams) {
-    const { Model } = this.getOptions(params)
+    const { Model } = this.getOptions(params ?? {} as ServiceParams)
     return Model
   }
 

--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -63,8 +63,8 @@ export class KnexAdapter<
     return this.getModel()
   }
 
-  getModel(params?: ServiceParams) {
-    const { Model } = this.getOptions(params ?? {} as ServiceParams)
+  getModel(params: ServiceParams = {} as ServiceParams) {
+    const { Model } = this.getOptions(params)
     return Model
   }
 

--- a/packages/knex/test/overrides.test.ts
+++ b/packages/knex/test/overrides.test.ts
@@ -122,4 +122,11 @@ describe('Feathers Knex Overridden Method With Self-Join', () => {
 
     assert.strictEqual(patchedAnimal.name, newName)
   })
+
+  it('get the service model (getModel)', async () => {
+    const model = animalService.Model
+    const options = animalService.options
+
+    assert.strictEqual(model, options.Model)
+  })
 })


### PR DESCRIPTION
This PR is related to this [Discord thread](https://discordapp.com/channels/509848480760725514/1069965207625019432) and should fix a small bug appeared in pre.36.

It solves problems when you want to access the model in your knexService via ``this.Model``.
A new test was added to compare the result of the getModel method and the one stored in the service options.