### PR TITLE
fix(knex): Ensure that columns are selected unambigiously

### DIFF
--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -125,8 +125,9 @@ export class KnexAdapter<
 
     // $select uses a specific find syntax, so it has to come first.
     if (filters.$select) {
+      const select = filters.$select.map((column) => (column.includes('.') ? column : `${name}.${column}`))
       // always select the id field, but make sure we only select it once
-      builder.select(...new Set([...filters.$select, `${name}.${id}`]))
+      builder.select(...new Set([...select, `${name}.${id}`]))
     } else {
       builder.select(`${name}.*`)
     }

--- a/packages/knex/test/index.test.ts
+++ b/packages/knex/test/index.test.ts
@@ -678,7 +678,7 @@ describe('Feathers Knex Service', () => {
   describe('associations', () => {
     const todoService = app.service('todos')
 
-    it('create, query and get with associations', async () => {
+    it('create, query and get with associations, can unambigiously $select', async () => {
       const dave = await peopleService.create({
         name: 'Dave',
         age: 133
@@ -696,6 +696,16 @@ describe('Feathers Knex Service', () => {
       })
       const got = await todoService.get(todo.id)
 
+      assert.deepStrictEqual(
+        await todoService.get(todo.id, {
+          query: { $select: ['id', 'text'] }
+        }),
+        {
+          id: todo.id,
+          text: todo.text,
+          personName: 'Dave'
+        }
+      )
       assert.strictEqual(got.personName, dave.name)
       assert.deepStrictEqual(got, todo)
       assert.deepStrictEqual(found, todo)


### PR DESCRIPTION
This also should prevent duplicate id selection.

Closes https://github.com/feathersjs/feathers/issues/3065