### PR TITLE
fix(authentication-oauth): Update OAuth redirect to handle user requested redirect paths

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -96,7 +96,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     }
 
     const redirectUrl = `${redirect}${queryRedirect}`
-    const separator = redirect.endsWith('?') ? '' : redirect.indexOf('#') !== -1 ? '?' : '#'
+    const separator = redirectUrl.endsWith('?') ? '' : redirect.indexOf('#') !== -1 ? '?' : '#'
     const authResult: AuthenticationResult = data
     const query = authResult.accessToken
       ? { access_token: authResult.accessToken }

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -43,6 +43,14 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
     )
     assert.strictEqual('/home/hi-there#access_token=testing', redirect)
 
+    redirect = await strategy.getRedirect(
+      { accessToken: 'testing' },
+      {
+        redirect: '/hi-there?'
+      }
+    )
+    assert.equal(redirect, '/home/hi-there?access_token=testing')
+
     redirect = await strategy.getRedirect(new Error('something went wrong'))
     assert.equal(redirect, '/home#error=something%20went%20wrong')
 


### PR DESCRIPTION
This PR fixes an issue with the redirect functionality for `authentication-oauth`. If a user had set `origins` in their configuration, and attempted to redirect to a different page on the client side by using a link in the format of `oauth/<name>/?redirect=my/path?`, the redirect would only send them to the path of the origin `myorigin/#access_token`.

The problem was the variable the `separator` variable used to determine how to build the resulting URL. An addition test was added to verify the issue. With the change, if the user has an origin of `http://localhost:8080` and a frontend application that uses OAuth with `oauth/<name>/?redirect=my/path`, they will be redirected properly to `http://localhost:8080/my/path?access_token`.