### PR TITLE
docs: Small Documentation Typos

### DIFF
--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -542,7 +542,7 @@ The sections of this format are described as follows:
 ###### `iso-date-time`
 
 ```ts
-Type.String({ format: 'date-time' })
+Type.String({ format: 'iso-date-time' })
 ```
 
 Validates against the [date-time](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) described in RFC3339/ISO8601, which is the following format:

--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -108,7 +108,7 @@ const messageQueryProperties = Type.Pick(messageSchema, ['id', 'text', 'createdA
 })
 const messageQuerySchema = Type.Intersect(
   [
-    // This will additioanlly allow querying for `{ name: { $ilike: 'Dav%' } }`
+    // This will additionally allow querying for `{ name: { $ilike: 'Dav%' } }`
     querySyntax(messageQueryProperties, {
       name: {
         $ilike: Type.String()

--- a/docs/guides/cli/service.schemas.md
+++ b/docs/guides/cli/service.schemas.md
@@ -71,7 +71,7 @@ export const messageDataValidator = getValidator(messageDataSchema, dataValidato
 export const messageDataResolver = resolve<Message, HookContext>({})
 ```
 
-### Patch schema and resolvers
+## Patch schema and Resolvers
 
 The patch schema is used for updating existing entries calling [service.patch](../../api/services.md#patchid-data-params). This is often different then the data schema for new entries and by default is a partial of the [main schema](#main-schemas-and-resolvers).
 


### PR DESCRIPTION
### Summary
A couple typo's I ran across when reading the documentation
