### PR TITLE
docs: Update adapter documentation

### DIFF
--- a/docs/api/databases/common.md
+++ b/docs/api/databases/common.md
@@ -29,15 +29,15 @@ app.use('/messages', new NameService({ id, events, paginate }))
 
 The following options are available for all database adapters:
 
-- `id` (_optional_) - The name of the id field property (usually set by default to `id` or `_id`).
-- `paginate` (_optional_) - A [pagination object](#pagination) containing a `default` and `max` page size
-- `multi` (_optional_, default: `false`) - Allow `create` with arrays and `patch` and `remove` with id `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
+- `id {string}` (_optional_) - The name of the id field property (usually set by default to `id` or `_id`).
+- `paginate {Object}` (_optional_) - A [pagination object](#pagination) containing a `default` and `max` page size
+- `multi {string[]|boolean}` (_optional_, default: `false`) - Allow `create` with arrays and `patch` and `remove` with id `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
 
 The following legacy options are still available but should be avoided:
 
-- `events` (_optional_, **deprecated**) - A list of [custom service events](../events.md#custom-events) sent by this service. Use the `events` option when [registering the service with app.use](../application.md#usepath-service--options) instead.
-- `operators` (_optional_, **deprecated**) - A list of additional non-standard query parameters to allow (e.g `[ '$regex' ]`). Not necessary when using a [query schema](../schema/validators.md#validatequery)
-- `filters` (_optional_, **deprecated**) - A list of top level `$` query parameters to allow (e.g. `[ '$populate' ]`). Not necessary when using a [query schema](../schema/validators.md#validatequery)
+- `events {string[]}` (_optional_, **deprecated**) - A list of [custom service events](../events.md#custom-events) sent by this service. Use the `events` option when [registering the service with app.use](../application.md#usepath-service--options) instead.
+- `operators {string[]}` (_optional_, **deprecated**) - A list of additional non-standard query parameters to allow (e.g `[ '$regex' ]`). Not necessary when using a [query schema](../schema/validators.md#validatequery)
+- `filters {Object}` (_optional_, **deprecated**) - An object of additional top level query filters, e.g. `{ $populate: true }`. Can also be a converter function like `{ $ignoreCase: (value) => value === 'true' ? true : false }`. Not necessary when using a [query schema](../schema/validators.md#validatequery)
 
 For database specific options see the adapter documentation.
 

--- a/docs/api/databases/knex.md
+++ b/docs/api/databases/knex.md
@@ -65,10 +65,11 @@ The Knex specific adapter options are:
 
 The [common API options](./common.md#options) are:
 
-- `id {string}` (_optional_, default: `'_id'`) - The name of the id field property. By design, MongoDB will always add an `_id` property.
-- `events {string[]}` (_optional_) - A list of [custom service events](/api/events.html#custom-events) sent by this service
-- `paginate {Object}` (_optional_) - A [pagination object](/api/databases/common.html#pagination) containing a `default` and `max` page size
-- `multi {string[]|true}` (_optional_) - Allow `create` with arrays and `update` and `remove` with `id` `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
+- `id {string}` (_optional_, default: `'id'`) - The name of the id field property. By design, Knex will always add an `id` property.
+- `paginate {Object}` (_optional_) - A [pagination object](#pagination) containing a `default` and `max` page size
+- `multi {string[]|boolean}` (_optional_, default: `false`) - Allow `create` with arrays and `patch` and `remove` with id `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
+
+There are additionally several legacy options in the [common API options](./common.md#options)
 
 ### getModel([params])
 

--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -67,9 +67,11 @@ MongoDB adapter specific options are:
 The [common API options](./common.md#options) are:
 
 - `id {string}` (_optional_, default: `'_id'`) - The name of the id field property. By design, MongoDB will always add an `_id` property.
-- `events {string[]}` (_optional_) - A list of [custom service events](/api/events.html#custom-events) sent by this service
-- `paginate {Object}` (_optional_) - A [pagination object](/api/databases/common.html#pagination) containing a `default` and `max` page size
-- `multi {string[]|true}` (_optional_) - Allow `create` with arrays and `update` and `remove` with `id` `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
+- `id {string}` (_optional_) - The name of the id field property (usually set by default to `id` or `_id`).
+- `paginate {Object}` (_optional_) - A [pagination object](#pagination) containing a `default` and `max` page size
+- `multi {string[]|boolean}` (_optional_, default: `false`) - Allow `create` with arrays and `patch` and `remove` with id `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
+
+There are additionally several legacy options in the [common API options](./common.md#options)
 
 ### getModel()
 


### PR DESCRIPTION
### Summary of Problem
The [current knex docs](https://github.com/feathersjs/feathers/blob/414336a047a556f1986b4bb253416d5b8a973d9f/docs/api/databases/knex.md?plain=1#L68) incorrectly refer to mongodb in the knex documentation, they state that the default id is `'_id'`, and they mention the events option which has been deprecated.   The mongodb docs similarly mention the deprecated events option.

The common adapters documentation does not have type descriptions for the options while the knex and mongodb docs do.  

### What did I do
Add /fix type annotation for the common adapter options. Directly copy updated documentation into the knex / mongodb sections so they are exactly the same and mention/link to the other, deprecated options
