### PR TITLE
Update apiKey.md docs

### DIFF
--- a/docs/cookbook/authentication/apiKey.md
+++ b/docs/cookbook/authentication/apiKey.md
@@ -134,27 +134,25 @@ Next, we create a hook called `allow-apiKey` that sets `params.authentication` i
 <LanguageBlock global-id="ts">
 
 ```ts
-import { Hook, HookContext } from '@feathersjs/feathers';
+import { HookContext, NextFunction } from '@feathersjs/feathers';
 
-export default (): Hook => {
-  return async (context: HookContext) => {
-    const { params, app } = context;
+export default () => async (context: HookContext, next: NextFunction) => {
+  const { params, app } = context;
 
-    const headerField = app.get('authentication').apiKey.header;
-    const token = params.headers ? params.headers[headerField] : null;
+  const headerField = app.get('authentication').apiKey.header;
+  const token = params.headers ? params.headers[headerField] : null;
 
-    if (token && params.provider && !params.authentication) {
-      context.params = {
-        ...params,
-        authentication: {
-          strategy: 'apiKey',
-          token
-        }
-      };
-    }
-
-    return context;
+  if (token && params.provider && !params.authentication) {
+    context.params = {
+      ...params,
+      authentication: {
+        strategy: 'apiKey',
+        token
+      }
+    };
   }
+
+  return next();
 }
 ```
 


### PR DESCRIPTION
Fix hook function so it can be used on hooks around all before `authenticate('jtw', 'apiKey')`.
The function now accepts `context, next`, and returns `next()`

