### PR TITLE
docs: update extended ajv docs

### DIFF
--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -1452,11 +1452,11 @@ Omitting this keyword has the same behavior as an empty object.
 
 ### Extended
 
-In addition to JSON schema types, TypeBox provides several extended types that allow for the composition of `function` and `constructor` types. These additional types are not valid JSON Schema and will not validate using typical JSON Schema validation. However, these types can be used to frame JSON schema and describe callable interfaces that may receive JSON validated data. These types are as follows.
+In addition to JSON schema types, TypeBox provides several extended types that allow for the composition of `function` and `constructor` types. These additional types are not valid JSON Schema and will not validate using typical JSON Schema validation. However, these types can be used to frame JSON schema and describe callable interfaces that may receive JSON validated data. Since these are nonstandard types, most applications will not need them. Consider using the [Standard Types](#standard), instead, as using these types may make it difficult to upgrade your application in the future.
 
 #### Extended Configuration
 
-Utilities in this section require updating `src/schemas/validators.ts` to the [Extended Ajv Configuration](https://github.com/sinclairzx81/typebox#ajv) shown in the Typebox documentation.
+Utilities in this section require updating `src/schemas/validators.ts` to the [Extended Ajv Configuration](https://github.com/sinclairzx81/typebox/tree/0.25.23#ajv) shown in the Typebox documentation. Check the detail/expand section under the AJV heading.
 
 #### Constructor
 

--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -1526,6 +1526,8 @@ const R = ajv.validate(Type.Object({                 // const R = true
 })
 ```
 
+If you see an error stating `Error: strict mode: unknown keyword: "instanceOf"`, it's likely because you need to extend your configuration, as shown above.
+
 #### Constructor
 
 Verifies that the value is a constructor with typed arguments and return value. Requires [Extended Ajv Configuration](#extended-configuration).

--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -1456,7 +1456,75 @@ In addition to JSON schema types, TypeBox provides several extended types that a
 
 #### Extended Configuration
 
-Utilities in this section require updating `src/schemas/validators.ts` to the [Extended Ajv Configuration](https://github.com/sinclairzx81/typebox/tree/0.25.23#ajv) shown in the Typebox documentation. Check the detail/expand section under the AJV heading.
+Utilities in this section require updating `src/schemas/validators.ts` to the Extended Ajv Configuration, as shown here: 
+
+```ts
+import { TypeGuard } from '@sinclair/typebox/guard'
+import { Value }     from '@sinclair/typebox/value'
+import { Type }      from '@sinclair/typebox'
+import addFormats    from 'ajv-formats'
+import Ajv           from 'ajv'
+
+function schemaOf(schemaOf: string, value: unknown, schema: unknown) {
+  switch (schemaOf) {
+    case 'Constructor':
+      return TypeGuard.TConstructor(schema) && Value.Check(schema, value) // not supported
+    case 'Function':
+      return TypeGuard.TFunction(schema) && Value.Check(schema, value) // not supported
+    case 'Date':
+      return TypeGuard.TDate(schema) && Value.Check(schema, value)
+    case 'Promise':
+      return TypeGuard.TPromise(schema) && Value.Check(schema, value) // not supported
+    case 'Uint8Array':
+      return TypeGuard.TUint8Array(schema) && Value.Check(schema, value)
+    case 'Undefined':
+      return TypeGuard.TUndefined(schema) && Value.Check(schema, value) // not supported
+    case 'Void':
+      return TypeGuard.TVoid(schema) && Value.Check(schema, value)
+    default:
+      return false
+  }
+}
+
+export function createAjv() {
+  return addFormats(new Ajv({}), [
+    'date-time', 
+    'time', 
+    'date', 
+    'email',  
+    'hostname', 
+    'ipv4', 
+    'ipv6', 
+    'uri', 
+    'uri-reference', 
+    'uuid',
+    'uri-template', 
+    'json-pointer', 
+    'relative-json-pointer', 
+    'regex'
+  ])
+  .addKeyword({ type: 'object', keyword: 'instanceOf', validate: schemaOf })
+  .addKeyword({ type: 'null', keyword: 'typeOf', validate: schemaOf })
+  .addKeyword('exclusiveMinimumTimestamp')
+  .addKeyword('exclusiveMaximumTimestamp')
+  .addKeyword('minimumTimestamp')
+  .addKeyword('maximumTimestamp')
+  .addKeyword('minByteLength')
+  .addKeyword('maxByteLength')
+}
+
+const ajv = createAjv()
+
+const R = ajv.validate(Type.Object({                 // const R = true
+  buffer: Type.Uint8Array(),
+  date: Type.Date(),
+  void: Type.Void()
+}), {
+  buffer: new Uint8Array(),
+  date: new Date(),
+  void: null
+})
+```
 
 #### Constructor
 


### PR DESCRIPTION
The link to Extended AJV configuration has changed.  I’ve updated the docs to link to the old tag in github as well as added a warning for most apps to not use the types if they want easy upgradeability.
