### PR TITLE
docs(guide): Fix typo in client.md

### DIFF
--- a/docs/guides/cli/client.md
+++ b/docs/guides/cli/client.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Client
 
-A generated application can used as an npm module that provides a [Feathers client](../../api/client.md). It gives you a fully typed client that can be installed in any TypeScript (e.g. React, VueJS, React Native etc.) application.
+A generated application can be used as an npm module that provides a [Feathers client](../../api/client.md). It gives you a fully typed client that can be installed in any TypeScript (e.g. React, VueJS, React Native etc.) application.
 
 ## Local installation
 


### PR DESCRIPTION
Fixes a small typo on the first paragraph.