### PR TITLE
fix(transport-commons): Handle invalid service paths on socket lookups

### DIFF
--- a/packages/transport-commons/src/socket/index.ts
+++ b/packages/transport-commons/src/socket/index.ts
@@ -50,9 +50,7 @@ export function socket({ done, emit, socketMap, socketKey, getParams }: SocketOp
               result[method] = (...args: any[]) => {
                 const [path, ...rest] = args
 
-                runMethod(app, getParams(connection), path, method, rest).catch((error) =>
-                  console.error(error)
-                )
+                runMethod(app, getParams(connection), path, method, rest)
               }
             }
           })

--- a/packages/transport-commons/src/socket/index.ts
+++ b/packages/transport-commons/src/socket/index.ts
@@ -1,10 +1,7 @@
 import { Application, getServiceOptions, Params, RealTimeConnection } from '@feathersjs/feathers'
-import { createDebug } from '@feathersjs/commons'
 import { channels } from '../channels'
 import { routing } from '../routing'
 import { getDispatcher, runMethod } from './utils'
-
-const debug = createDebug('@feathersjs/transport-commons')
 
 export interface SocketOptions {
   done: Promise<any>
@@ -51,10 +48,11 @@ export function socket({ done, emit, socketMap, socketKey, getParams }: SocketOp
           methods.forEach((method) => {
             if (!result[method]) {
               result[method] = (...args: any[]) => {
-                const path = args.shift()
+                const [path, ...rest] = args
 
-                debug(`Got '${method}' call for service '${path}'`)
-                runMethod(app, getParams(connection), path, method, args)
+                runMethod(app, getParams(connection), path, method, rest).catch((error) =>
+                  console.error(error)
+                )
               }
             }
           })

--- a/packages/transport-commons/src/socket/utils.ts
+++ b/packages/transport-commons/src/socket/utils.ts
@@ -69,10 +69,12 @@ export function getDispatcher(emit: string, socketMap: WeakMap<RealTimeConnectio
 export async function runMethod(
   app: Application,
   connection: RealTimeConnection,
-  path: string,
-  method: string,
+  _path: string,
+  _method: string,
   args: any[]
 ) {
+  const path = typeof _path === 'string' ? _path : null
+  const method = typeof _method === 'string' ? _method : null
   const trace = `method '${method}' on service '${path}'`
   const methodArgs = args.slice(0)
   const callback =
@@ -91,7 +93,7 @@ export async function runMethod(
 
     // No valid service was found throw a NotFound error
     if (lookup === null) {
-      throw new NotFound(`Service '${path}' not found`)
+      throw new NotFound(path === null ? `Invalid service path` : `Service '${path}' not found`)
     }
 
     const { service, params: route = {} } = lookup

--- a/packages/transport-commons/test/socket/index.test.ts
+++ b/packages/transport-commons/test/socket/index.test.ts
@@ -90,14 +90,26 @@ describe('@feathersjs/transport-commons', () => {
       })
     })
 
-    it('.get with invalid service name and arguments', (done) => {
+    it('method with invalid service name and arguments', (done) => {
       const socket = new EventEmitter()
 
       provider.emit('connection', socket)
 
       socket.emit('get', null, (error: any) => {
         assert.strictEqual(error.name, 'NotFound')
-        assert.strictEqual(error.message, "Service 'null' not found")
+        assert.strictEqual(error.message, 'Invalid service path')
+        done()
+      })
+    })
+
+    it('method with implicit toString errors properly', (done) => {
+      const socket = new EventEmitter()
+
+      provider.emit('connection', socket)
+
+      socket.emit('get', { toString: '' }, (error: any) => {
+        assert.strictEqual(error.name, 'NotFound')
+        assert.strictEqual(error.message, 'Invalid service path')
         done()
       })
     })


### PR DESCRIPTION
This is a fix for a security issue where the conversion of the following template string:

```ts
const message = `${{ toString: '' }}`
```

Triggers an error killing the NodeJS process. This error happens when e.g. sending a `socket.emit('find', { toString: '' })` message.