### PR TITLE
fix(generators): Fix configure channels when not real-time app

### DIFF
--- a/packages/generators/src/app/templates/app.tpl.ts
+++ b/packages/generators/src/app/templates/app.tpl.ts
@@ -43,7 +43,7 @@ ${
     : ''
 }
 app.configure(services)
-${transports.includes('websockets') ? `app.configure(channels)` : ''}
+${transports.includes('websockets') ? 'app.configure(channels)' : ''}
 
 
 // Register hooks that run on all service methods
@@ -105,7 +105,7 @@ ${
     : ''
 }
 app.configure(services)
-${transports.includes('websockets') ? `app.configure(channels)` : ''}
+${transports.includes('websockets') ? 'app.configure(channels)' : ''}
 
 // Configure a middleware for 404s and the error handler
 app.use(notFound())

--- a/packages/generators/src/app/templates/app.tpl.ts
+++ b/packages/generators/src/app/templates/app.tpl.ts
@@ -43,7 +43,7 @@ ${
     : ''
 }
 app.configure(services)
-app.configure(channels)
+${transports.includes('websockets') ? `app.configure(channels)` : ''}
 
 
 // Register hooks that run on all service methods
@@ -105,7 +105,7 @@ ${
     : ''
 }
 app.configure(services)
-app.configure(channels)
+${transports.includes('websockets') ? `app.configure(channels)` : ''}
 
 // Configure a middleware for 404s and the error handler
 app.use(notFound())


### PR DESCRIPTION
### Summary

When I create a new project with feathers cli the app configure "channels" even if I answer the app is not a real-time app.
The presence of this line make an error when I run the project wich said "channels is undefined".
I see the import of "channels" is conditioned by the presence of "websockets" but not the "app.configure".
