### PR TITLE
fix(mongodb): Speed up multi create

### DIFF
--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -292,9 +292,7 @@ export class MongoDbAdapter<
       ? model
           .insertMany(data.map(setId), writeOptions)
           .then(async (result) =>
-            Promise.all(
-              Object.values(result.insertedIds).map(async (_id) => model.findOne({ _id }, params.mongodb))
-            )
+            model.find({ _id: { $in: Object.values(result.insertedIds) } }, params.mongodb).toArray()
           )
       : model
           .insertOne(setId(data), writeOptions)


### PR DESCRIPTION
I know there have been some conversations around how multi will work in the future; which will affect speed and if records are returned. But I figured this was a good holdover until then. I have 2 apps that are suffering from slow multi create that this will hopefully help.