### PR TITLE
fix(memory/mongodb): $select as only property & force 'id' in '$select'

### DIFF
--- a/packages/adapter-tests/src/methods.ts
+++ b/packages/adapter-tests/src/methods.ts
@@ -99,6 +99,7 @@ export default (test: AdapterMethodsTest, app: any, _errors: any, serviceName: s
           query: { $select: ['name'] }
         })
 
+        assert.strictEqual(data[idProp].toString(), doug[idProp].toString(), `${idProp} id property matches`)
         assert.strictEqual(data.name, 'Doug', 'data.name matches')
         assert.ok(!data.age, 'data.age is falsy')
       })
@@ -244,6 +245,7 @@ export default (test: AdapterMethodsTest, app: any, _errors: any, serviceName: s
           query: { $select: ['name'] }
         })
 
+        assert.strictEqual(data[idProp].toString(), doug[idProp].toString(), `${idProp} id property matches`)
         assert.strictEqual(data.name, 'Dougler', 'data.name matches')
         assert.ok(!data.age, 'data.age is falsy')
       })
@@ -333,6 +335,7 @@ export default (test: AdapterMethodsTest, app: any, _errors: any, serviceName: s
           query: { $select: ['name'] }
         })
 
+        assert.strictEqual(data[idProp].toString(), doug[idProp].toString(), `${idProp} id property matches`)
         assert.strictEqual(data.name, 'PatchDoug', 'data.name matches')
         assert.ok(!data.age, 'data.age is falsy')
       })
@@ -617,6 +620,7 @@ export default (test: AdapterMethodsTest, app: any, _errors: any, serviceName: s
           query: { $select: ['name'] }
         })
 
+        assert.ok(idProp in data, 'data has id')
         assert.strictEqual(data.name, 'William', 'data.name matches')
         assert.ok(!data.age, 'data.age is falsy')
 

--- a/packages/adapter-tests/src/syntax.ts
+++ b/packages/adapter-tests/src/syntax.ts
@@ -127,6 +127,7 @@ export default (test: AdapterSyntaxTest, app: any, _errors: any, serviceName: st
         })
 
         assert.strictEqual(data.length, 1)
+        assert.ok(idProp in data[0], 'data has id')
         assert.strictEqual(data[0].name, 'Alice')
         assert.strictEqual(data[0].age, undefined)
       })

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -22,7 +22,7 @@ export interface MemoryServiceOptions<T = any> extends AdapterServiceOptions {
   sorter?: (sort: any) => any
 }
 
-const _select = (data: any, params: any, ...args: any[]) => {
+const _select = (data: any, params: any, ...args: string[]) => {
   const base = select(params, ...args)
 
   return base(JSON.parse(JSON.stringify(data)))
@@ -111,6 +111,8 @@ export class MemoryAdapter<
       }
 
       values = matched
+    } else {
+      values = values.map((value) => _select(value, params))
     }
 
     const result: Paginated<Result> = {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -103,7 +103,7 @@ export class MemoryAdapter<
           continue
         }
 
-        matched.push(_select(value, params))
+        matched.push(_select(value, params, this.id))
 
         if (hasLimit && filters.$limit === matched.length) {
           break
@@ -112,7 +112,7 @@ export class MemoryAdapter<
 
       values = matched
     } else {
-      values = values.map((value) => _select(value, params))
+      values = values.map((value) => _select(value, params, this.id))
     }
 
     const result: Paginated<Result> = {

--- a/packages/memory/test/index.test.ts
+++ b/packages/memory/test/index.test.ts
@@ -217,6 +217,25 @@ describe('Feathers Memory Service', () => {
     }
   })
 
+  it('use $select as only query property', async () => {
+    const people = app.service('people')
+    const person = await people.create({
+      name: 'Tester',
+      age: 42
+    })
+
+    const results = await people.find({
+      paginate: false,
+      query: {
+        $select: ['name']
+      }
+    })
+
+    assert.deepStrictEqual(results[0], { id: person.id, name: 'Tester' })
+
+    await people.remove(person.id)
+  })
+
   testSuite(app, errors, 'people')
   testSuite(app, errors, 'people-customid', 'customid')
 })

--- a/packages/memory/test/index.test.ts
+++ b/packages/memory/test/index.test.ts
@@ -231,7 +231,7 @@ describe('Feathers Memory Service', () => {
       }
     })
 
-    assert.deepStrictEqual(results[0], { id: person.id, name: 'Tester' })
+    assert.deepStrictEqual(results[0], { name: 'Tester' })
 
     await people.remove(person.id)
   })

--- a/packages/memory/test/index.test.ts
+++ b/packages/memory/test/index.test.ts
@@ -190,24 +190,6 @@ describe('Feathers Memory Service', () => {
     await people.remove(person.id)
   })
 
-  it('does not $select the id', async () => {
-    const people = app.service('people')
-    const person = await people.create({
-      name: 'Tester'
-    })
-    const results = await people.find({
-      paginate: false,
-      query: {
-        name: 'Tester',
-        $select: ['name']
-      }
-    })
-
-    assert.deepStrictEqual(results[0], { name: 'Tester' }, 'deepEquals the same')
-
-    await people.remove(person.id)
-  })
-
   it('update with null throws error', async () => {
     try {
       await app.service('people').update(null, {})
@@ -231,7 +213,7 @@ describe('Feathers Memory Service', () => {
       }
     })
 
-    assert.deepStrictEqual(results[0], { name: 'Tester' })
+    assert.deepStrictEqual(results[0], { id: person.id, name: 'Tester' })
 
     await people.remove(person.id)
   })

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -159,6 +159,9 @@ export class MongoDbAdapter<
 
   getSelect(select: string[] | { [key: string]: number }) {
     if (Array.isArray(select)) {
+      if (!select.includes(this.id)) {
+        select = [this.id, ...select]
+      }
       return select.reduce<{ [key: string]: number }>(
         (value, name) => ({
           ...value,
@@ -166,6 +169,13 @@ export class MongoDbAdapter<
         }),
         {}
       )
+    }
+
+    if (!select[this.id]) {
+      return {
+        ...select,
+        [this.id]: 1
+      }
     }
 
     return select

--- a/packages/schema/src/hooks/resolve.ts
+++ b/packages/schema/src/hooks/resolve.ts
@@ -76,12 +76,13 @@ export const resolveResult = <H extends HookContext>(...resolvers: Resolver<any,
       throw new Error('The resolveResult hook must be used as an around hook')
     }
 
-    const { $resolve, $select: select, ...query } = context.params?.query || {}
-    const $select = Array.isArray(select) ? select.filter((name) => !virtualProperties.has(name)) : select
+    const { $resolve, $select, ...query } = context.params?.query || {}
+    const hasVirtualSelects = Array.isArray($select) && $select.some((name) => virtualProperties.has(name))
+
     const resolve = {
       originalContext: context,
       ...context.params.resolve,
-      properties: $resolve || select
+      properties: $resolve || $select
     }
 
     context.params = {
@@ -89,7 +90,7 @@ export const resolveResult = <H extends HookContext>(...resolvers: Resolver<any,
       resolve,
       query: {
         ...query,
-        ...($select ? { $select } : {})
+        ...(!hasVirtualSelects ? { $select } : {})
       }
     }
 

--- a/packages/schema/test/hooks.test.ts
+++ b/packages/schema/test/hooks.test.ts
@@ -129,7 +129,7 @@ describe('@feathersjs/schema/hooks', () => {
         $select: ['user', 'text']
       }
     })
-    assert.strictEqual(Object.keys(messages[0]).length, 2)
+    assert.deepStrictEqual(Object.keys(messages[0]), ['text', 'user'])
   })
 
   it('resolves find results with paginated result object', async () => {


### PR DESCRIPTION
Quick fix for `@feathersjs/memory`.

First commit is the test which should work but fails without the second commit.

The problem was, that `select(...)` only was called if there was `$sort`, `$limit` or `$skip` in the query.

While being at it:

## ‼️ diffing behaviour of `$select` also returning `id`, also if not added explicitely.
- memory: has a test to not select `id` automatically, which is crucial for crud! https://github.com/feathersjs/feathers/blob/dove/packages/memory/test/index.test.ts#L193 I think this was introduced by recent changes from @DaddyWarbucks 
- knex: adds `id` automatically, if it's not provided: https://github.com/feathersjs/feathers/blob/dove/packages/knex/src/adapter.ts#L128
- mongodb: same as knex: https://github.com/feathersjs/feathers/blob/dove/packages/mongodb/src/adapter.ts#L203
- I can confirm, that `feathers-sequelize` also adds `id`

I think that should be tested by `@feathersjs/adapter-tests`. We have it in:
- `.find + $select` not included ❌ https://github.com/feathersjs/feathers/blob/dove/packages/adapter-tests/src/syntax.ts#L129
- `.get + $select`: included ✅ https://github.com/feathersjs/feathers/blob/dove/packages/adapter-tests/src/methods.ts#L32
- `.create + $select`: not included ❌ https://github.com/feathersjs/feathers/blob/dove/packages/adapter-tests/src/methods.ts#L620
- `.patch + $select`: not included ❌ https://github.com/feathersjs/feathers/blob/dove/packages/adapter-tests/src/methods.ts#L329
- `.update + $select`: not included ❌ https://github.com/feathersjs/feathers/blob/dove/packages/adapter-tests/src/methods.ts#L247
-  `.remove + $select`: not included ❌ https://github.com/feathersjs/feathers/blob/dove/packages/adapter-tests/src/methods.ts#L97

This PR adds explicit tests to `@feathersjs/adapter-tests` and makes sure, that all tests pass for these linked tests.