### PR TITLE
fix(schema): validateQuery - move next function outside of try-catch

### DIFF
--- a/packages/schema/src/hooks/validate.ts
+++ b/packages/schema/src/hooks/validate.ts
@@ -19,12 +19,12 @@ export const validateQuery = <H extends HookContext>(schema: Schema<any> | Valid
         ...context.params,
         query
       }
-
-      if (typeof next === 'function') {
-        return next()
-      }
     } catch (error: any) {
       throw error.ajv ? new BadRequest(error.message, error.errors) : error
+    }
+    
+    if (typeof next === 'function') {
+      return next()
     }
   }
 }


### PR DESCRIPTION
same as `validateData`. Do not handle errors from `next` function