### PR TITLE
fix(authentication): Export JwtVerifyOptions

### DIFF
--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -6,7 +6,8 @@ export {
   AuthenticationResult,
   AuthenticationStrategy,
   AuthenticationParams,
-  ConnectionEvent
+  ConnectionEvent,
+  JwtVerifyOptions
 } from './core'
 export { AuthenticationBaseStrategy } from './strategy'
 export { AuthenticationService } from './service'


### PR DESCRIPTION
### Summary
Added JwtVerifyOptions to the list exports

- [ ] allows JwtVerifyOptions to be accessed without importing from auth/lib/core. 


### Other Information

very light bug fix

Thanks for contributing to Feathers! :heart:
