### PR TITLE
fix: allow _patch to modify the entire base schema

### DIFF
--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -254,12 +254,12 @@ export class KnexAdapter<
     })
   }
 
-  async _patch(id: null, data: PatchData, params?: ServiceParams): Promise<Result[]>
-  async _patch(id: Id, data: PatchData, params?: ServiceParams): Promise<Result>
-  async _patch(id: NullableId, data: PatchData, _params?: ServiceParams): Promise<Result | Result[]>
+  async _patch(id: null, data: PatchData | Partial<Result>, params?: ServiceParams): Promise<Result[]>
+  async _patch(id: Id, data: PatchData | Partial<Result>, params?: ServiceParams): Promise<Result>
+  async _patch(id: NullableId, data: PatchData | Partial<Result>, _params?: ServiceParams): Promise<Result | Result[]>
   async _patch(
     id: NullableId,
-    raw: PatchData,
+    raw: PatchData | Partial<Result>,
     params: ServiceParams = {} as ServiceParams
   ): Promise<Result | Result[]> {
     if (id === null && !this.allowsMulti('patch', params)) {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -178,12 +178,12 @@ export class MemoryAdapter<
     return this._get(id, params)
   }
 
-  async _patch(id: null, data: PatchData, params?: ServiceParams): Promise<Result[]>
-  async _patch(id: Id, data: PatchData, params?: ServiceParams): Promise<Result>
-  async _patch(id: NullableId, data: PatchData, _params?: ServiceParams): Promise<Result | Result[]>
+  async _patch(id: null, data: PatchData | Partial<Result>, params?: ServiceParams): Promise<Result[]>
+  async _patch(id: Id, data: PatchData | Partial<Result>, params?: ServiceParams): Promise<Result>
+  async _patch(id: NullableId, data: PatchData | Partial<Result>, _params?: ServiceParams): Promise<Result | Result[]>
   async _patch(
     id: NullableId,
-    data: PatchData,
+    data: PatchData | Partial<Result>,
     params: ServiceParams = {} as ServiceParams
   ): Promise<Result | Result[]> {
     if (id === null && !this.allowsMulti('patch', params)) {

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -301,12 +301,12 @@ export class MongoDbAdapter<
     return promise.then(select(params, this.id)).catch(errorHandler)
   }
 
-  async _patch(id: null, data: PatchData, params?: ServiceParams): Promise<Result[]>
-  async _patch(id: AdapterId, data: PatchData, params?: ServiceParams): Promise<Result>
-  async _patch(id: NullableAdapterId, data: PatchData, _params?: ServiceParams): Promise<Result | Result[]>
+  async _patch(id: null, data: PatchData | Partial<Result>, params?: ServiceParams): Promise<Result[]>
+  async _patch(id: AdapterId, data: PatchData | Partial<Result>, params?: ServiceParams): Promise<Result>
+  async _patch(id: NullableAdapterId, data: PatchData | Partial<Result>, _params?: ServiceParams): Promise<Result | Result[]>
   async _patch(
     id: NullableAdapterId,
-    _data: PatchData,
+    _data: PatchData | Partial<Result>,
     params: ServiceParams = {} as ServiceParams
   ): Promise<Result | Result[]> {
     if (id === null && !this.allowsMulti('patch', params)) {


### PR DESCRIPTION
### Summary

With this given schema

```ts
export const userSchema = Type.Object(
  {
    id: Type.Number(),
    username: Type.String(),
    isAdmin: Type.Boolean()
  },
  { $id: 'User', additionalProperties: false }
)
```

You may want a user to be able modify their own username, but obviously not set `isAdmin` to `true` whenever they want.

So you have a patch schema that only permits the username to be modified.

```ts
export const userPatchSchema = Type.Pick(userSchema, ['username'], {
  $id: 'UserPatch'
})
```

But the backend still retains the ability to modify any property by using underscore methods. `_patch` ignores all hooks and can set `isAdmin` to `true`

```ts
app.service('user')._patch(user.id, { isAdmin: true })
```

The issue is that currently Feathers throws a type error if you try to modify anything that isn't part of the `userPatchSchema`, even if you are using `_patch`.  You get an error similar to this, `Argument of type  { isAdmin: boolean; }  is not assignable to parameter of type  { username: string; } `

This is very frustrating to deal with, since the code is perfectly valid.

This PR attempts to address that type issue. 
### Other Information

I have tried my best in testing this, I ran the test script and all passed. I also tried this against my local feathers app and it seems to work correctly. I spent a decent bit of time on figuring out these whole 12 lines of changes. This was seemingly the simplest way of fixing the types, without breaking a lot of stuff
