### PR TITLE
fix(core): Add PaginationParams to general find method of 'FeathersService'

### DIFF
--- a/packages/adapter-commons/src/declarations.ts
+++ b/packages/adapter-commons/src/declarations.ts
@@ -1,4 +1,4 @@
-import { Query, Params, Paginated, Id } from '@feathersjs/feathers'
+import { Query, Params, Paginated, Id, PaginationParams, PaginationOptions } from '@feathersjs/feathers'
 
 export type FilterQueryOptions = {
   filters?: FilterSettings
@@ -12,12 +12,8 @@ export type FilterSettings = {
   [key: string]: QueryFilter | true
 }
 
-export interface PaginationOptions {
-  default?: number
-  max?: number
-}
-
-export type PaginationParams = false | PaginationOptions
+// re-export from @feathersjs/feathers to prevent breaking changes
+export { PaginationOptions, PaginationParams }
 
 export interface AdapterServiceOptions {
   /**

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -72,7 +72,7 @@ export interface ServiceMethods<
   ServiceParams = Params,
   PatchData = Partial<Data>
 > {
-  find(params?: ServiceParams): Promise<Result | Result[]>
+  find(params?: ServiceParams & { paginate?: PaginationParams }): Promise<Result | Result[]>
 
   get(id: Id, params?: ServiceParams): Promise<Result>
 
@@ -137,7 +137,7 @@ export interface ServiceAddons<A = Application, S = Service> extends EventEmitte
 }
 
 export interface ServiceHookOverloads<S, P = Params> {
-  find(params: P, context: HookContext): Promise<HookContext>
+  find(params: P & { paginate?: PaginationParams }, context: HookContext): Promise<HookContext>
 
   get(id: Id, params: P, context: HookContext): Promise<HookContext>
 
@@ -330,6 +330,13 @@ export interface Params<Q = Query> {
   route?: { [key: string]: any }
   headers?: { [key: string]: any }
 }
+
+export interface PaginationOptions {
+  default?: number
+  max?: number
+}
+
+export type PaginationParams = false | PaginationOptions
 
 export interface Http {
   /**


### PR DESCRIPTION
For a not explicitely typed service, the Service uses the `FeathersService` type from `@feathersjs/feathers`. `FeathersService` extends `ServiceMethods` which does not support `paginate` param for `find` method. So `service.find({ paginate: false })` throws because `paginate` is not defined in interface `Params`.

See:
<img width="1070" alt="Bildschirm­foto 2023-03-08 um 23 45 05" src="https://user-images.githubusercontent.com/22286818/223868603-aed2d564-e9fb-41bc-8fbc-a50ae6e8753b.png">

<img width="826" alt="Bildschirm­foto 2023-03-08 um 23 46 18" src="https://user-images.githubusercontent.com/22286818/223868718-6bacf3ba-84bd-46aa-918b-72c18cb98dfb.png">
