### PR TITLE
fix(schema): Do not change the hook context in resolvers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,12 +209,12 @@
       "optional": true
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.266.0.tgz",
-      "integrity": "sha512-H/ySWWSwJN5coP9c5Ge2pOJYs1YPG5AVemGeKRx3kw5Z7Btd9jSFyYV0qGPd78HG3FopjZqSb4l2puPPp8UdpA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.267.0.tgz",
+      "integrity": "sha512-5R7OSnHFV/f+qQpMf1RuSQoVdXroK94Vl6naWjMOAhMyofHykVhEok9hmFPac86AVx8rVX/vuA7u9GKI6/EE7g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -222,44 +222,44 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.266.0.tgz",
-      "integrity": "sha512-Hww10GE9J1baUIO9GuNgoRp4DU8mwuaeO8aIij4p1EaeyAmeV2LbLFt04UBZfwF4BGFrbssauRlItf+/IMFaTA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.267.0.tgz",
+      "integrity": "sha512-jEE5aw7wp7VhiaU0vCbNQbEIhiaNZnBhRj+vJVCd2HQBI9IVLVXAoyExWxLruAXKEO+A1w1df+fwZAOo0M7aQQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.266.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/credential-provider-node": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-signing": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/client-sts": "3.267.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/credential-provider-node": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-signing": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
@@ -268,41 +268,41 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.266.0.tgz",
-      "integrity": "sha512-eK20HlA61ehvCBf62bk29DX0cXPQh2/KMlvuHnjhxDrn4BLMxLCMer8Awz3MIoBbVQKG1h46X2z6/pJra8Fs4w==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.267.0.tgz",
+      "integrity": "sha512-/475/mT0gYhimpCdK4iZW+eX0DT6mkTgVk5P9ARpQGzEblFM6i2pE7GQnlGeLyHVOtA0cNAyGrWUuj2pyigUaA==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
@@ -311,41 +311,41 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.266.0.tgz",
-      "integrity": "sha512-kpXr0Vj7IjDZ1ef3GHAe+/eDFp/XpEKfNHCl0r2MB5zTTFYxDm8BlFl7qB1rBJlqzqpPRhy+1J+UAsg84melsw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.267.0.tgz",
+      "integrity": "sha512-Jdq0v0mJSJbG/CKLfHC1L0cjCot48Y6lLMQV1lfkYE65xD0ZSs8Gl7P/T391ZH7cLO6ifVoPdsYnwzhi1ZPXSQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
@@ -354,44 +354,44 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.266.0.tgz",
-      "integrity": "sha512-ml3cjtIhHP21OwNKAC25ys5nAox0m4E2gPH97Q5s/1aE/hzxqQKkTO6YWp3eW7gwruubNV1GG/w0uHvAUYMjBw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.267.0.tgz",
+      "integrity": "sha512-bJ+SwJZAP3DuDUgToDV89HsB80IhSfB1rhzLG9csqs6h7uMLO8H1/fymElYKT4VMMAA+rpWJ3pznyGiCK7w28A==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/credential-provider-node": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-sdk-sts": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-signing": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/credential-provider-node": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-sdk-sts": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-signing": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
@@ -401,15 +401,15 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.266.0.tgz",
-      "integrity": "sha512-s1DKPIJVcB506mRDGLzRAT3ZFUD/JvglbRoN9/oGUkCHusiOAlOIuTTilSfkjq13Ntq+O/sUIpWhir0R45dBcA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.267.0.tgz",
+      "integrity": "sha512-UMvJY548xOkamU9ZuZk336VX9r3035CAbttagiPJ/FXy9S8jcQ7N722PAovtxs69nNBQf56cmWsnOHphLCGG9w==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -417,14 +417,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.266.0.tgz",
-      "integrity": "sha512-eBNEr1Vs0G8GIKVaZ07XPnH93+yUP6gjUAyBfdEsMvs9S9LmSXfwskKUeQhB1X0d4L9VqDo8AZ5zOufurGPbfg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.267.0.tgz",
+      "integrity": "sha512-H97VsbiTcb4tbY/LQMZNglJIHt7CHso7RtGgctmdsEA7Rha79fV/egF0Vqo2OQHDgEEpgQDWCeHbXO1P5ibR/A==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-cognito-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -432,13 +432,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.266.0.tgz",
-      "integrity": "sha512-hh6/mkchzl6KUZBNFBkTB2YKEKPr2nLYS65d5DQnj+O2zXrWzVejS3mGT5iI7FZTcmKEdkxEGM+w8eZNGrdLBQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.267.0.tgz",
+      "integrity": "sha512-oiem2UtaFe4CQHscUCImJjPhYWd4iF8fqXhlq6BqHs1wsO6A0vnIUGh+Srut/2q7Xeegl/SRU34HK0hh8JCbxg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -446,15 +446,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.266.0.tgz",
-      "integrity": "sha512-UEfzcMtSJsNt9DedP+LDAG3cSLq7XFl/6wJAkDAAeNuDmy5iTCk03sZF21LJ1A31GKviEHpxLquBslOdk1DYGQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.267.0.tgz",
+      "integrity": "sha512-Afd5+LdJ9QyeI5L4iyVmI4MLV+0JBtRLmRy0LdinwJaP0DyKyv9+uaIaorKfWihQpe8hwjEfQWTlTz2A3JMJtw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -462,19 +462,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.266.0.tgz",
-      "integrity": "sha512-zyQo/eCtiPjoDvcsDI4xBojY6qy+o59B4LiVan1byvDQBbdI2VqshaDC4E+VJyCXcIZlYY1cT5NWt2g3wKKOLg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.267.0.tgz",
+      "integrity": "sha512-pHHlqZqZXA4cTssTyRmbYtrjxS2BEy2KFYHEEHNUrd82pUHnj70n+lrpVnT5pRhPPDacpNzxq0KZGeNgmETpbw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/credential-provider-process": "3.266.0",
-        "@aws-sdk/credential-provider-sso": "3.266.0",
-        "@aws-sdk/credential-provider-web-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/credential-provider-env": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/credential-provider-process": "3.267.0",
+        "@aws-sdk/credential-provider-sso": "3.267.0",
+        "@aws-sdk/credential-provider-web-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -482,20 +482,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.266.0.tgz",
-      "integrity": "sha512-x4KtMZFpNuh6jfrKWtOnwkRrVJj4dR7fAWD95xiUtykE4eD7YthTBOQPVtRcroxHNKo80gmcZnJf6ZdvHG0XCw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.267.0.tgz",
+      "integrity": "sha512-uo8VyZ/L8HBXskYZC65bR1ZUJ5mBn8JarrGHt6vMG2A+uM7AuryTsKn2wdhPfuCUGKuQLXmix5K4VW/wzq11kQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/credential-provider-ini": "3.266.0",
-        "@aws-sdk/credential-provider-process": "3.266.0",
-        "@aws-sdk/credential-provider-sso": "3.266.0",
-        "@aws-sdk/credential-provider-web-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/credential-provider-env": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/credential-provider-ini": "3.267.0",
+        "@aws-sdk/credential-provider-process": "3.267.0",
+        "@aws-sdk/credential-provider-sso": "3.267.0",
+        "@aws-sdk/credential-provider-web-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -503,14 +503,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.266.0.tgz",
-      "integrity": "sha512-x9MvMCAVUGr/7c2h6HbpDbEQSkdc2CH7snqdzl3fL6f3Q2HqhIG9rYWi9kAm4WIOIe2AuEIyzpOcGhwu+lyAqQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.267.0.tgz",
+      "integrity": "sha512-pd1OOB1Mm+QdPv3sPfO+1G8HBaPAAYXxjLcOK5z/myBeZAsLR12Xcaft4RR1XWwXXKEQqq42cbAINWQdyVykqQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -518,16 +518,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.266.0.tgz",
-      "integrity": "sha512-48QjXHmL8etffasJa0ioQxLvFGJrD53cPC8PbiUCcsbhmEg7TEGIRDdir7h+RzEup+9s1kJhdwCsi1k2jkyXMg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.267.0.tgz",
+      "integrity": "sha512-JqwxelzeRhVdloNi+VUUXhJdziTtNrrwMuhds9wj4KPfl1S2EIzkRxHSjwDz1wtSyuIPOOo6pPJiaVbwvLpkVg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/token-providers": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-sso": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/token-providers": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -535,13 +535,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.266.0.tgz",
-      "integrity": "sha512-EMcH+vt/WyWysHa2vwq2G3n73gRhyJ7fw3sh+3MhBtK5850bpLeSBz3iXvow3VKm8rbkn5IwZ2YdwG2OZgr66w==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.267.0.tgz",
+      "integrity": "sha512-za5UsQmj3sYRhd4h5eStj3GCHHfAAjfx2x5FmgQ9ldOp+s0wHEqSL1g+OL9v6o8otf9JnWha+wfUYq3yVGfufQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -549,25 +549,25 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.266.0.tgz",
-      "integrity": "sha512-FyUNKLZ6B5vFVmxFzmi1lHcFq7MkQU+sJQpBPiBenWu4UeqWL6QUhxSYx2J4ptE8W+JYkhnrBoBitHkOecFDZQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.267.0.tgz",
+      "integrity": "sha512-Og70E1eHGcxShMbrmm8lOepF82Hg5Fe7WXv0pnUKFFUxr+pf89bCjxGwktZIDM7ZMMXGIyladeIgTjsJkhpjRQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.266.0",
-        "@aws-sdk/client-sso": "3.266.0",
-        "@aws-sdk/client-sts": "3.266.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.266.0",
-        "@aws-sdk/credential-provider-env": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/credential-provider-ini": "3.266.0",
-        "@aws-sdk/credential-provider-node": "3.266.0",
-        "@aws-sdk/credential-provider-process": "3.266.0",
-        "@aws-sdk/credential-provider-sso": "3.266.0",
-        "@aws-sdk/credential-provider-web-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-cognito-identity": "3.267.0",
+        "@aws-sdk/client-sso": "3.267.0",
+        "@aws-sdk/client-sts": "3.267.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.267.0",
+        "@aws-sdk/credential-provider-env": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/credential-provider-ini": "3.267.0",
+        "@aws-sdk/credential-provider-node": "3.267.0",
+        "@aws-sdk/credential-provider-process": "3.267.0",
+        "@aws-sdk/credential-provider-sso": "3.267.0",
+        "@aws-sdk/credential-provider-web-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -575,25 +575,25 @@
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.266.0.tgz",
-      "integrity": "sha512-qqW5G/AdanNdAtNtDripRvijzgVOhvZ6NLRjVuOwWp3C5WRAAzMdl2lew2Q2swUy4InHwDsNeYjdhn1+hIIjrg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.267.0.tgz",
+      "integrity": "sha512-u8v8OvWvLVfifmETCAj+DCTot900AsdO1b+N+O8nXiTm2v99rtEoNRJW+no/5vJKNqR+95OAz4NWjFep8nzseg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/querystring-builder": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/querystring-builder": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.266.0.tgz",
-      "integrity": "sha512-E0uXwLU0/lY1itKhS2wsDBaqysAryV/Suk6cXpyJWe13iktRJhMoVaD3SYEJD9jytXohXYgXCRly8tDYnxPwZQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.267.0.tgz",
+      "integrity": "sha512-N3xeChdJg4V4jh2vrRN521EMJYxjUOo/LpvpisFyQHE/p31AfcOLb05upYFoYLvyeder9RHBIyNsvvnMYYoCsA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
@@ -603,12 +603,12 @@
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.266.0.tgz",
-      "integrity": "sha512-q3LkPLTd3LXhFnym6jjtlZzhJK9U4WekCyhFYrD+bBlyQGW/wuimpKE0ovGIyxuIZ/oklreYai5u1uH5FzgFlA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.267.0.tgz",
+      "integrity": "sha512-I95IR/eDLC54+9qrL6uh64nhpLVHwxxbBhhEUZKDACp86eXulO8T/DOwUX31ps4+2lI7tbEhQT7f9WDOO3fN8Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
@@ -625,13 +625,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.266.0.tgz",
-      "integrity": "sha512-sVsSJ00BBu5ttOOggNp9kRKPopz01g3+z4aZng8nH/ZLpNO0cNVJPqU0SOlwiWuYCQQBXJahMe/SpWLXuPPstA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.267.0.tgz",
+      "integrity": "sha512-b6MBIK12iwcATKnWIhsh50xWVMmZOXZFIo9D4io6D+JM6j/U+GZrSWqxhHzb3SjavuwVgA2hwq4mUCh2WJPJKA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -639,18 +639,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.266.0.tgz",
-      "integrity": "sha512-xAuLKmCjD8DYNIb9LVfnWG/16nqzoHEW+kxfecxeTaKGXb3eD+LoCbbE2l7pqBFC4uE+8ufrgexBBibHRnhotg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.267.0.tgz",
+      "integrity": "sha512-pGICM/qlQVfixtfKZt8zHq54KvLG2MmOAgNWj2MXB7oirPs/3rC9Kz9ITFXJgjlRFyfssgP/feKhs2yZkI8lhw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -658,13 +658,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.266.0.tgz",
-      "integrity": "sha512-Rz5xkVkr7DW23QiZoXHUhqXIHhtqM364jjmIfmHCXeYsobXqLw9spU8n2DLzcltFqFKLOljzahu3RKjYe5IUSw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.267.0.tgz",
+      "integrity": "sha512-D8TfjMeuQXTsB7Ni8liMmNqb3wz+T6t/tYUHtsMo0j++94KAPPj1rhkkTAjR4Rc+IYGCS4YyyCuCXjGB6gkjnA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -672,12 +672,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.266.0.tgz",
-      "integrity": "sha512-JiAvd0kKOmehdn2KBWxd7EobOVg5LCVZUtSKcwNdZiWhcxLw/z4Rn95J+Sk/e0GoHKETIkD5gRLWNNumjGgnvA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.267.0.tgz",
+      "integrity": "sha512-wnLeZYWbgGCuNmRl0Pmky0cSXBWmMTaQBgq90WfwyM0V8wzcoeaovTWA5/qe8oJzusOgUMFoVia4Ew20k3lu8w==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -685,13 +685,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.266.0.tgz",
-      "integrity": "sha512-kaAQQmeTL0JNPtT6g83FksIwnJfgtRP05a8FAeiLQOdhkxs862HWK7vpFHlEgSrGi49LP27Du+msqTErXcwOMQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.267.0.tgz",
+      "integrity": "sha512-NCBkTLxaW7XtfQoVBqQCaQZqec5XDtEylkw7g0tGjYDcl934fzu3ciH9MsJ34QFe9slYM6g4v+eC9f1w9K/19g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -699,16 +699,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.266.0.tgz",
-      "integrity": "sha512-SxfRXOfuuvllgtTSAPX/43+PTb0Xf8BlAoVQDstW+GDC+IfaL4wcmOKS4ClwUdzGEGBb4E+wL8wdEaVej3T3lA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.267.0.tgz",
+      "integrity": "sha512-MiiNtddZXVhtSAnJFyChwNxnhzMYmv6qWl8qgSjuIOw9SczkHPCoANTfUdRlzG6RfPYhgYtzMGqqnrficJ6mVg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/service-error-classification": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/util-middleware": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/service-error-classification": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/util-middleware": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -726,16 +726,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.266.0.tgz",
-      "integrity": "sha512-8yETgfyfFHc1m4v8LEUpxF2kEzc6qokjC6vwPGx2FghmZ9JdhpVWNJZRzpNqecKCl+MpkGfRv07NLvyc9veqww==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.267.0.tgz",
+      "integrity": "sha512-JLDNNvV7Hr0CQrf1vSmflvPbfDFIx5lFf8tY7DZwYWEE920ZzbJTfUsTW9iZHJGeIe8dAQX1tmfYL68+++nvEQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/middleware-signing": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -743,12 +743,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.266.0.tgz",
-      "integrity": "sha512-UX7kFB5SmizNBcFIw6qNp/87dldx0VsDIZtTDpbeS05O3vsh7BEfByibOFPS5PlGqWjZt0T+FLcx/9Y4XSrSxA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.267.0.tgz",
+      "integrity": "sha512-9qspxiZs+JShukzKMAameBSubfvtUOGZviu9GT5OfRekY2dBbwWcfchP2WvlwxZ/CcC+GwO1HcPqKDCMGsNoow==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -756,16 +756,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.266.0.tgz",
-      "integrity": "sha512-PlpngmBB5P9oxEdYZRtCbHiP1ftDk/RIWLY2ewk02xK6lkzY8tlZ8wPGOmshj9C7b3SzPOASJLEbtDS86yXn/Q==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.267.0.tgz",
+      "integrity": "sha512-thkFEBiFW0M/73dIzl7hQmyAONb8zyD2ZYUFyGm7cIM60sRDUKejPHV6Izonll+HbBZgiBdwUi42uu8O+LfFGQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.266.0.tgz",
-      "integrity": "sha512-v1BHaHu+o1MUYoozeHRJQBEbnQvFeOnxL8e1/uio19DdWqtOA2wv6eznTfsxXOORER1xZX38EjlcZGWbM41maA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.267.0.tgz",
+      "integrity": "sha512-52uH3JO3ceI15dgzt8gU7lpJf59qbRUQYJ7pAmTMiHtyEawZ39Puv6sGheY3fAffhqd/aQvup6wn18Q1fRIQUA==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -785,13 +785,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.266.0.tgz",
-      "integrity": "sha512-ofnRkm+iMMl6NatDa0nqGIFRVEtS5lIKntS4htPVsJvI/lqWzlgn75L2YgzYgkpU2o4GWBMvjCjhnnZ3V32BQQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.267.0.tgz",
+      "integrity": "sha512-eaReMnoB1Cx3OY8WDSiUMNDz/EkdAo4w/m3d5CizckKQNmB29gUrgyFs7g7sHTcShQAduZzlsfRPzc6NmKYaWQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -799,14 +799,14 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.266.0.tgz",
-      "integrity": "sha512-myK9Dr/QNfijEZQFOFkQJ8NAyZVA8yBiZTA15+EMphap1ciVXRGSpE/8KzF/qEX5wY2WoDZuPUUfmPebC3+jUA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.267.0.tgz",
+      "integrity": "sha512-wNX+Cu0x+kllng253j5dvmLm4opDRr7YehJ0rNGAV24X+UPJPluN9HrBFly+z4+bH16TpJEPKx7AayiWZGFE1w==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -814,15 +814,15 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.266.0.tgz",
-      "integrity": "sha512-JLezkHEDWN7dN/mZEzA0La+iKRZqxOyqjYJNpFNTz4ZiR0XlV5zhihHBkgatE0/hL1xVCV+ljSiyMGP//4DkjQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.267.0.tgz",
+      "integrity": "sha512-wtt3O+e8JEKaLFtmQd74HSZj2TyiApPkwMJ3R50hyboVswt8RcdMWdFbzLnPVpT1AqskG3fMECSKbu8AC/xvBQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/querystring-builder": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/abort-controller": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/querystring-builder": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -830,12 +830,12 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.266.0.tgz",
-      "integrity": "sha512-/M0HpUNkAUJF9wEKsWyJ/w2ZXwSwRByZ1IGkDluPoCweDmhbSp2n9WC8S/IyPktGlesEjQbfuLCvgjgiEfGPkg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.267.0.tgz",
+      "integrity": "sha512-/BD1Zar9PCQSV8VZTAWOJmtojAeMIl16ljZX3Kix84r45qqNNxuPST2AhNVN+p97Js4x9kBFCHkdFOpW94wr4Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -843,12 +843,12 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.266.0.tgz",
-      "integrity": "sha512-bg59CcRVgqKlrwDBdxy3NFmi30P61nUqZlAHaEtdxoj/oVHNaUKMDGl/YEM8O1UB2r0KO4KJdEu5tvAcChYk+A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.267.0.tgz",
+      "integrity": "sha512-8HhOZXMCZ0nsJC/FoifX7YrTYGP91tCpSxIHkr7HxQcTdBMI7QakMtIIWK9Qjsy6tUI98aAdEo5PNCbzdpozmQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -856,12 +856,12 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.266.0.tgz",
-      "integrity": "sha512-dor4slaD1ohUiGZxouK4Nu5LmRwspJg6JhOwKfaUMUR3oJnVnBBv5k/84UHjsmC6mJDWu4fEsfUd8rVg2HpYxA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.267.0.tgz",
+      "integrity": "sha512-SKo8V3oPV1wZy4r4lccH7R2LT0PUK/WGaXkKR30wyrtDjJRWVJDYef9ysOpRP+adCTt3G5XO0SzyPQUW5dXYVA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
@@ -870,12 +870,12 @@
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.266.0.tgz",
-      "integrity": "sha512-XECB7T7xNoFOfyqgitQPwjLDGn4Y9M5pnPVwdKs3UiZGvX0KSBxtWMNRo5Sv4QyIOm0DQYQimER1DiKxbrpvZA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.267.0.tgz",
+      "integrity": "sha512-Krq36GXqEfRfzJ9wOzkkzpbb4SWjgSYydTIgK6KtKapme0HPcB24kmmsjsUVuHzKuQMCHHDRWm+b47iBmHGpSQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -883,21 +883,21 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.266.0.tgz",
-      "integrity": "sha512-Yq9NVRkVaVzNsQsWZ6gwkfmyuPM6CBxBeWkjvcE0B4TiD8DDjFZIjGoUrUpGgraCA4W7WHeTwOFghzSK+BcYVA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.267.0.tgz",
+      "integrity": "sha512-fOWg7bcItmJqD/YQbGvN9o03ucoBzvWNTQEB81mLKMSKr1Cf/ms0f8oa94LlImgqjjfjvAqHh6rUBTpSmSEyaw==",
       "optional": true,
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.266.0.tgz",
-      "integrity": "sha512-8S/7I6FjQczulFha2ebpBfUcbg3G/NDp+fByTz9DWqY9EI4VsvCJsScYexSc9t89F0ny9zyyspfESzfzdy2PRw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.267.0.tgz",
+      "integrity": "sha512-Jz9R5hXKSk+aRoBKi4Bnf6T/FZUBYrIibbLnhiNxpQ1FY9mTggJR/rxuIdOE23LtfW+CRqqEYOtAtmC1oYE6tw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -905,15 +905,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.266.0.tgz",
-      "integrity": "sha512-TvDhA3yVTKLBgHNtKNY31m7O5HRSSQrk0OjVVt6mkEjAuXjSC4TDno+l/kOfpFco+gV1WiFt0cqrLAM6h9CL8A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.267.0.tgz",
+      "integrity": "sha512-Je1e7rum2zvxa3jWfwq4E+fyBdFJmSJAwGtWYz3+/rWipwXFlSAPeSVqtNjHdfzakgabvzLp7aesG4yQTrO2YQ==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
@@ -923,13 +923,13 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.266.0.tgz",
-      "integrity": "sha512-FCv4cIt/uDFe2E24mgnL4PlnQcnkIj1v7H/jS6amRoZAkrDai6DcvnUQJ6TsyRTjKY56K1Xq/ev7vcXe+bcVJA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.267.0.tgz",
+      "integrity": "sha512-WdgXHqKmFQIkAWETO/I5boX9u6QbMLC4X74OVSBaBLhRjqYmvolMFtNrQzvSKGB3FaxAN9Do41amC0mGoeLC8A==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -937,15 +937,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.266.0.tgz",
-      "integrity": "sha512-NnWqT03u8STssKnKkGtHUSFDUBgv/VF+h4rwvyY5NKO9FMReN0v90XE/Bb2Oa3pzx6C5AG89kGmAvy+0VRn+Rg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.267.0.tgz",
+      "integrity": "sha512-CGayGrPl4ONG4RuGbNv+QS4oVuItx4hK2FCbFS7d6V7h53rkDrcFd34NsvbicQ2KVFobE7fKs6ZaripJbJbLHA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-sso-oidc": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.266.0.tgz",
-      "integrity": "sha512-DGOnzUKM9gE1xRyzNKe9S0hOMHT1C1CEuTJ8MgPQjXj5UgndAIItU+9kkfeZTLSbp3rDHeNZ8EP9/oS9kC+q8Q==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.267.0.tgz",
+      "integrity": "sha512-fICTbSeIfXlTHnciQgDt37R0kXoKxgh0a3prnLWVvTcmf7NFujdZmg5YTAZT3KJJ7SuKsIgnI8azBYioVY8BVQ==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -965,13 +965,13 @@
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.266.0.tgz",
-      "integrity": "sha512-KeXkGDNBlNGdrXKu9mKE018GvgtJg5aH3mliXvPnO3jXlhpbgu7G+PJoykAJiw41fcIwWC/lX6JDMkmIgvElwQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.267.0.tgz",
+      "integrity": "sha512-xoQ5Fd11moiE82QTL9GGE6e73SFuD0Wi73tA75TAwKuY12OP5vDJ4oBC86A1G2T+OzeHJQmYyqiA5j48CzqB6A==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/querystring-parser": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
@@ -1035,13 +1035,13 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.266.0.tgz",
-      "integrity": "sha512-DzjU4TZyrvQBZfwdBBXTH5+SjeHWSrCplOOt6zXKtu8rt5GntVS4Oyx0DTz1JGCAqesicQpZ9jTQ6YKp7EOntw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.267.0.tgz",
+      "integrity": "sha512-MgrqpedA58HVR8RpT2A42//5Lb3M0JwEiYlDaA7EvIVsMx1NzO+cng4MDJi03YBAP5hwCVQmO9Sf5Au4dm+m0g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       },
@@ -1050,16 +1050,16 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.266.0.tgz",
-      "integrity": "sha512-hyxPm84YuHPxze7jHnYaLBGVcmdE6V9irlXUe3V/JgYYCnGdwMob+TNwkdWVp4DGW/8b41FxlBDvRZPBKCvTpQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.267.0.tgz",
+      "integrity": "sha512-JyFk95T77sGM4q386id/mDt9/7HvoQySAygPyv/lj//WEJJIRKiefB277CKKJPT8nRAsO4mIyAT+YO/xGCxkQA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1067,12 +1067,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.266.0.tgz",
-      "integrity": "sha512-G75mBFyEoO9+fnx2BawcmdnRyBkE2mIyDl560cgxH3HiicmgED71QNQ+qWxxmFx+G4bnZOft+2l9BfIf+i9wcA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.267.0.tgz",
+      "integrity": "sha512-c6miY83Eo0erqXY+YiS2sOg3izURqvaWHd9przJzBQea9XRCN4ANT2P8AhoC0BPIORutaaOSoCSp/crHG0XLLg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.266.0.tgz",
-      "integrity": "sha512-q5dWY20Euh9vCXCuTNbcKXLNhW6dXBHxYAHR+csP2OFNLLB4wiJaeMYr9iwcB0YXcfnpQbXznSF0PLbPPZgCmw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.267.0.tgz",
+      "integrity": "sha512-7nvqBZVz3RdwYv6lU958g6sWI2Qt8lzxDVn0uwfnPH+fAiX7Ln1Hen2A0XeW5cL5uYUJy6wNM5cyfTzFZosE0A==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1116,12 +1116,12 @@
       }
     },
     "node_modules/@aws-sdk/util-retry": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.266.0.tgz",
-      "integrity": "sha512-+HcMcJ8y9O3Jsq0I3Zqh9/cqMey3RM4j+M6hzAsFBOwjbBvWV4EfXb5g+NODJzyLxrBIHAesZyyQAiCipvbAlA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.267.0.tgz",
+      "integrity": "sha512-ZXo1ICG2HgxkIZWlnPteh2R90kwmhRwvbP282CwrrYgTKuMZmW2R/+o6vqhWyPkjoNFN/pno0FxuDA3IYau3Sw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.266.0",
+        "@aws-sdk/service-error-classification": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1141,24 +1141,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.266.0.tgz",
-      "integrity": "sha512-pMJ4C5lzDEVJ0kZoZdV1ww4hn9s15cExaPcRgUqjCwzNxYo9E1Jc6wCC533sYNZF1aSkY9NDLyJmv/lP7FvF4A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.267.0.tgz",
+      "integrity": "sha512-SmI6xInnPPa0gFhCqhtWOUMTxLeRbm7X5HXzeprhK1d8aNNlUVyALAV7K8ovIjnv3a97lIJSekyb78oTuYITCA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.266.0.tgz",
-      "integrity": "sha512-CNpJsxvEplAP3XLwUmr7iJ428pCH2aFQIFLjXFjcAaB2IbgG1/801hdzdmeBH+1LSYVJ5qd3R+HeaZhxMDo62A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.267.0.tgz",
+      "integrity": "sha512-nfmyffA1yIypJ30CIMO6Tc16t8dFJzdztzoowjmnfb8/LzTZECERM3GICq0DvZDPfSo+jbuz634VtS2K7tVZjA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2989,6 +2989,11 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
       "version": "7.20.13",
@@ -7275,11 +7280,6 @@
         "regjsparser": "^0.1.4"
       }
     },
-    "node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g=="
-    },
     "node_modules/babel-plugin-transform-es2015-unicode-regex/node_modules/regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
@@ -8119,9 +8119,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001450",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
-      "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==",
+      "version": "1.0.30001451",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
+      "integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==",
       "funding": [
         {
           "type": "opencollective",
@@ -9371,9 +9371,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.288",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.288.tgz",
-      "integrity": "sha512-8s9aJf3YiokIrR+HOQzNOGmEHFXVUQzXM/JaViVvKdCkNUjS+lEa/uT7xw3nDVG/IgfxiIwUGkwJ6AR1pTpYsQ=="
+      "version": "1.4.292",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.292.tgz",
+      "integrity": "sha512-ESWOSyJy5odDlE8wvh5NNAMORv4r6assPwIPGHEMWrWD0SONXcG/xT+9aD9CQyeRwyYDPo6dJT4Bbeg5uevVQQ=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -18409,13 +18409,13 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.2.tgz",
-      "integrity": "sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.0.tgz",
+      "integrity": "sha512-ZdhUQlng0RoscyW7jADnUZ25F5eVtHdMyXSb2PiwafvteRAOJUjFoUPEYZSIfP99fBIs3maLIRfpEddT78wAAQ==",
       "dependencies": {
+        "@babel/regjsgen": "^0.8.0",
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.1.0",
-        "regjsgen": "^0.7.1",
         "regjsparser": "^0.9.1",
         "unicode-match-property-ecmascript": "^2.0.0",
         "unicode-match-property-value-ecmascript": "^2.1.0"
@@ -18452,9 +18452,9 @@
       }
     },
     "node_modules/regjsgen": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
-      "integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g=="
     },
     "node_modules/regjsparser": {
       "version": "0.9.1",
@@ -20440,9 +20440,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.6.tgz",
-      "integrity": "sha512-6bd2bflx8ed7c99tc6zSTIzHr1/QG29bQoK4Qh8MYGnlPbODUzGxklLShjwc/xWQQFHgIci+y5Arv7Rbb0LjXw==",
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.7.tgz",
+      "integrity": "sha512-6J4bYzb4sdkcLBty4XW7F18VPI66M4boXNE+CY40532oq2OJe6AVMB5NmjOp6skt/jw5mRjz/hLRpuglz0U+FA==",
       "engines": {
         "node": ">=14.16"
       },
@@ -21700,358 +21700,358 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.266.0.tgz",
-      "integrity": "sha512-H/ySWWSwJN5coP9c5Ge2pOJYs1YPG5AVemGeKRx3kw5Z7Btd9jSFyYV0qGPd78HG3FopjZqSb4l2puPPp8UdpA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.267.0.tgz",
+      "integrity": "sha512-5R7OSnHFV/f+qQpMf1RuSQoVdXroK94Vl6naWjMOAhMyofHykVhEok9hmFPac86AVx8rVX/vuA7u9GKI6/EE7g==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-cognito-identity": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.266.0.tgz",
-      "integrity": "sha512-Hww10GE9J1baUIO9GuNgoRp4DU8mwuaeO8aIij4p1EaeyAmeV2LbLFt04UBZfwF4BGFrbssauRlItf+/IMFaTA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.267.0.tgz",
+      "integrity": "sha512-jEE5aw7wp7VhiaU0vCbNQbEIhiaNZnBhRj+vJVCd2HQBI9IVLVXAoyExWxLruAXKEO+A1w1df+fwZAOo0M7aQQ==",
       "optional": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.266.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/credential-provider-node": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-signing": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/client-sts": "3.267.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/credential-provider-node": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-signing": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.266.0.tgz",
-      "integrity": "sha512-eK20HlA61ehvCBf62bk29DX0cXPQh2/KMlvuHnjhxDrn4BLMxLCMer8Awz3MIoBbVQKG1h46X2z6/pJra8Fs4w==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.267.0.tgz",
+      "integrity": "sha512-/475/mT0gYhimpCdK4iZW+eX0DT6mkTgVk5P9ARpQGzEblFM6i2pE7GQnlGeLyHVOtA0cNAyGrWUuj2pyigUaA==",
       "optional": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.266.0.tgz",
-      "integrity": "sha512-kpXr0Vj7IjDZ1ef3GHAe+/eDFp/XpEKfNHCl0r2MB5zTTFYxDm8BlFl7qB1rBJlqzqpPRhy+1J+UAsg84melsw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.267.0.tgz",
+      "integrity": "sha512-Jdq0v0mJSJbG/CKLfHC1L0cjCot48Y6lLMQV1lfkYE65xD0ZSs8Gl7P/T391ZH7cLO6ifVoPdsYnwzhi1ZPXSQ==",
       "optional": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.266.0.tgz",
-      "integrity": "sha512-ml3cjtIhHP21OwNKAC25ys5nAox0m4E2gPH97Q5s/1aE/hzxqQKkTO6YWp3eW7gwruubNV1GG/w0uHvAUYMjBw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.267.0.tgz",
+      "integrity": "sha512-bJ+SwJZAP3DuDUgToDV89HsB80IhSfB1rhzLG9csqs6h7uMLO8H1/fymElYKT4VMMAA+rpWJ3pznyGiCK7w28A==",
       "optional": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/credential-provider-node": "3.266.0",
-        "@aws-sdk/fetch-http-handler": "3.266.0",
-        "@aws-sdk/hash-node": "3.266.0",
-        "@aws-sdk/invalid-dependency": "3.266.0",
-        "@aws-sdk/middleware-content-length": "3.266.0",
-        "@aws-sdk/middleware-endpoint": "3.266.0",
-        "@aws-sdk/middleware-host-header": "3.266.0",
-        "@aws-sdk/middleware-logger": "3.266.0",
-        "@aws-sdk/middleware-recursion-detection": "3.266.0",
-        "@aws-sdk/middleware-retry": "3.266.0",
-        "@aws-sdk/middleware-sdk-sts": "3.266.0",
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/middleware-signing": "3.266.0",
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/middleware-user-agent": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/node-http-handler": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/smithy-client": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/credential-provider-node": "3.267.0",
+        "@aws-sdk/fetch-http-handler": "3.267.0",
+        "@aws-sdk/hash-node": "3.267.0",
+        "@aws-sdk/invalid-dependency": "3.267.0",
+        "@aws-sdk/middleware-content-length": "3.267.0",
+        "@aws-sdk/middleware-endpoint": "3.267.0",
+        "@aws-sdk/middleware-host-header": "3.267.0",
+        "@aws-sdk/middleware-logger": "3.267.0",
+        "@aws-sdk/middleware-recursion-detection": "3.267.0",
+        "@aws-sdk/middleware-retry": "3.267.0",
+        "@aws-sdk/middleware-sdk-sts": "3.267.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/middleware-signing": "3.267.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/middleware-user-agent": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/node-http-handler": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/smithy-client": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
-        "@aws-sdk/util-defaults-mode-node": "3.266.0",
-        "@aws-sdk/util-endpoints": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
-        "@aws-sdk/util-user-agent-browser": "3.266.0",
-        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.267.0",
+        "@aws-sdk/util-defaults-mode-node": "3.267.0",
+        "@aws-sdk/util-endpoints": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
+        "@aws-sdk/util-user-agent-browser": "3.267.0",
+        "@aws-sdk/util-user-agent-node": "3.267.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.266.0.tgz",
-      "integrity": "sha512-s1DKPIJVcB506mRDGLzRAT3ZFUD/JvglbRoN9/oGUkCHusiOAlOIuTTilSfkjq13Ntq+O/sUIpWhir0R45dBcA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.267.0.tgz",
+      "integrity": "sha512-UMvJY548xOkamU9ZuZk336VX9r3035CAbttagiPJ/FXy9S8jcQ7N722PAovtxs69nNBQf56cmWsnOHphLCGG9w==",
       "optional": true,
       "requires": {
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.266.0.tgz",
-      "integrity": "sha512-eBNEr1Vs0G8GIKVaZ07XPnH93+yUP6gjUAyBfdEsMvs9S9LmSXfwskKUeQhB1X0d4L9VqDo8AZ5zOufurGPbfg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.267.0.tgz",
+      "integrity": "sha512-H97VsbiTcb4tbY/LQMZNglJIHt7CHso7RtGgctmdsEA7Rha79fV/egF0Vqo2OQHDgEEpgQDWCeHbXO1P5ibR/A==",
       "optional": true,
       "requires": {
-        "@aws-sdk/client-cognito-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-cognito-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.266.0.tgz",
-      "integrity": "sha512-hh6/mkchzl6KUZBNFBkTB2YKEKPr2nLYS65d5DQnj+O2zXrWzVejS3mGT5iI7FZTcmKEdkxEGM+w8eZNGrdLBQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.267.0.tgz",
+      "integrity": "sha512-oiem2UtaFe4CQHscUCImJjPhYWd4iF8fqXhlq6BqHs1wsO6A0vnIUGh+Srut/2q7Xeegl/SRU34HK0hh8JCbxg==",
       "optional": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.266.0.tgz",
-      "integrity": "sha512-UEfzcMtSJsNt9DedP+LDAG3cSLq7XFl/6wJAkDAAeNuDmy5iTCk03sZF21LJ1A31GKviEHpxLquBslOdk1DYGQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.267.0.tgz",
+      "integrity": "sha512-Afd5+LdJ9QyeI5L4iyVmI4MLV+0JBtRLmRy0LdinwJaP0DyKyv9+uaIaorKfWihQpe8hwjEfQWTlTz2A3JMJtw==",
       "optional": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.266.0.tgz",
-      "integrity": "sha512-zyQo/eCtiPjoDvcsDI4xBojY6qy+o59B4LiVan1byvDQBbdI2VqshaDC4E+VJyCXcIZlYY1cT5NWt2g3wKKOLg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.267.0.tgz",
+      "integrity": "sha512-pHHlqZqZXA4cTssTyRmbYtrjxS2BEy2KFYHEEHNUrd82pUHnj70n+lrpVnT5pRhPPDacpNzxq0KZGeNgmETpbw==",
       "optional": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/credential-provider-process": "3.266.0",
-        "@aws-sdk/credential-provider-sso": "3.266.0",
-        "@aws-sdk/credential-provider-web-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/credential-provider-env": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/credential-provider-process": "3.267.0",
+        "@aws-sdk/credential-provider-sso": "3.267.0",
+        "@aws-sdk/credential-provider-web-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.266.0.tgz",
-      "integrity": "sha512-x4KtMZFpNuh6jfrKWtOnwkRrVJj4dR7fAWD95xiUtykE4eD7YthTBOQPVtRcroxHNKo80gmcZnJf6ZdvHG0XCw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.267.0.tgz",
+      "integrity": "sha512-uo8VyZ/L8HBXskYZC65bR1ZUJ5mBn8JarrGHt6vMG2A+uM7AuryTsKn2wdhPfuCUGKuQLXmix5K4VW/wzq11kQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/credential-provider-ini": "3.266.0",
-        "@aws-sdk/credential-provider-process": "3.266.0",
-        "@aws-sdk/credential-provider-sso": "3.266.0",
-        "@aws-sdk/credential-provider-web-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/credential-provider-env": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/credential-provider-ini": "3.267.0",
+        "@aws-sdk/credential-provider-process": "3.267.0",
+        "@aws-sdk/credential-provider-sso": "3.267.0",
+        "@aws-sdk/credential-provider-web-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.266.0.tgz",
-      "integrity": "sha512-x9MvMCAVUGr/7c2h6HbpDbEQSkdc2CH7snqdzl3fL6f3Q2HqhIG9rYWi9kAm4WIOIe2AuEIyzpOcGhwu+lyAqQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.267.0.tgz",
+      "integrity": "sha512-pd1OOB1Mm+QdPv3sPfO+1G8HBaPAAYXxjLcOK5z/myBeZAsLR12Xcaft4RR1XWwXXKEQqq42cbAINWQdyVykqQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.266.0.tgz",
-      "integrity": "sha512-48QjXHmL8etffasJa0ioQxLvFGJrD53cPC8PbiUCcsbhmEg7TEGIRDdir7h+RzEup+9s1kJhdwCsi1k2jkyXMg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.267.0.tgz",
+      "integrity": "sha512-JqwxelzeRhVdloNi+VUUXhJdziTtNrrwMuhds9wj4KPfl1S2EIzkRxHSjwDz1wtSyuIPOOo6pPJiaVbwvLpkVg==",
       "optional": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/token-providers": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-sso": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/token-providers": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.266.0.tgz",
-      "integrity": "sha512-EMcH+vt/WyWysHa2vwq2G3n73gRhyJ7fw3sh+3MhBtK5850bpLeSBz3iXvow3VKm8rbkn5IwZ2YdwG2OZgr66w==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.267.0.tgz",
+      "integrity": "sha512-za5UsQmj3sYRhd4h5eStj3GCHHfAAjfx2x5FmgQ9ldOp+s0wHEqSL1g+OL9v6o8otf9JnWha+wfUYq3yVGfufQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-providers": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.266.0.tgz",
-      "integrity": "sha512-FyUNKLZ6B5vFVmxFzmi1lHcFq7MkQU+sJQpBPiBenWu4UeqWL6QUhxSYx2J4ptE8W+JYkhnrBoBitHkOecFDZQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.267.0.tgz",
+      "integrity": "sha512-Og70E1eHGcxShMbrmm8lOepF82Hg5Fe7WXv0pnUKFFUxr+pf89bCjxGwktZIDM7ZMMXGIyladeIgTjsJkhpjRQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/client-cognito-identity": "3.266.0",
-        "@aws-sdk/client-sso": "3.266.0",
-        "@aws-sdk/client-sts": "3.266.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.266.0",
-        "@aws-sdk/credential-provider-env": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/credential-provider-ini": "3.266.0",
-        "@aws-sdk/credential-provider-node": "3.266.0",
-        "@aws-sdk/credential-provider-process": "3.266.0",
-        "@aws-sdk/credential-provider-sso": "3.266.0",
-        "@aws-sdk/credential-provider-web-identity": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-cognito-identity": "3.267.0",
+        "@aws-sdk/client-sso": "3.267.0",
+        "@aws-sdk/client-sts": "3.267.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.267.0",
+        "@aws-sdk/credential-provider-env": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/credential-provider-ini": "3.267.0",
+        "@aws-sdk/credential-provider-node": "3.267.0",
+        "@aws-sdk/credential-provider-process": "3.267.0",
+        "@aws-sdk/credential-provider-sso": "3.267.0",
+        "@aws-sdk/credential-provider-web-identity": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.266.0.tgz",
-      "integrity": "sha512-qqW5G/AdanNdAtNtDripRvijzgVOhvZ6NLRjVuOwWp3C5WRAAzMdl2lew2Q2swUy4InHwDsNeYjdhn1+hIIjrg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.267.0.tgz",
+      "integrity": "sha512-u8v8OvWvLVfifmETCAj+DCTot900AsdO1b+N+O8nXiTm2v99rtEoNRJW+no/5vJKNqR+95OAz4NWjFep8nzseg==",
       "optional": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/querystring-builder": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/querystring-builder": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.266.0.tgz",
-      "integrity": "sha512-E0uXwLU0/lY1itKhS2wsDBaqysAryV/Suk6cXpyJWe13iktRJhMoVaD3SYEJD9jytXohXYgXCRly8tDYnxPwZQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.267.0.tgz",
+      "integrity": "sha512-N3xeChdJg4V4jh2vrRN521EMJYxjUOo/LpvpisFyQHE/p31AfcOLb05upYFoYLvyeder9RHBIyNsvvnMYYoCsA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.266.0.tgz",
-      "integrity": "sha512-q3LkPLTd3LXhFnym6jjtlZzhJK9U4WekCyhFYrD+bBlyQGW/wuimpKE0ovGIyxuIZ/oklreYai5u1uH5FzgFlA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.267.0.tgz",
+      "integrity": "sha512-I95IR/eDLC54+9qrL6uh64nhpLVHwxxbBhhEUZKDACp86eXulO8T/DOwUX31ps4+2lI7tbEhQT7f9WDOO3fN8Q==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
@@ -22065,75 +22065,75 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.266.0.tgz",
-      "integrity": "sha512-sVsSJ00BBu5ttOOggNp9kRKPopz01g3+z4aZng8nH/ZLpNO0cNVJPqU0SOlwiWuYCQQBXJahMe/SpWLXuPPstA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.267.0.tgz",
+      "integrity": "sha512-b6MBIK12iwcATKnWIhsh50xWVMmZOXZFIo9D4io6D+JM6j/U+GZrSWqxhHzb3SjavuwVgA2hwq4mUCh2WJPJKA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.266.0.tgz",
-      "integrity": "sha512-xAuLKmCjD8DYNIb9LVfnWG/16nqzoHEW+kxfecxeTaKGXb3eD+LoCbbE2l7pqBFC4uE+8ufrgexBBibHRnhotg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.267.0.tgz",
+      "integrity": "sha512-pGICM/qlQVfixtfKZt8zHq54KvLG2MmOAgNWj2MXB7oirPs/3rC9Kz9ITFXJgjlRFyfssgP/feKhs2yZkI8lhw==",
       "optional": true,
       "requires": {
-        "@aws-sdk/middleware-serde": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/middleware-serde": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/url-parser": "3.267.0",
         "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.266.0.tgz",
-      "integrity": "sha512-Rz5xkVkr7DW23QiZoXHUhqXIHhtqM364jjmIfmHCXeYsobXqLw9spU8n2DLzcltFqFKLOljzahu3RKjYe5IUSw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.267.0.tgz",
+      "integrity": "sha512-D8TfjMeuQXTsB7Ni8liMmNqb3wz+T6t/tYUHtsMo0j++94KAPPj1rhkkTAjR4Rc+IYGCS4YyyCuCXjGB6gkjnA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.266.0.tgz",
-      "integrity": "sha512-JiAvd0kKOmehdn2KBWxd7EobOVg5LCVZUtSKcwNdZiWhcxLw/z4Rn95J+Sk/e0GoHKETIkD5gRLWNNumjGgnvA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.267.0.tgz",
+      "integrity": "sha512-wnLeZYWbgGCuNmRl0Pmky0cSXBWmMTaQBgq90WfwyM0V8wzcoeaovTWA5/qe8oJzusOgUMFoVia4Ew20k3lu8w==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.266.0.tgz",
-      "integrity": "sha512-kaAQQmeTL0JNPtT6g83FksIwnJfgtRP05a8FAeiLQOdhkxs862HWK7vpFHlEgSrGi49LP27Du+msqTErXcwOMQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.267.0.tgz",
+      "integrity": "sha512-NCBkTLxaW7XtfQoVBqQCaQZqec5XDtEylkw7g0tGjYDcl934fzu3ciH9MsJ34QFe9slYM6g4v+eC9f1w9K/19g==",
       "optional": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.266.0.tgz",
-      "integrity": "sha512-SxfRXOfuuvllgtTSAPX/43+PTb0Xf8BlAoVQDstW+GDC+IfaL4wcmOKS4ClwUdzGEGBb4E+wL8wdEaVej3T3lA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.267.0.tgz",
+      "integrity": "sha512-MiiNtddZXVhtSAnJFyChwNxnhzMYmv6qWl8qgSjuIOw9SczkHPCoANTfUdRlzG6RfPYhgYtzMGqqnrficJ6mVg==",
       "optional": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/service-error-classification": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/util-middleware": "3.266.0",
-        "@aws-sdk/util-retry": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/service-error-classification": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/util-middleware": "3.267.0",
+        "@aws-sdk/util-retry": "3.267.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -22147,201 +22147,201 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.266.0.tgz",
-      "integrity": "sha512-8yETgfyfFHc1m4v8LEUpxF2kEzc6qokjC6vwPGx2FghmZ9JdhpVWNJZRzpNqecKCl+MpkGfRv07NLvyc9veqww==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.267.0.tgz",
+      "integrity": "sha512-JLDNNvV7Hr0CQrf1vSmflvPbfDFIx5lFf8tY7DZwYWEE920ZzbJTfUsTW9iZHJGeIe8dAQX1tmfYL68+++nvEQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/middleware-signing": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.266.0.tgz",
-      "integrity": "sha512-UX7kFB5SmizNBcFIw6qNp/87dldx0VsDIZtTDpbeS05O3vsh7BEfByibOFPS5PlGqWjZt0T+FLcx/9Y4XSrSxA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.267.0.tgz",
+      "integrity": "sha512-9qspxiZs+JShukzKMAameBSubfvtUOGZviu9GT5OfRekY2dBbwWcfchP2WvlwxZ/CcC+GwO1HcPqKDCMGsNoow==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.266.0.tgz",
-      "integrity": "sha512-PlpngmBB5P9oxEdYZRtCbHiP1ftDk/RIWLY2ewk02xK6lkzY8tlZ8wPGOmshj9C7b3SzPOASJLEbtDS86yXn/Q==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.267.0.tgz",
+      "integrity": "sha512-thkFEBiFW0M/73dIzl7hQmyAONb8zyD2ZYUFyGm7cIM60sRDUKejPHV6Izonll+HbBZgiBdwUi42uu8O+LfFGQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/signature-v4": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/signature-v4": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.266.0.tgz",
-      "integrity": "sha512-v1BHaHu+o1MUYoozeHRJQBEbnQvFeOnxL8e1/uio19DdWqtOA2wv6eznTfsxXOORER1xZX38EjlcZGWbM41maA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.267.0.tgz",
+      "integrity": "sha512-52uH3JO3ceI15dgzt8gU7lpJf59qbRUQYJ7pAmTMiHtyEawZ39Puv6sGheY3fAffhqd/aQvup6wn18Q1fRIQUA==",
       "optional": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.266.0.tgz",
-      "integrity": "sha512-ofnRkm+iMMl6NatDa0nqGIFRVEtS5lIKntS4htPVsJvI/lqWzlgn75L2YgzYgkpU2o4GWBMvjCjhnnZ3V32BQQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.267.0.tgz",
+      "integrity": "sha512-eaReMnoB1Cx3OY8WDSiUMNDz/EkdAo4w/m3d5CizckKQNmB29gUrgyFs7g7sHTcShQAduZzlsfRPzc6NmKYaWQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.266.0.tgz",
-      "integrity": "sha512-myK9Dr/QNfijEZQFOFkQJ8NAyZVA8yBiZTA15+EMphap1ciVXRGSpE/8KzF/qEX5wY2WoDZuPUUfmPebC3+jUA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.267.0.tgz",
+      "integrity": "sha512-wNX+Cu0x+kllng253j5dvmLm4opDRr7YehJ0rNGAV24X+UPJPluN9HrBFly+z4+bH16TpJEPKx7AayiWZGFE1w==",
       "optional": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.266.0.tgz",
-      "integrity": "sha512-JLezkHEDWN7dN/mZEzA0La+iKRZqxOyqjYJNpFNTz4ZiR0XlV5zhihHBkgatE0/hL1xVCV+ljSiyMGP//4DkjQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.267.0.tgz",
+      "integrity": "sha512-wtt3O+e8JEKaLFtmQd74HSZj2TyiApPkwMJ3R50hyboVswt8RcdMWdFbzLnPVpT1AqskG3fMECSKbu8AC/xvBQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.266.0",
-        "@aws-sdk/protocol-http": "3.266.0",
-        "@aws-sdk/querystring-builder": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/abort-controller": "3.267.0",
+        "@aws-sdk/protocol-http": "3.267.0",
+        "@aws-sdk/querystring-builder": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.266.0.tgz",
-      "integrity": "sha512-/M0HpUNkAUJF9wEKsWyJ/w2ZXwSwRByZ1IGkDluPoCweDmhbSp2n9WC8S/IyPktGlesEjQbfuLCvgjgiEfGPkg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.267.0.tgz",
+      "integrity": "sha512-/BD1Zar9PCQSV8VZTAWOJmtojAeMIl16ljZX3Kix84r45qqNNxuPST2AhNVN+p97Js4x9kBFCHkdFOpW94wr4Q==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.266.0.tgz",
-      "integrity": "sha512-bg59CcRVgqKlrwDBdxy3NFmi30P61nUqZlAHaEtdxoj/oVHNaUKMDGl/YEM8O1UB2r0KO4KJdEu5tvAcChYk+A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.267.0.tgz",
+      "integrity": "sha512-8HhOZXMCZ0nsJC/FoifX7YrTYGP91tCpSxIHkr7HxQcTdBMI7QakMtIIWK9Qjsy6tUI98aAdEo5PNCbzdpozmQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.266.0.tgz",
-      "integrity": "sha512-dor4slaD1ohUiGZxouK4Nu5LmRwspJg6JhOwKfaUMUR3oJnVnBBv5k/84UHjsmC6mJDWu4fEsfUd8rVg2HpYxA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.267.0.tgz",
+      "integrity": "sha512-SKo8V3oPV1wZy4r4lccH7R2LT0PUK/WGaXkKR30wyrtDjJRWVJDYef9ysOpRP+adCTt3G5XO0SzyPQUW5dXYVA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.266.0.tgz",
-      "integrity": "sha512-XECB7T7xNoFOfyqgitQPwjLDGn4Y9M5pnPVwdKs3UiZGvX0KSBxtWMNRo5Sv4QyIOm0DQYQimER1DiKxbrpvZA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.267.0.tgz",
+      "integrity": "sha512-Krq36GXqEfRfzJ9wOzkkzpbb4SWjgSYydTIgK6KtKapme0HPcB24kmmsjsUVuHzKuQMCHHDRWm+b47iBmHGpSQ==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.266.0.tgz",
-      "integrity": "sha512-Yq9NVRkVaVzNsQsWZ6gwkfmyuPM6CBxBeWkjvcE0B4TiD8DDjFZIjGoUrUpGgraCA4W7WHeTwOFghzSK+BcYVA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.267.0.tgz",
+      "integrity": "sha512-fOWg7bcItmJqD/YQbGvN9o03ucoBzvWNTQEB81mLKMSKr1Cf/ms0f8oa94LlImgqjjfjvAqHh6rUBTpSmSEyaw==",
       "optional": true
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.266.0.tgz",
-      "integrity": "sha512-8S/7I6FjQczulFha2ebpBfUcbg3G/NDp+fByTz9DWqY9EI4VsvCJsScYexSc9t89F0ny9zyyspfESzfzdy2PRw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.267.0.tgz",
+      "integrity": "sha512-Jz9R5hXKSk+aRoBKi4Bnf6T/FZUBYrIibbLnhiNxpQ1FY9mTggJR/rxuIdOE23LtfW+CRqqEYOtAtmC1oYE6tw==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.266.0.tgz",
-      "integrity": "sha512-TvDhA3yVTKLBgHNtKNY31m7O5HRSSQrk0OjVVt6mkEjAuXjSC4TDno+l/kOfpFco+gV1WiFt0cqrLAM6h9CL8A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.267.0.tgz",
+      "integrity": "sha512-Je1e7rum2zvxa3jWfwq4E+fyBdFJmSJAwGtWYz3+/rWipwXFlSAPeSVqtNjHdfzakgabvzLp7aesG4yQTrO2YQ==",
       "optional": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-middleware": "3.267.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.266.0.tgz",
-      "integrity": "sha512-FCv4cIt/uDFe2E24mgnL4PlnQcnkIj1v7H/jS6amRoZAkrDai6DcvnUQJ6TsyRTjKY56K1Xq/ev7vcXe+bcVJA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.267.0.tgz",
+      "integrity": "sha512-WdgXHqKmFQIkAWETO/I5boX9u6QbMLC4X74OVSBaBLhRjqYmvolMFtNrQzvSKGB3FaxAN9Do41amC0mGoeLC8A==",
       "optional": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/middleware-stack": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.266.0.tgz",
-      "integrity": "sha512-NnWqT03u8STssKnKkGtHUSFDUBgv/VF+h4rwvyY5NKO9FMReN0v90XE/Bb2Oa3pzx6C5AG89kGmAvy+0VRn+Rg==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.267.0.tgz",
+      "integrity": "sha512-CGayGrPl4ONG4RuGbNv+QS4oVuItx4hK2FCbFS7d6V7h53rkDrcFd34NsvbicQ2KVFobE7fKs6ZaripJbJbLHA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/shared-ini-file-loader": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/client-sso-oidc": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/shared-ini-file-loader": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.266.0.tgz",
-      "integrity": "sha512-DGOnzUKM9gE1xRyzNKe9S0hOMHT1C1CEuTJ8MgPQjXj5UgndAIItU+9kkfeZTLSbp3rDHeNZ8EP9/oS9kC+q8Q==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.267.0.tgz",
+      "integrity": "sha512-fICTbSeIfXlTHnciQgDt37R0kXoKxgh0a3prnLWVvTcmf7NFujdZmg5YTAZT3KJJ7SuKsIgnI8azBYioVY8BVQ==",
       "optional": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/url-parser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.266.0.tgz",
-      "integrity": "sha512-KeXkGDNBlNGdrXKu9mKE018GvgtJg5aH3mliXvPnO3jXlhpbgu7G+PJoykAJiw41fcIwWC/lX6JDMkmIgvElwQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.267.0.tgz",
+      "integrity": "sha512-xoQ5Fd11moiE82QTL9GGE6e73SFuD0Wi73tA75TAwKuY12OP5vDJ4oBC86A1G2T+OzeHJQmYyqiA5j48CzqB6A==",
       "optional": true,
       "requires": {
-        "@aws-sdk/querystring-parser": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/querystring-parser": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
@@ -22393,38 +22393,38 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.266.0.tgz",
-      "integrity": "sha512-DzjU4TZyrvQBZfwdBBXTH5+SjeHWSrCplOOt6zXKtu8rt5GntVS4Oyx0DTz1JGCAqesicQpZ9jTQ6YKp7EOntw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.267.0.tgz",
+      "integrity": "sha512-MgrqpedA58HVR8RpT2A42//5Lb3M0JwEiYlDaA7EvIVsMx1NzO+cng4MDJi03YBAP5hwCVQmO9Sf5Au4dm+m0g==",
       "optional": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.266.0.tgz",
-      "integrity": "sha512-hyxPm84YuHPxze7jHnYaLBGVcmdE6V9irlXUe3V/JgYYCnGdwMob+TNwkdWVp4DGW/8b41FxlBDvRZPBKCvTpQ==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.267.0.tgz",
+      "integrity": "sha512-JyFk95T77sGM4q386id/mDt9/7HvoQySAygPyv/lj//WEJJIRKiefB277CKKJPT8nRAsO4mIyAT+YO/xGCxkQA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.266.0",
-        "@aws-sdk/credential-provider-imds": "3.266.0",
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/property-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/config-resolver": "3.267.0",
+        "@aws-sdk/credential-provider-imds": "3.267.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/property-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.266.0.tgz",
-      "integrity": "sha512-G75mBFyEoO9+fnx2BawcmdnRyBkE2mIyDl560cgxH3HiicmgED71QNQ+qWxxmFx+G4bnZOft+2l9BfIf+i9wcA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.267.0.tgz",
+      "integrity": "sha512-c6miY83Eo0erqXY+YiS2sOg3izURqvaWHd9przJzBQea9XRCN4ANT2P8AhoC0BPIORutaaOSoCSp/crHG0XLLg==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
@@ -22447,21 +22447,21 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.266.0.tgz",
-      "integrity": "sha512-q5dWY20Euh9vCXCuTNbcKXLNhW6dXBHxYAHR+csP2OFNLLB4wiJaeMYr9iwcB0YXcfnpQbXznSF0PLbPPZgCmw==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.267.0.tgz",
+      "integrity": "sha512-7nvqBZVz3RdwYv6lU958g6sWI2Qt8lzxDVn0uwfnPH+fAiX7Ln1Hen2A0XeW5cL5uYUJy6wNM5cyfTzFZosE0A==",
       "optional": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-retry": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.266.0.tgz",
-      "integrity": "sha512-+HcMcJ8y9O3Jsq0I3Zqh9/cqMey3RM4j+M6hzAsFBOwjbBvWV4EfXb5g+NODJzyLxrBIHAesZyyQAiCipvbAlA==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.267.0.tgz",
+      "integrity": "sha512-ZXo1ICG2HgxkIZWlnPteh2R90kwmhRwvbP282CwrrYgTKuMZmW2R/+o6vqhWyPkjoNFN/pno0FxuDA3IYau3Sw==",
       "optional": true,
       "requires": {
-        "@aws-sdk/service-error-classification": "3.266.0",
+        "@aws-sdk/service-error-classification": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
@@ -22475,24 +22475,24 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.266.0.tgz",
-      "integrity": "sha512-pMJ4C5lzDEVJ0kZoZdV1ww4hn9s15cExaPcRgUqjCwzNxYo9E1Jc6wCC533sYNZF1aSkY9NDLyJmv/lP7FvF4A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.267.0.tgz",
+      "integrity": "sha512-SmI6xInnPPa0gFhCqhtWOUMTxLeRbm7X5HXzeprhK1d8aNNlUVyALAV7K8ovIjnv3a97lIJSekyb78oTuYITCA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/types": "3.267.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.266.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.266.0.tgz",
-      "integrity": "sha512-CNpJsxvEplAP3XLwUmr7iJ428pCH2aFQIFLjXFjcAaB2IbgG1/801hdzdmeBH+1LSYVJ5qd3R+HeaZhxMDo62A==",
+      "version": "3.267.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.267.0.tgz",
+      "integrity": "sha512-nfmyffA1yIypJ30CIMO6Tc16t8dFJzdztzoowjmnfb8/LzTZECERM3GICq0DvZDPfSo+jbuz634VtS2K7tVZjA==",
       "optional": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.266.0",
-        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.267.0",
+        "@aws-sdk/types": "3.267.0",
         "tslib": "^2.3.1"
       }
     },
@@ -23766,6 +23766,11 @@
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
       }
+    },
+    "@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
       "version": "7.20.13",
@@ -27324,11 +27329,6 @@
             "regjsparser": "^0.1.4"
           }
         },
-        "regjsgen": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-          "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g=="
-        },
         "regjsparser": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
@@ -27992,9 +27992,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001450",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
-      "integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew=="
+      "version": "1.0.30001451",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
+      "integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w=="
     },
     "center-align": {
       "version": "0.1.3",
@@ -28958,9 +28958,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.288",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.288.tgz",
-      "integrity": "sha512-8s9aJf3YiokIrR+HOQzNOGmEHFXVUQzXM/JaViVvKdCkNUjS+lEa/uT7xw3nDVG/IgfxiIwUGkwJ6AR1pTpYsQ=="
+      "version": "1.4.292",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.292.tgz",
+      "integrity": "sha512-ESWOSyJy5odDlE8wvh5NNAMORv4r6assPwIPGHEMWrWD0SONXcG/xT+9aD9CQyeRwyYDPo6dJT4Bbeg5uevVQQ=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -35882,13 +35882,13 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.2.tgz",
-      "integrity": "sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.0.tgz",
+      "integrity": "sha512-ZdhUQlng0RoscyW7jADnUZ25F5eVtHdMyXSb2PiwafvteRAOJUjFoUPEYZSIfP99fBIs3maLIRfpEddT78wAAQ==",
       "requires": {
+        "@babel/regjsgen": "^0.8.0",
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.1.0",
-        "regjsgen": "^0.7.1",
         "regjsparser": "^0.9.1",
         "unicode-match-property-ecmascript": "^2.0.0",
         "unicode-match-property-value-ecmascript": "^2.1.0"
@@ -35913,9 +35913,9 @@
       }
     },
     "regjsgen": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
-      "integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha512-x+Y3yA24uF68m5GA+tBjbGYo64xXVJpbToBaWCoSNSc1hdk6dfctaRWrNFTVJZIIhL5GxW8zwjoixbnifnK59g=="
     },
     "regjsparser": {
       "version": "0.9.1",
@@ -37401,9 +37401,9 @@
       "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA=="
     },
     "type-fest": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.6.tgz",
-      "integrity": "sha512-6bd2bflx8ed7c99tc6zSTIzHr1/QG29bQoK4Qh8MYGnlPbODUzGxklLShjwc/xWQQFHgIci+y5Arv7Rbb0LjXw=="
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.7.tgz",
+      "integrity": "sha512-6J4bYzb4sdkcLBty4XW7F18VPI66M4boXNE+CY40532oq2OJe6AVMB5NmjOp6skt/jw5mRjz/hLRpuglz0U+FA=="
     },
     "type-is": {
       "version": "1.6.18",


### PR DESCRIPTION
This pull request removes the unexpected (and undocumented) behaviour of emptying the query in a resolver. It was originally intended to be able to just pass `context.params` along to other requests but it makes more sense to put together the parameters you need yourself anyway.

Closes https://github.com/feathersjs/feathers/issues/2995