### PR TITLE
fix(memory): Ensure correct pagination totals

### DIFF
--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -76,7 +76,6 @@ export class MemoryAdapter<
     const { query, filters } = this.getQuery(params)
 
     let values = _.values(this.store)
-    const total = values.length
     const hasSkip = filters.$skip !== undefined
     const hasSort = filters.$sort !== undefined
     const hasLimit = filters.$limit !== undefined
@@ -86,10 +85,40 @@ export class MemoryAdapter<
       values.sort(this.options.sorter(filters.$sort))
     }
 
+    if (paginate) {
+      if (hasQuery) {
+        values = values.filter(this.options.matcher(query))
+      }
+
+      const total = values.length
+
+      if (hasSkip) {
+        values = values.slice(filters.$skip)
+      }
+
+      if (hasLimit) {
+        values = values.slice(0, filters.$limit)
+      }
+
+      const result: Paginated<Result> = {
+        total,
+        limit: filters.$limit,
+        skip: filters.$skip || 0,
+        data: values.map((value) => _select(value, params, this.id))
+      }
+
+      return result
+    }
+
+    /*  Without pagination, we don't have to match every result and gain considerable performance improvements with a breaking for loop. */
     if (hasQuery || hasLimit || hasSkip) {
       let skipped = 0
       const matcher = this.options.matcher(query)
       const matched = []
+
+      if (hasLimit && filters.$limit === 0) {
+        return []
+      }
 
       for (let index = 0, length = values.length; index < length; index++) {
         const value = values[index]
@@ -110,23 +139,10 @@ export class MemoryAdapter<
         }
       }
 
-      values = matched
-    } else {
-      values = values.map((value) => _select(value, params, this.id))
+      return matched
     }
 
-    const result: Paginated<Result> = {
-      total: hasQuery ? values.length : total,
-      limit: filters.$limit,
-      skip: filters.$skip || 0,
-      data: filters.$limit === 0 ? [] : values
-    }
-
-    if (!paginate) {
-      return result.data
-    }
-
-    return result
+    return values.map((value) => _select(value, params, this.id))
   }
 
   async _get(id: Id, params: ServiceParams = {} as ServiceParams): Promise<Result> {


### PR DESCRIPTION
This PR addresses the comments made at https://github.com/feathersjs/feathers/pull/2844.

When pagination is enabled, the total is now correct and essentially works as things used to. There are two changes from the original implementation. 

1 - We check `hasQuery` before running the matcher. This is something I mentioned in my first PR. It just means that for our most basic calls like `service.find()` that we don't match the whole array for no reason.

2 - We now also add `this.id` in `_select(value, params, this.id))`. This ensures that the record ID is always selected, and is more in line with how most of the the DB adapters work. We may or may not want this, but its something to note as you guys are moving this over to Wings.
