### PR TITLE
docs(guides): Highlight appropriate code lines regarding the context

### DIFF
--- a/docs/guides/cli/service.md
+++ b/docs/guides/cli/service.md
@@ -60,7 +60,7 @@ app.service(messagePath).hooks({
 
 Note that you can add hooks to a specific method as documented in the [hook registration API](../../api/hooks.md#registering-hooks). For example, to use the [profiling hook](./hook.md#profiling-example) only for `find` and `get` the registration can be updated like this:
 
-```ts{8-9}
+```ts{12-13}
 import { profiler } from '../../hooks/profiler'
 // ...
 


### PR DESCRIPTION
Wrong code lines are set to be highlighted in `docs/guides/cli/service.md`.

<img width="747" alt="wrong-code-lines-highlighting" src="https://github.com/feathersjs/feathers/assets/33063780/df396fa0-3429-4464-88d8-b31238df663c">
