### PR TITLE
docs: fix typo in client.md

### DIFF
--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -11,7 +11,7 @@ In order to connect to a Feathers server, a client creates [Services](./services
 Modules most relevant on the client are:
 
 - `@feathersjs/feathers` to initialize a new Feathers [application](./application.md)
-- [@feathersjs/rest-client](./client/rest.md) to connect to services through REST HTTP provided by [Koa](./koa.md) or [Epress](./express.md).
+- [@feathersjs/rest-client](./client/rest.md) to connect to services through REST HTTP provided by [Koa](./koa.md) or [Express](./express.md).
 - [@feathersjs/socketio-client](./client/socketio.md) to connect to services through [Socket.io](./socketio.md).
 - [@feathersjs/authentication-client](./authentication/client.md) to authenticate a client
 


### PR DESCRIPTION
### Summary
This PR updates the docs by fixing a typo on a hyperlink from Epress to Express.
(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/dove/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If this is a new feature, please remember to add the appropriate documentation in their respective pages in the `docs` folder.

Thanks for contributing to Feathers! :heart:
