### PR TITLE
Expose parsed files to hooks and services

### DIFF
--- a/packages/koa/src/rest.ts
+++ b/packages/koa/src/rest.ts
@@ -28,7 +28,7 @@ const serviceMiddleware = (): Middleware => {
     }
 
     const createArguments = http.argumentsFor[method as 'get'] || http.argumentsFor.default
-    const params = { query, headers, route, ...ctx.feathers }
+    const params = { query, headers, route, files: ctx.request.files, ...ctx.feathers }
     const args = createArguments({ id, data, params })
     const contextBase = createContext(service, method, { http: {} })
     ctx.hook = contextBase


### PR DESCRIPTION
When using the koa-body body parser it will create an additional property (files) in the request object. This property is not exposed to feather services / hooks which make it tedious to work with file uploads directly in the services itself.

This field will only be filled when multipart is activated and a binary file is sent. Otherwise it will be undefined.

### Usage:

#### Hooks:
```javascript
export const uploadFiles = async ({ arguments: args }: HookContext) => {
  console.log(args[1].files)
}
```

#### Services:

```javascript
export class MessagesService<ServiceParams extends Params = MessagesParams> extends KnexService<
  Messages,
  MessagesData,
  MessagesParams,
  MessagesPatch
> {
  create(data: { text: string; }, params?: MessagesParams | undefined): Promise<{ id: number; text: string; files: string[]; }>;
  create(data: { text: string; }[], params?: MessagesParams | undefined): Promise<{ id: number; text: string; files: string[]; }[]>;
  create(data: { text: string; } | { text: string; }[], params?: MessagesParams | undefined): Promise<{ id: number; text: string; files: string[]; } | { id: number; text: string; files: string[]; }[]>;
  create(data: unknown, params?: unknown): Promise<{ id: number; text: string; files: string[]; }[]> | Promise<{ id: number; text: string; files: string[]; }> | Promise<{ id: number; text: string; files: string[]; } | { id: number; text: string; files: string[]; }[]> {
    const { files } = params as any
    console.log(files)
  }
}
```