### PR TITLE
chore: Update CI to Node 18 minimum

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 20.x]
+        node-version: [18.x, 20.x]
 
     services:
       postgres:


### PR DESCRIPTION
Since Node 16 will be end of life next week and CI has been failing with it already.