### PR TITLE
fix(authentication): Ensure authentication.entity configuration can be null

### DIFF
--- a/packages/typebox/src/default-schemas.ts
+++ b/packages/typebox/src/default-schemas.ts
@@ -2,7 +2,12 @@ import { Type, Static } from '@sinclair/typebox'
 
 export const authenticationSettingsSchema = Type.Object({
   secret: Type.String({ description: 'The JWT signing secret' }),
-  entity: Type.Optional(Type.String({ description: 'The name of the authentication entity (e.g. user)' })),
+  entity: Type.Optional(
+    Type.Union([
+      Type.String({ description: 'The name of the authentication entity (e.g. user)' }),
+      Type.Null()
+   ])
+  ),
   entityId: Type.Optional(Type.String({ description: 'The name of the authentication entity id property' })),
   service: Type.Optional(Type.String({ description: 'The path of the entity service' })),
   authStrategies: Type.Array(Type.String(), {


### PR DESCRIPTION
If the authentication does not need a (user)-service one can set `authentication.entity = null` which [disables service validation](https://github.com/feathersjs/feathers/blob/dove/packages/authentication/src/service.ts#L181) but the base authenticationSchema does not allow using `null` in a config-json.
