### PR TITLE
Sort all front-end clients list to remain client framework agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Feathers is a full-stack framework for creating web APIs and real-time applications with TypeScript or JavaScript.
 
-Feathers can interact with any backend technology, supports many databases out of the box and works with any frontend like React, VueJS, Angular, React Native, Android or iOS.
+Feathers can interact with any backend technology, supports many databases out of the box and works with any frontend like Angular/React/Vue, Android or iOS.
 
 # Getting started
 

--- a/docs/feathers-vs-meteor.md
+++ b/docs/feathers-vs-meteor.md
@@ -4,7 +4,7 @@ Both Feathers and Meteor are open source real-time JavaScript platforms that pro
 
 Feathers is community supported, whereas Meteor is venture backed and has raised 31.2 million dollars to date.
 
-Meteor only has official support for MongoDB but there are some community modules of various levels of quality that support other databases. Meteor has it's own package manager and package ecosystem. They have their own template engine called Blaze which is based off of Mustache along with their own build system, but also have guides for Angular and React.
+Meteor only has official support for MongoDB but there are some community modules of various levels of quality that support other databases. Meteor has it's own package manager and package ecosystem. They have their own template engine called Blaze which is based off of Mustache along with their own build system, but also have guides for Angular/React/Vue.
 
 Feathers has official support for many more databases and supports any front-end framework or view engine that you want by working seamlessly on the client.
 

--- a/docs/guides/frameworks.md
+++ b/docs/guides/frameworks.md
@@ -1,10 +1,10 @@
 # Frontend Frameworks
 
-Feathers works the same on the server and on the client and is front-end framework agnostic. You can use it with Vue, React, React Native, Angular, or whatever other front-end tech stack you choose.
+Feathers works the same on the server and on the client and is front-end framework agnostic. You can use it with Angular/React/Vue or whatever other front-end tech stack you choose.
 
 ## Client Side Docs
 
-If you want to learn how to use Feathers as a client in Node.js, React Native, or in the browser with a module loader like Webpack refer to the [client API docs](../api/client.md).
+If you want to learn how to use Feathers as a client in Node.js, Angular/React/Vue, or in the browser with a module loader like Webpack refer to the [client API docs](../api/client.md).
 
 ## The Feathers chat
 
@@ -23,4 +23,4 @@ Beyond the basics, see [this list](https://github.com/feathersjs/awesome-feather
 
 ## Framework Integrations
 
-See [this list](https://github.com/feathersjs/awesome-feathersjs#frontend-frameworks) of Feathers front-end framework integrations if you are looking for something that makes Feathers even easier to use with things like React, Vue or others.
+See [this list](https://github.com/feathersjs/awesome-feathersjs#frontend-frameworks) of Feathers front-end framework integrations if you are looking for something that makes Feathers even easier to use with things like Angular/React/Vue or others.

--- a/docs/guides/migrating.md
+++ b/docs/guides/migrating.md
@@ -254,7 +254,7 @@ Setting the debugger will apply to all `@feathersjs` modules.
 ### Client
 
 - The `request` library has been deprecated and request support has been removed from the REST client.
-- Since all modern browsers now support built-in [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), the Angular and jQuery REST clients have been removed as well.
+- Since all modern browsers now support built-in [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), the jQuery REST clients has been removed as well.
 - The `@feathersjs/client` package now only comes with a full (`dist/feathers.js`) and core (`dist/core.js`) browser build. Using Feathers [with a module loader](../api/client.md#module-loaders) is recommended for all other use cases.
 
 ### Removed Primus Transport

--- a/packages/generators/src/app/index.ts
+++ b/packages/generators/src/app/index.ts
@@ -111,7 +111,7 @@ export const generate = (ctx: AppGeneratorArguments) =>
           type: 'confirm',
           when: ctx.client === undefined,
           message: (answers) => `Generate ${answers.language === 'ts' ? 'end-to-end typed ' : ''}client?`,
-          suffix: chalk.grey(' Can be used with React, Vue, React Native, Angular, Node.js etc.')
+          suffix: chalk.grey('Can be used anywhere TypeScript is supported, like Angular/React/Vue, etc')
         },
         {
           type: 'list',

--- a/packages/generators/src/app/index.ts
+++ b/packages/generators/src/app/index.ts
@@ -111,7 +111,7 @@ export const generate = (ctx: AppGeneratorArguments) =>
           type: 'confirm',
           when: ctx.client === undefined,
           message: (answers) => `Generate ${answers.language === 'ts' ? 'end-to-end typed ' : ''}client?`,
-          suffix: chalk.grey(' Can be used with React, Angular, Vue, React Native, Node.js etc.')
+          suffix: chalk.grey(' Can be used with React, Vue, React Native, Angular, Node.js etc.')
         },
         {
           type: 'list',


### PR DESCRIPTION
Minor, I know. But hear me out.

We are implying that we support or prefer angular over Vue in some way by not having an alphabetical list, or one that's not even sorted by github stars... Vue has [203k](https://github.com/vuejs/vue) + [36k](https://github.com/vuejs/core) stars, over angular's  [87k](https://github.com/angular/angular), which is technically lower than Node.js, but that's not a front-end framework (Unless you count webcontainers).

We can cutout Lit, Svelte and Astro as they did not exist when Feathers was released, and having 4 would violate the literary convention known as "rule of three's".

This PR also adds Angular and Vue where it's missing from a list mentioning other compatible Feathers clients.