### PR TITLE
fix(core): Use Symbol.for to instantiate shared symbols

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -7,7 +7,7 @@ import {
 } from './declarations'
 import { filterQuery } from './query'
 
-export const VALIDATED = Symbol('@feathersjs/adapter/sanitized')
+export const VALIDATED = Symbol.for('@feathersjs/adapter/sanitized')
 
 const alwaysMulti: { [key: string]: boolean } = {
   find: true,

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -96,7 +96,7 @@ export function isPromise(result: any) {
 }
 
 export function createSymbol(name: string) {
-  return typeof Symbol !== 'undefined' ? Symbol(name) : name
+  return typeof Symbol !== 'undefined' ? Symbol.for(name) : name
 }
 
 export * from './debug'

--- a/packages/knex/src/error-handler.ts
+++ b/packages/knex/src/error-handler.ts
@@ -1,6 +1,6 @@
 import { errors } from '@feathersjs/errors'
 
-export const ERROR = Symbol('@feathersjs/knex/error')
+export const ERROR = Symbol.for('@feathersjs/knex/error')
 
 export function errorHandler(error: any) {
   const { message } = error

--- a/packages/schema/src/hooks/resolve.ts
+++ b/packages/schema/src/hooks/resolve.ts
@@ -110,7 +110,7 @@ export const resolveResult = <H extends HookContext>(...resolvers: Resolver<any,
   }
 }
 
-export const DISPATCH = Symbol('@feathersjs/schema/dispatch')
+export const DISPATCH = Symbol.for('@feathersjs/schema/dispatch')
 
 export const getDispatchValue = (value: any): any => {
   if (typeof value === 'object' && value !== null) {

--- a/packages/schema/src/resolver.ts
+++ b/packages/schema/src/resolver.ts
@@ -14,7 +14,7 @@ export type VirtualResolver<T, V, C> = (
   status: ResolverStatus<T, C>
 ) => Promise<V | undefined>
 
-export const IS_VIRTUAL = Symbol('@feathersjs/schema/virtual')
+export const IS_VIRTUAL = Symbol.for('@feathersjs/schema/virtual')
 
 /**
  * Create a resolver for a virtual property. A virtual property is a property that

--- a/packages/transport-commons/src/channels/mixins.ts
+++ b/packages/transport-commons/src/channels/mixins.ts
@@ -5,9 +5,9 @@ import { Channel } from './channel/base'
 import { CombinedChannel } from './channel/combined'
 
 const debug = createDebug('@feathersjs/transport-commons/channels/mixins')
-const PUBLISHERS = Symbol('@feathersjs/transport-commons/publishers')
-const CHANNELS = Symbol('@feathersjs/transport-commons/channels')
-const ALL_EVENTS = Symbol('@feathersjs/transport-commons/all-events')
+const PUBLISHERS = Symbol.for('@feathersjs/transport-commons/publishers')
+const CHANNELS = Symbol.for('@feathersjs/transport-commons/channels')
+const ALL_EVENTS = Symbol.for('@feathersjs/transport-commons/all-events')
 
 export const keys = {
   PUBLISHERS: PUBLISHERS as typeof PUBLISHERS,


### PR DESCRIPTION
This pull request ensures that all Symbols are shared from the global symbol registry so that it is possible to use different package versions.

Closes #3071