### PR TITLE
fix(generators): Add sourceMap to tsconfig.json template

### DIFF
--- a/packages/generators/src/app/templates/tsconfig.json.tpl.ts
+++ b/packages/generators/src/app/templates/tsconfig.json.tpl.ts
@@ -17,7 +17,8 @@ export const generate = (ctx: AppGeneratorContext) =>
             rootDir: `./${lib}`,
             declaration: true,
             strict: true,
-            esModuleInterop: true
+            esModuleInterop: true,
+            sourceMap: true
           },
           include: [lib],
           exclude: ['test']


### PR DESCRIPTION
### Summary
In order to debug a Feathers 5 typescript server with VSCode, the tsconfig file needs sourceMap enabled.

Closes #3164