### PR TITLE
fix(authentication-local): Local Auth - Nested username & Password fields

### DIFF
--- a/docs/api/authentication/local.md
+++ b/docs/api/authentication/local.md
@@ -51,8 +51,8 @@ export const authentication = (app: Application) => {
 
 Options are set in the [authentication configuration](./service.md#configuration) under the strategy name. Available options are:
 
-- `usernameField`: Name of the username field (e.g. `'email'`)
-- `passwordField`: Name of the password field (e.g. `'password'`)
+- `usernameField`: Name of the username field (e.g. `'email'`), may be a nested property (e.g. `'auth.email'`)
+- `passwordField`: Name of the password field (e.g. `'password'`), may be a nested property (e.g. `'auth.password'`)
 - `hashSize` (default: `10`): The BCrypt salt length
 - `errorMessage` (default: `'Invalid login'`): The error message to return on errors
 - `entityUsernameField` (default: `usernameField`): Name of the username field on the entity if authentication request data and entity field names are different

--- a/packages/authentication-local/src/strategy.ts
+++ b/packages/authentication-local/src/strategy.ts
@@ -122,8 +122,8 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
 
   async authenticate(data: AuthenticationRequest, params: Params) {
     const { passwordField, usernameField, entity, errorMessage } = this.configuration
-    const username = data[usernameField]
-    const password = data[passwordField]
+    const username = get(data, usernameField)
+    const password = get(data, passwordField)
 
     if (!password) {
       // exit early if there is no password
@@ -131,7 +131,6 @@ export class LocalStrategy extends AuthenticationBaseStrategy {
     }
 
     const result = await this.findEntity(username, omit(params, 'provider'))
-
     await this.comparePassword(result, password)
 
     return {

--- a/packages/authentication-local/test/strategy.test.ts
+++ b/packages/authentication-local/test/strategy.test.ts
@@ -195,4 +195,30 @@ describe('@feathersjs/authentication-local/strategy', () => {
 
     assert.notStrictEqual(resolvedData.password, 'supersecret')
   })
+  it('should allow for nested values in the usernameField', async () => {
+    const appWithNestedFieldOverride = createApplication(undefined, {
+      local: {
+        usernameField: 'auth.email',
+        passwordField: 'auth.password'
+      }
+    })
+    const nestedUser = await appWithNestedFieldOverride.service('users').create({ auth: { email, password } })
+    const authService = appWithNestedFieldOverride.service('authentication')
+    const authResult = await authService.create({
+      strategy: 'local',
+      auth: {
+        email,
+        password
+      }
+    })
+    const { accessToken } = authResult
+
+    assert.ok(accessToken)
+    assert.strictEqual(authResult.user.auth.email, email)
+
+    const decoded = await authService.verifyAccessToken(accessToken)
+
+    assert.strictEqual(decoded.sub, `${nestedUser.id}`)
+    //
+  })
 })


### PR DESCRIPTION
In my application, I store all the authentication related information related to the user in a nested object. This nested subobject includes for example, the last login time, the password hash & salt, last login IP address etc and in my case it is called `_auth`. The problem is that currently the library only allows you to confirgure the username and password fields for authentication to only be on the top level of the entity.
A test has been added for the nested field case and lint rules passing locally.

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/dove/.github/contributing.md#pull-requests))

- [X] Tell us about the problem your pull request is solving. Please see above
- [X] Are there any open issues that are related to this? No
- [X] Is this PR dependent on PRs in other repos? No

If so, please mention them to keep the conversations linked together.
