### PR TITLE
fix(transport-commons): Allow case insensitive route lookups

### DIFF
--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -155,6 +155,12 @@ lookup.service.find({
 })
 ```
 
+Case insensitive lookups can be enabled in the `app` file like this:
+
+```ts
+app.routes.caseSensitive = false
+```
+
 ## .hooks(hooks)
 
 `app.hooks(hooks) -> app` allows registration of application-level hooks. For more information see the [application hooks section in the hooks chapter](./hooks.md#application-hooks).

--- a/packages/transport-commons/src/routing/router.ts
+++ b/packages/transport-commons/src/routing/router.ts
@@ -115,10 +115,18 @@ export class RouteNode<T = any> {
 }
 
 export class Router<T = any> {
+  public caseSensitive = true
+
   constructor(public root: RouteNode<T> = new RouteNode<T>('', 0)) {}
 
   getPath(path: string) {
-    return stripSlashes(path).split('/')
+    const result = stripSlashes(path).split('/')
+
+    if (!this.caseSensitive) {
+      return result.map((p) => (p.startsWith(':') ? p : p.toLowerCase()))
+    }
+
+    return result
   }
 
   insert(path: string, data: T) {

--- a/packages/transport-commons/test/routing/index.test.ts
+++ b/packages/transport-commons/test/routing/index.test.ts
@@ -43,6 +43,14 @@ describe('app.routes', () => {
     assert.strictEqual(result.service, app.service('/my/service/'))
   })
 
+  it('can look up case insensitive', () => {
+    app.routes.caseSensitive = false
+
+    const result = app.lookup('/My/ServicE')
+
+    assert.strictEqual(result.service, app.service('my/service'))
+  })
+
   it('can look up with id', () => {
     const result = app.lookup('/my/service/1234')
 


### PR DESCRIPTION
This pull request allows case insensitive route lookups by setting `app.routes.caseSensitive = false`.

Closes https://github.com/feathersjs/feathers/issues/3330