### PR TITLE
fix(koa): Make Koa app inspectable

### DIFF
--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -83,6 +83,13 @@ export function koa<S = any, C = any>(
 
   koaQs(app as any)
 
+  Object.getOwnPropertySymbols(koaApp).forEach((symbol) => {
+    const target = app as any
+    const source = koaApp as any
+
+    target[symbol] = source[symbol]
+  })
+
   // This reinitializes hooks
   app.setup = feathersApp.setup as any
   app.teardown = feathersApp.teardown as any


### PR DESCRIPTION
This pull request fixes an issue that didn't allow to `console.log` a Koa based Feathers application. The problem was that the [util.inspect.custom](https://nodejs.org/api/util.html#utilinspectcustom) symbol was not copied to the new application so it tried to serialise the non-serialisable Koa `app.context`.

Closes https://github.com/feathersjs/feathers/issues/3066