### PR TITLE
Update docs for those without feathers cli in dev/globals

### DIFF
--- a/docs/guides/basics/services.md
+++ b/docs/guides/basics/services.md
@@ -124,6 +124,7 @@ If you went with the default selection, we will use **SQLite** which writes the 
 In our new `feathers-chat` application, we can create database backed services with the following command:
 
 ```sh
+# Provided by `@feathersjs/cli`
 npx feathers generate service
 ```
 


### PR DESCRIPTION
### Summary

This could work 100% of the time... but right now it only works IF you have feathersjs/cli installed globally or in the devDependencies. If you don't you'll have to know it's in `@feathersjs/cli` somehow. That's specially not obvious as the Getting Started guide uses `create-feathers` not the CLI explicitly.

Daffl could replace  https://www.npmjs.com/package/feathers with the CLI to make it work... Perhaps it's worth cross-publishing.