### PR TITLE
fix(schema): Exclude json-schema-to-ts@2.8.0

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -62,7 +62,7 @@
     "@types/json-schema": "^7.0.11",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
-    "json-schema-to-ts": "2.7.2"
+    "json-schema-to-ts": "^2.7.2 <2.8.0 || ^2.8.2"
   },
   "devDependencies": {
     "@feathersjs/memory": "^5.0.4",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -62,7 +62,7 @@
     "@types/json-schema": "^7.0.11",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
-    "json-schema-to-ts": "^2.7.2"
+    "json-schema-to-ts": "2.7.2"
   },
   "devDependencies": {
     "@feathersjs/memory": "^5.0.4",


### PR DESCRIPTION
Until 2.8 is patched, #3168 is making tests fail. The view of PR's and commits is binary, putting us in danger of test failure fatigue. This ameliorates that.

Semver testing util: https://semver.npmjs.com/
Root issue: https://github.com/ThomasAribart/json-schema-to-ts/issues/132