### PR TITLE
fix(koa): Ensure .teardown works without a server

### DIFF
--- a/packages/koa/src/index.ts
+++ b/packages/koa/src/index.ts
@@ -53,11 +53,16 @@ export function koa<S = any, C = any>(
     },
 
     async teardown(server?: any) {
-      return feathersTeardown
-        .call(this, server)
-        .then(
-          () => new Promise((resolve, reject) => this.server.close((e) => (e ? reject(e) : resolve(this))))
-        )
+      return feathersTeardown.call(this, server).then(
+        () =>
+          new Promise((resolve, reject) => {
+            if (this.server) {
+              this.server.close((e) => (e ? reject(e) : resolve(this)))
+            } else {
+              resolve(this)
+            }
+          })
+      )
     }
   } as Application)
 

--- a/packages/koa/test/index.test.ts
+++ b/packages/koa/test/index.test.ts
@@ -208,6 +208,12 @@ describe('@feathersjs/koa', () => {
     assert.ok(called)
   })
 
+  it('.teardown works without server (#3224)', async () => {
+    const app = koa(feathers())
+
+    await app.teardown()
+  })
+
   restTests('Services', 'todo', 8465)
   restTests('Root service', '/', 8465)
 })


### PR DESCRIPTION
Closes https://github.com/feathersjs/feathers/issues/3224