### PR TITLE
feat(schema): Add schema helper for handling Object ids

### DIFF
--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -396,15 +396,22 @@ MongoDB uses [ObjectId](https://www.mongodb.com/docs/manual/reference/method/Obj
 
 ### AJV keyword
 
-To validate and convert strings to an object id using AJV, the `keywordObjectId` [AJV keyword](https://ajv.js.org/api.html#ajv-addkeyword-definition-string-object-ajv) helper can be used. It is set up automatically in a generated application using MongoDB. Both, `@feathersjs/typebox` and `@feathersjs/schema` export an `ObjectIdSchema` helper that creates a schema which can be both, a MongoDB ObjectId or a string that will be converted with the `objectid` keyword:
+To validate and convert strings to an object id using AJV, the `keywordObjectId` [AJV keyword](https://ajv.js.org/api.html#ajv-addkeyword-definition-string-object-ajv) helper can be used. It is set up automatically in a generated application using MongoDB.
 
 ```ts
 import { keywordObjectId } from '@feathersjs/mongodb'
-import { ObjectIdSchema } from '@feathersjs/typebox' // or '@feathersjs/schema'
 
 const validator = new Ajv()
 
 validator.addKeyword(keywordObjectId)
+```
+
+### ObjectIdSchema
+
+Both, `@feathersjs/typebox` and `@feathersjs/schema` export an `ObjectIdSchema` helper that creates a schema which can be both, a MongoDB ObjectId or a string that will be converted with the `objectid` keyword:
+
+```ts
+import { ObjectIdSchema } from '@feathersjs/typebox' // or '@feathersjs/schema'
 
 const typeboxSchema = Type.Object({
   userId: ObjectIdSchema()
@@ -420,7 +427,7 @@ const jsonSchema = {
 
 <BlockQuote label="Important" type="warning">
 
-Usually a converted object id property can be treated like a string but in some cases when working with it on the server you may have to call `toString()` to get the proper type.
+The `ObjectIdSchema` helper will only work when the [`objectid` AJV keyword](#ajv-keyword) is registered.
 
 </BlockQuote>
 

--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -400,20 +400,20 @@ To validate and convert strings to an object id using AJV, the `keywordObjectId`
 
 ```ts
 import { keywordObjectId } from '@feathersjs/mongodb'
-import { ObjectId } from '@feathersjs/typebox' // or '@feathersjs/schema'
+import { ObjectIdSchema } from '@feathersjs/typebox' // or '@feathersjs/schema'
 
 const validator = new Ajv()
 
 validator.addKeyword(keywordObjectId)
 
 const typeboxSchema = Type.Object({
-  userId: ObjectId()
+  userId: ObjectIdSchema()
 })
 
 const jsonSchema = {
   type: 'object',
   properties: {
-    userId: ObjectId()
+    userId: ObjectIdSchema()
   }
 }
 ```

--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -396,26 +396,24 @@ MongoDB uses [ObjectId](https://www.mongodb.com/docs/manual/reference/method/Obj
 
 ### AJV keyword
 
-To validate and convert strings to an object id using AJV, the `keywordObjectId` [AJV keyword](https://ajv.js.org/api.html#ajv-addkeyword-definition-string-object-ajv) helper can be used. It is set up automatically in a generated application using MongoDB.
+To validate and convert strings to an object id using AJV, the `keywordObjectId` [AJV keyword](https://ajv.js.org/api.html#ajv-addkeyword-definition-string-object-ajv) helper can be used. It is set up automatically in a generated application using MongoDB. Both, `@feathersjs/typebox` and `@feathersjs/schema` export an `ObjectIdSchema` helper that creates a schema which can be both, a MongoDB ObjectId or a string that will be converted with the `objectid` keyword:
 
 ```ts
 import { keywordObjectId } from '@feathersjs/mongodb'
+import { ObjectId } from '@feathersjs/typebox' // or '@feathersjs/schema'
 
 const validator = new Ajv()
 
 validator.addKeyword(keywordObjectId)
 
 const typeboxSchema = Type.Object({
-  userId: Type.String({ objectid: true })
+  userId: ObjectId()
 })
 
 const jsonSchema = {
   type: 'object',
   properties: {
-    userId: {
-      type: 'string',
-      objectid: true
-    }
+    userId: ObjectId()
   }
 }
 ```

--- a/packages/generators/src/authentication/templates/schema.json.tpl.ts
+++ b/packages/generators/src/authentication/templates/schema.json.tpl.ts
@@ -11,7 +11,12 @@ const template = ({
   type,
   relative
 }: AuthenticationGeneratorContext) => /* ts */ `// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
-import { resolve, querySyntax, getValidator } from '@feathersjs/schema'
+import { resolve, querySyntax, getValidator } from '@feathersjs/schema'${
+  type === 'mongodb'
+    ? `
+import { ObjectIdSchema } from '@feathersjs/schema'`
+    : ''
+}
 import type { FromSchema } from '@feathersjs/schema'
 ${localTemplate(authStrategies, `import { passwordHash } from '@feathersjs/authentication-local'`)}
 
@@ -27,16 +32,7 @@ export const ${camelName}Schema = {
   additionalProperties: false,
   required: [ '${type === 'mongodb' ? '_id' : 'id'}'${localTemplate(authStrategies, ", 'email'")} ],
   properties: {
-    ${
-      type === 'mongodb'
-        ? `_id: {
-      type: 'string',
-      objectid: true
-    },`
-        : `id: {
-      type: 'number'
-    },`
-    }
+    ${type === 'mongodb' ? `_id: ObjectIdSchema(),` : `id: { type: 'number' },`}
     ${authStrategies
       .map((name) =>
         name === 'local'

--- a/packages/generators/src/authentication/templates/schema.typebox.tpl.ts
+++ b/packages/generators/src/authentication/templates/schema.typebox.tpl.ts
@@ -12,7 +12,12 @@ export const template = ({
   relative
 }: AuthenticationGeneratorContext) => /* ts */ `// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve } from '@feathersjs/schema'
-import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'${
+  type === 'mongodb'
+    ? `
+import { ObjectIdSchema } from '@feathersjs/typebox'`
+    : ''
+}
 import type { Static } from '@feathersjs/typebox'
 ${localTemplate(authStrategies, `import { passwordHash } from '@feathersjs/authentication-local'`)}
 
@@ -23,7 +28,7 @@ import { dataValidator, queryValidator } from '${relative}/${
 
 // Main data model schema
 export const ${camelName}Schema = Type.Object({
-  ${type === 'mongodb' ? '_id: Type.String({ objectid: true })' : 'id: Type.Number()'},
+  ${type === 'mongodb' ? '_id: ObjectIdSchema()' : 'id: Type.Number()'},
   ${authStrategies
     .map((name) =>
       name === 'local'

--- a/packages/generators/src/service/templates/schema.json.tpl.ts
+++ b/packages/generators/src/service/templates/schema.json.tpl.ts
@@ -10,7 +10,12 @@ const template = ({
   cwd,
   lib
 }: ServiceGeneratorContext) => /* ts */ `// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
-import { resolve, getValidator, querySyntax } from '@feathersjs/schema'
+import { resolve, getValidator, querySyntax } from '@feathersjs/schema'${
+  type === 'mongodb'
+    ? `
+import { ObjectIdSchema } from '@feathersjs/schema'`
+    : ''
+}
 import type { FromSchema } from '@feathersjs/schema'
 
 import type { HookContext } from '${relative}/declarations'
@@ -25,19 +30,8 @@ export const ${camelName}Schema = {
   additionalProperties: false,
   required: [ '${type === 'mongodb' ? '_id' : 'id'}', 'text' ],
   properties: {
-    ${
-      type === 'mongodb'
-        ? `_id: {
-      type: 'string',
-      objectid: true
-    },`
-        : `id: {
-      type: 'number'
-    },`
-    }
-    text: {
-      type: 'string'
-    }
+    ${type === 'mongodb' ? `_id: ObjectIdSchema(),` : `id: { type: 'number' },`}
+    text: { type: 'string' }
   }
 } as const
 export type ${upperName} = FromSchema<typeof ${camelName}Schema>

--- a/packages/generators/src/service/templates/schema.typebox.tpl.ts
+++ b/packages/generators/src/service/templates/schema.typebox.tpl.ts
@@ -11,7 +11,12 @@ const template = ({
   lib
 }: ServiceGeneratorContext) => /* ts */ `// // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
 import { resolve } from '@feathersjs/schema'
-import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'${
+  type === 'mongodb'
+    ? `
+import { ObjectIdSchema } from '@feathersjs/typebox'`
+    : ''
+}
 import type { Static } from '@feathersjs/typebox'
 
 import type { HookContext } from '${relative}/declarations'
@@ -21,7 +26,7 @@ import { dataValidator, queryValidator } from '${relative}/${
 
 // Main data model schema
 export const ${camelName}Schema = Type.Object({
-    ${type === 'mongodb' ? '_id: Type.String({ objectid: true })' : 'id: Type.Number()'},
+    ${type === 'mongodb' ? '_id: ObjectIdSchema()' : 'id: Type.Number()'},
     text: Type.String()
   }, { $id: '${upperName}', additionalProperties: false })
 export type ${upperName} = Static<typeof ${camelName}Schema>

--- a/packages/schema/src/hooks/validate.ts
+++ b/packages/schema/src/hooks/validate.ts
@@ -22,7 +22,7 @@ export const validateQuery = <H extends HookContext>(schema: Schema<any> | Valid
     } catch (error: any) {
       throw error.ajv ? new BadRequest(error.message, error.errors) : error
     }
-    
+
     if (typeof next === 'function') {
       return next()
     }

--- a/packages/schema/src/json-schema.ts
+++ b/packages/schema/src/json-schema.ts
@@ -144,11 +144,6 @@ export const queryProperties = <
   Object.keys(definitions).reduce((res, key) => {
     const result = res as any
     const definition = definitions[key]
-    const { $ref } = definition as any
-
-    if ($ref) {
-      throw new Error(`Can not create query syntax schema for reference property '${key}'`)
-    }
 
     result[key] = queryProperty(definition as JSONSchemaDefinition, extensions[key as keyof T])
 
@@ -227,3 +222,11 @@ export const querySyntax = <
     ...props
   } as const
 }
+
+export const ObjectIdSchema = () =>
+  ({
+    anyOf: [
+      { type: 'string', objectid: true },
+      { type: 'object', properties: {}, additionalProperties: false }
+    ]
+  } as const)

--- a/packages/schema/test/json-schema.test.ts
+++ b/packages/schema/test/json-schema.test.ts
@@ -1,23 +1,10 @@
 import Ajv from 'ajv'
 import assert from 'assert'
+import { ObjectId as MongoObjectId } from 'mongodb'
 import { FromSchema } from '../src'
-import { queryProperties, querySyntax } from '../src/json-schema'
+import { querySyntax, ObjectIdSchema } from '../src/json-schema'
 
 describe('@feathersjs/schema/json-schema', () => {
-  it('queryProperties errors for unsupported query types', () => {
-    assert.throws(
-      () =>
-        queryProperties({
-          something: {
-            $ref: 'something'
-          }
-        }),
-      {
-        message: "Can not create query syntax schema for reference property 'something'"
-      }
-    )
-  })
-
   it('querySyntax works with no properties', async () => {
     const schema = {
       type: 'object',
@@ -68,5 +55,28 @@ describe('@feathersjs/schema/json-schema', () => {
     const validator = new Ajv({ strict: false }).compile(schema)
 
     assert.ok(validator(q))
+  })
+
+  // Test ObjectId validation
+  it('ObjectId', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        _id: ObjectIdSchema()
+      }
+    }
+
+    const validator = new Ajv({
+      strict: false
+    }).compile(schema)
+    const validated = await validator({
+      _id: '507f191e810c19729de860ea'
+    })
+    assert.ok(validated)
+
+    const validated2 = await validator({
+      _id: new MongoObjectId()
+    })
+    assert.ok(validated2)
   })
 })

--- a/packages/typebox/src/index.ts
+++ b/packages/typebox/src/index.ts
@@ -129,10 +129,6 @@ export const queryProperties = <
     const result = res as any
     const value = definition.properties[key]
 
-    if (value.$ref) {
-      throw new Error(`Can not create query syntax schema for reference property '${key}'`)
-    }
-
     result[key] = queryProperty(value, extensions[key])
 
     return result
@@ -182,3 +178,6 @@ export const querySyntax = <
     options
   )
 }
+
+export const ObjectIdSchema = () =>
+  Type.Union([Type.String({ objectid: true }), Type.Object({}, { additionalProperties: false })])

--- a/packages/typebox/test/index.test.ts
+++ b/packages/typebox/test/index.test.ts
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import { ObjectId as MongoObjectId } from 'mongodb'
 import { Ajv } from '@feathersjs/schema'
 import {
   querySyntax,
@@ -7,7 +8,7 @@ import {
   defaultAppConfiguration,
   getDataValidator,
   getValidator,
-  queryProperties
+  ObjectIdSchema
 } from '../src'
 
 describe('@feathersjs/schema/typebox', () => {
@@ -37,20 +38,6 @@ describe('@feathersjs/schema/typebox', () => {
 
       validated = (await validator({ ...query, something: 'wrong' })) as any as Query
       assert.ok(!validated)
-    })
-
-    it('queryProperties errors for unsupported query types', () => {
-      assert.throws(
-        () =>
-          queryProperties(
-            Type.Object({
-              something: Type.Ref(Type.Object({}, { $id: 'something' }))
-            })
-          ),
-        {
-          message: "Can not create query syntax schema for reference property 'something'"
-        }
-      )
     })
 
     it('querySyntax works with no properties', async () => {
@@ -111,6 +98,26 @@ describe('@feathersjs/schema/typebox', () => {
     })
 
     assert.ok(validated)
+  })
+
+  // Test ObjectId validation
+  it('ObjectId', async () => {
+    const schema = Type.Object({
+      _id: ObjectIdSchema()
+    })
+
+    const validator = new Ajv({
+      strict: false
+    }).compile(schema)
+    const validated = await validator({
+      _id: '507f191e810c19729de860ea'
+    })
+    assert.ok(validated)
+
+    const validated2 = await validator({
+      _id: new MongoObjectId()
+    })
+    assert.ok(validated2)
   })
 
   it('validators', () => {


### PR DESCRIPTION
This pull request adds an `ObjectIdSchema` helper that allows validating both, strings that will be converted to object ids and existing MongoDB object ids and updates the generator accordingly.