### PR TITLE
fix(koa): Replace koa-bodyparser with koa-body

### DIFF
--- a/docs/api/koa.md
+++ b/docs/api/koa.md
@@ -253,7 +253,7 @@ app.use(
 
 ### bodyParser
 
-A reference to the [koa-bodyparser](https://github.com/koajs/bodyparser) module.
+A reference to the [koa-body](https://github.com/koajs/koa-body) module.
 
 ### cors
 

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -56,12 +56,11 @@
     "@feathersjs/transport-commons": "^5.0.0",
     "@koa/cors": "^4.0.0",
     "@types/koa": "^2.13.5",
-    "@types/koa-bodyparser": "^4.3.10",
     "@types/koa-qs": "^2.0.0",
     "@types/koa-static": "^4.0.2",
     "@types/koa__cors": "^3.3.1",
     "koa": "^2.14.1",
-    "koa-bodyparser": "^4.3.0",
+    "koa-body": "^6.0.1",
     "koa-compose": "^4.1.0",
     "koa-qs": "^3.0.0",
     "koa-static": "^5.0.0"

--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -3,7 +3,7 @@ import koaQs from 'koa-qs'
 import { Application as FeathersApplication } from '@feathersjs/feathers'
 import { routing } from '@feathersjs/transport-commons'
 import { createDebug } from '@feathersjs/commons'
-import bodyParser from 'koa-bodyparser'
+import { koaBody as bodyParser } from 'koa-body'
 import cors from '@koa/cors'
 import serveStatic from 'koa-static'
 


### PR DESCRIPTION
Been looking at possible ways to implement an upload service.

After looking over the current options it would appear either we use `koa-body` to allow handling of `multipart/form-data` or we roll the dice and find another package as `koa-bodyparser` doesn't support `multipart/form-data`.

There is also the option where each developer could import and use `koa-body` themselves.
But there is currently a type compatibility issue with the older `koa-bodyparser` package.
More info over [here](https://github.com/koajs/bodyparser/issues/150).

What i can say though is it seems `koa-body` functions as a more up to date feature full drop in replacement.
Might need some extra testing though.