### PR TITLE
fix(typebox): Allow default value in StringEnum

### DIFF
--- a/packages/typebox/src/index.ts
+++ b/packages/typebox/src/index.ts
@@ -38,8 +38,8 @@ export const getDataValidator = (def: TObject | TDataSchemaMap, validator: Ajv):
  * @param allowedValues array of strings for the enum
  * @returns TypeBox.Type
  */
-export function StringEnum<T extends string[]>(allowedValues: [...T]) {
-  return Type.Unsafe<T[number]>({ type: 'string', enum: allowedValues })
+export function StringEnum<T extends string[]>(allowedValues: [...T], options?: { default: T[number] }) {
+  return Type.Unsafe<T[number]>({ type: 'string', enum: allowedValues, ...options })
 }
 
 const arrayOfKeys = <T extends TObject>(type: T) => {


### PR DESCRIPTION
### Summary

Closes https://github.com/feathersjs/feathers/issues/3280

### Other Information

This is a PR that expands `StringEnum` to accept a default value. I would prefer to expand the type to allow for all of the `TSchema` properties. But I was not able to figure out the types for it. 

Would appreciate some assistance completing the types if possible
