### PR TITLE
docs: Updated how to type HookContext

### DIFF
--- a/docs/guides/cli/declarations.md
+++ b/docs/guides/cli/declarations.md
@@ -92,7 +92,7 @@ The `HookContext` type exports a [hook context](../../api/hooks.md) type with th
 export type HookContext<S = any> = FeathersHookContext<Application, S>
 ```
 
-Use `HookContext<FeathersService<UserService>>` to get the full hook context for a service.
+Use `HookContext<UserService>` to get the full hook context for a service.
 
 ## Services and Params
 


### PR DESCRIPTION
**Problem**
The docs were incorrectly showing how to type of HookContext for a specific service

 **Fix**
This PR attempts to rectify the typo such that the HookContext returns the correct type for the specified service