### PR TITLE
fix[authentication]: Support StackBlitz

### DIFF
--- a/packages/authentication/src/core.ts
+++ b/packages/authentication/src/core.ts
@@ -199,7 +199,7 @@ export class AuthenticationBase {
   ) {
     const { secret, jwtOptions } = this.configuration
     // Use configuration by default but allow overriding the secret
-    const jwtSecret = secretOverride || secret
+    const jwtSecret = globalThis.process?.versions?.webcontainer === undefined ? secretOverride || secret : null
     // Default jwt options merged with additional options
     const options = merge({}, jwtOptions, optsOverride)
 

--- a/packages/authentication/src/service.ts
+++ b/packages/authentication/src/service.ts
@@ -174,7 +174,7 @@ export class AuthenticationService
     // connection and event (login, logout) hooks
     const { secret, service, entity, entityId } = this.configuration
 
-    if (typeof secret !== 'string') {
+    if (typeof secret !== 'string' && globalThis.process?.versions?.webcontainer === undefined) {
       throw new Error("A 'secret' must be provided in your authentication configuration")
     }
 


### PR DESCRIPTION
- On AuthenticationService.setup, The error suppression is necessary as without publish, you'll also get errors when login out.
- disables validation and signing of JWT. This works surprisingly well... nothing is lost feature wise, aside from allowing others to spoof login, but that's not a concern in StackBlitz as WebContainers can't be hosted publicly. WASI runtimes run on bare metal and would not have an issue or be affected by this code.
- performance impact is undetectable, as jwt.sign is a usertime function, and this boolean check is a computer time check of the fastest order.

---

P.S. I was working on a fine example for far too long, but the lack of ESM exports has ruined my day. 
https://stackblitz.com/edit/feathersjs-playground-veesb9?file=vite.config.ts