### PR TITLE
fix(schema): Remove undefined $select when using resolveResult hook

### DIFF
--- a/packages/schema/src/hooks/resolve.ts
+++ b/packages/schema/src/hooks/resolve.ts
@@ -90,7 +90,7 @@ export const resolveResult = <H extends HookContext>(...resolvers: Resolver<any,
       resolve,
       query: {
         ...query,
-        ...(!hasVirtualSelects ? { $select } : {})
+        ...(!!$select && !hasVirtualSelects ? { $select } : {})
       }
     }
 


### PR DESCRIPTION
Without this code, an extra `$select: undefined` is added to queries.  This little update fixes that issue.
