### PR TITLE
fix(core): context.path is now typed correctly

### DIFF
--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -3,6 +3,10 @@ import { NextFunction, HookContext as BaseHookContext } from '@feathersjs/hooks'
 
 type SelfOrArray<S> = S | S[]
 type OptionalPick<T, K extends PropertyKey> = Pick<T, Extract<keyof T, K>>
+type Entries<T> = {
+  [K in keyof T]: [K, T[K]]
+}[keyof T][]
+type GetKeyByValue<Obj, Value> = Extract<Entries<Obj>[number], [PropertyKey, Value]>[0]
 
 export type { NextFunction }
 
@@ -355,6 +359,8 @@ export interface Http {
 
 export type HookType = 'before' | 'after' | 'error' | 'around'
 
+type Serv<FA> = FA extends Application<infer S> ? S : never
+
 export interface HookContext<A = Application, S = any> extends BaseHookContext<ServiceGenericType<S>> {
   /**
    * A read only property that contains the Feathers application object. This can be used to
@@ -370,7 +376,7 @@ export interface HookContext<A = Application, S = any> extends BaseHookContext<S
    * A read only property and contains the service name (or path) without leading or
    * trailing slashes.
    */
-  readonly path: string
+  path: 0 extends 1 & S ? keyof Serv<A> & string : GetKeyByValue<Serv<A>, S> & string
   /**
    * A read only property and contains the service this hook currently runs on.
    */


### PR DESCRIPTION
### Summary

Currently `app.service()` is typed to all the registered services, and since `context.path` is just a string doing `app.service(context.path)` in a hook leads to an error that string is not assignable to `<list of schemas>`

This issue resolve that by allow `context.path` to check against the service provided in the `HookContext`. If `HookContext` is not typed with a service, it will default back to all services. 

If you create a hook in your user service. Where the `context.path` should always be `user`. It should not be typed as such

If you create a global hook, `context.path` will be a intersection of all your registered services.

