### PR TITLE
fix: default custom-env-config settings caused name conflicts

### DIFF
--- a/packages/generators/src/app/templates/app.test.tpl.ts
+++ b/packages/generators/src/app/templates/app.test.tpl.ts
@@ -11,7 +11,7 @@ import type { Server } from 'http'
 import { app } from '../${lib}/app'
 
 const port = app.get('port')
-const appUrl = \`http://\${app.get('host')}:\${port}\`
+const appUrl = \`http://localhost:\${port}\`
 
 describe('Feathers application tests', () => {
   let server: Server

--- a/packages/generators/src/app/templates/client.test.tpl.ts
+++ b/packages/generators/src/app/templates/client.test.tpl.ts
@@ -11,7 +11,7 @@ import { createClient } from '../${lib}/client'
 import rest from '@feathersjs/rest-client'
 
 const port = app.get('port')
-const appUrl = \`http://\${app.get('host')}:\${port}\`
+const appUrl = \`http://localhost:\${port}\`
 
 describe('client tests', () => {
   const client = createClient(rest(appUrl).axios(axios))

--- a/packages/generators/src/app/templates/configuration.tpl.tsS
+++ b/packages/generators/src/app/templates/configuration.tpl.tsS
@@ -47,7 +47,7 @@ export const configurationSchema = {
     ...defaultAppSettings,
     port: { type: 'number' },
     public: { type: 'string' },
-    origins: Type.Array(Type.String())
+    origins: { type: 'array', items: { type: 'string' } }
   }
 } as const
 
@@ -65,9 +65,9 @@ import { dataValidator } from './validators'
 export const configurationSchema = Type.Intersect([
   defaultAppConfiguration,
   Type.Object({
-    host: Type.String(),
     port: Type.Number(),
-    public: Type.String()
+    public: Type.String(),
+    origins: Type.Array(Type.String())
   })
 ])
 

--- a/packages/generators/src/app/templates/configuration.tpl.tsS
+++ b/packages/generators/src/app/templates/configuration.tpl.tsS
@@ -19,6 +19,10 @@ const customEnvironment = {
     __format: 'number'
   },
   host: 'FEATHERS_HOSTNAME',
+  origins: {
+    __name: 'FEATHERS_ORIGINS',
+    __format: 'json'
+  },
   authentication: {
     secret: 'FEATHERS_SECRET'
   }
@@ -43,7 +47,8 @@ export const configurationSchema = {
     ...defaultAppSettings,
     host: { type: 'string' },
     port: { type: 'number' },
-    public: { type: 'string' }
+    public: { type: 'string' },
+    origins: Type.Array(Type.String())
   }
 } as const
 

--- a/packages/generators/src/app/templates/configuration.tpl.tsS
+++ b/packages/generators/src/app/templates/configuration.tpl.tsS
@@ -15,10 +15,10 @@ const defaultConfig = ({}: AppGeneratorContext) => ({
 
 const customEnvironment = {
   port: {
-    __name: 'PORT',
+    __name: 'FEATHERS_PORT',
     __format: 'number'
   },
-  host: 'HOSTNAME',
+  host: 'FEATHERS_HOSTNAME',
   authentication: {
     secret: 'FEATHERS_SECRET'
   }

--- a/packages/generators/src/app/templates/configuration.tpl.tsS
+++ b/packages/generators/src/app/templates/configuration.tpl.tsS
@@ -45,7 +45,6 @@ export const configurationSchema = {
   required: [ 'host', 'port', 'public' ],
   properties: {
     ...defaultAppSettings,
-    host: { type: 'string' },
     port: { type: 'number' },
     public: { type: 'string' },
     origins: Type.Array(Type.String())

--- a/packages/generators/src/app/templates/index.tpl.ts
+++ b/packages/generators/src/app/templates/index.tpl.ts
@@ -6,14 +6,14 @@ const template = ({}: AppGeneratorContext) => /* ts */ `import { app } from './a
 import { logger } from './logger'
 
 const port = app.get('port')
-const host = app.get('host')
+const origin = app.get('origins')[0]
 
 process.on('unhandledRejection', (reason) =>
   logger.error('Unhandled Rejection %O', reason)
 )
 
 app.listen(port).then(() => {
-  logger.info(\`Feathers app listening on http://\${host}:\${port}\`)
+  logger.info(\`Feathers app listening on \${origin}\`)
 })
 `
 


### PR DESCRIPTION
### Summary

HOSTNAME is available in most Posix systems by default, so it can override your config/default.json OOTB. This is not a well known fact and a new feature in Dove. This conditions combined cause unexpected bindings, errors and interactions with other parts of your server/app/system.

### Suggested solution

Namespace them.

### Additional details

This reminds me of another feathers-configuration feature, relating to path resolution, that caused unexpected issues. I chose not to include OAUTH secrets as the origin definition seems imperfect, as it somewhat duplicates the top level origins.

https://github.com/feathersjs/feathers-chat/blob/dove/feathers-chat-ts/config/custom-environment-variables.json

![Screenshot 2023-06-05 14 26 38](https://github.com/feathersjs/feathers/assets/876076/d6923756-861d-4794-8752-38ac0233ee9e)
