### PR TITLE
docs: Fix example in Discord oauth cookbook

### DIFF
--- a/docs/cookbook/authentication/_discord.md
+++ b/docs/cookbook/authentication/_discord.md
@@ -36,7 +36,7 @@ import axios, {AxiosRequestConfig} from 'axios'
 import {ServiceAddons} from '@feathersjs/feathers';
 import {AuthenticationService, JWTStrategy} from '@feathersjs/authentication';
 import {LocalStrategy} from '@feathersjs/authentication-local';
-import {expressOauth} from '@feathersjs/authentication-oauth';
+import {oauth} from '@feathersjs/authentication-oauth';
 import {Application} from './declarations';
 
 
@@ -48,7 +48,7 @@ export default function (app: Application) {
   authentication.register('discord', new DiscordStrategy());
 
   app.use('/authentication', authentication);
-  app.configure(expressOauth());
+  app.configure(oauth());
 }
 
 export class DiscordStrategy extends OAuthStrategy {

--- a/docs/cookbook/authentication/_discord.md
+++ b/docs/cookbook/authentication/_discord.md
@@ -13,7 +13,7 @@ Discord login can be initialized like any other [OAuth provider](../../api/authe
       "discord": {
         "key": "<App ID>",
         "secret": "<App Secret>",
-        "scopes": ["identify email"]
+        "scope": ["identify email"]
       }
     }
   }


### PR DESCRIPTION
Both Discord and `@feathers/authentication-oauth` expect "scope" key in config file instead of "scopes".
