### PR TITLE
fix(generators): Fix channel/service configuration order for Koa based apps

### DIFF
--- a/packages/generators/src/app/templates/app.tpl.ts
+++ b/packages/generators/src/app/templates/app.tpl.ts
@@ -39,11 +39,11 @@ ${
   cors: {
     origin: app.get('origins')
   }
-}))
-app.configure(channels)`
+}))`
     : ''
 }
 app.configure(services)
+app.configure(channels)
 
 
 // Register hooks that run on all service methods


### PR DESCRIPTION
When creating a new app using Koa, the generated `app.ts` configured `app.configure(channels)` before `app.configure(services)`. This resulted in service references being unavailable in `channels.ts`.

This update to the template places the services configuration before channels, allowing services to be referenced in channels as expected.  