### PR TITLE
fix(schema): add typescript >=4.7 as peerDependency

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -73,5 +73,8 @@
     "shx": "^0.3.4",
     "typescript": "^5.2.2"
   },
+  "peerDependencies": {
+    "typescript": ">=4.7"
+  },
   "gitHead": "90caf635aec850550b9d37bea2762af959d9e8d5"
 }


### PR DESCRIPTION
Schema package doesn't compile when installed TS is below 4.7, giving cryptic errors that are hard to track down. See https://discord.com/channels/509848480760725514/1079914294323445975 for context