### PR TITLE
fix(schema): Allow $in and $nin queries to work for arrays

### DIFF
--- a/packages/schema/src/json-schema.ts
+++ b/packages/schema/src/json-schema.ts
@@ -112,14 +112,20 @@ export const queryProperty = <T extends JSONSchema, X extends { [key: string]: J
           $lt: definition,
           $lte: definition,
           $ne: definition,
-          $in: {
-            type: 'array',
-            items: definition
-          },
-          $nin: {
-            type: 'array',
-            items: definition
-          },
+          $in:
+            definition.type === 'array'
+              ? definition
+              : {
+                  type: 'array',
+                  items: definition
+                },
+          $nin:
+            definition.type === 'array'
+              ? definition
+              : {
+                  type: 'array',
+                  items: definition
+                },
           ...extensions
         }
       }

--- a/packages/schema/test/json-schema.test.ts
+++ b/packages/schema/test/json-schema.test.ts
@@ -52,7 +52,34 @@ describe('@feathersjs/schema/json-schema', () => {
       }
     }
 
-    const validator = new Ajv({ strict: false }).compile(schema)
+    const validator = new Ajv({ strict: false }).compile(querySchema)
+
+    assert.ok(validator(q))
+  })
+
+  it('$in and $nin works with array definitions', async () => {
+    const schema = {
+      things: {
+        type: 'array',
+        items: { type: 'number' }
+      }
+    } as const
+
+    const querySchema = {
+      type: 'object',
+      properties: querySyntax(schema)
+    } as const
+
+    type Query = FromSchema<typeof querySchema>
+
+    const q: Query = {
+      things: {
+        $in: [10, 20],
+        $nin: [30]
+      }
+    }
+
+    const validator = new Ajv({ strict: false }).compile(querySchema)
 
     assert.ok(validator(q))
   })

--- a/packages/typebox/src/index.ts
+++ b/packages/typebox/src/index.ts
@@ -110,8 +110,8 @@ export const queryProperty = <T extends TSchema, X extends { [key: string]: TSch
               $lt: def,
               $lte: def,
               $ne: def,
-              $in: Type.Array(def),
-              $nin: Type.Array(def)
+              $in: def.type === 'array' ? def : Type.Array(def),
+              $nin: def.type === 'array' ? def : Type.Array(def)
             }),
             Type.Object(extension)
           ],

--- a/packages/typebox/test/index.test.ts
+++ b/packages/typebox/test/index.test.ts
@@ -80,6 +80,27 @@ describe('@feathersjs/schema/typebox', () => {
     })
   })
 
+  it('$in and $nin works with array type', async () => {
+    const schema = Type.Object({
+      things: Type.Array(Type.Number())
+    })
+    const querySchema = querySyntax(schema)
+    const validator = new Ajv().compile(querySchema)
+
+    type Query = Static<typeof querySchema>
+
+    const query: Query = {
+      things: {
+        $in: [10, 20],
+        $nin: [30]
+      }
+    }
+
+    const validated = (await validator(query)) as any as Query
+
+    assert.ok(validated)
+  })
+
   it('defaultAppConfiguration', async () => {
     const configSchema = Type.Intersect([
       defaultAppConfiguration,


### PR DESCRIPTION
This allows for the query syntax to query MongoDB arrays with `$in` and `$nin`.

Closes https://github.com/feathersjs/feathers/issues/3346