### PR TITLE
fix(mongodb): MongoDB Aggregation improvements

### DIFF
--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -208,7 +208,7 @@ Here's how it works with the operators that match the Feathers Query syntax. Let
 const query = {
   text: { $regex: 'feathersjs', $options: 'igm' },
   $sort: { createdAt: -1 },
-  $skip: 0,
+  $skip: 20,
   $limit: 10
 }
 ```

--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -86,7 +86,7 @@ The `find` method has been split into separate utilities for converting params i
 
 ### makeFeathersPipeline(params)
 
-`makeFeathersPipeline(params)` takes a set of Feathers params and converts them to a pipeline array, ready to pass to `modal.aggregate`. This utility comprises the bulk of the `aggregateRaw` functionality, but does not use `params.pipeline`.
+`makeFeathersPipeline(params)` takes a set of Feathers params and converts them to a pipeline array, ready to pass to `model.aggregate`. This utility comprises the bulk of the `aggregateRaw` functionality, but does not use `params.pipeline`.
 
 ### Custom Params
 
@@ -98,7 +98,7 @@ Allows to dynamically set the [adapter options](#options) (like the `Model` coll
 
 #### params.pipeline
 
-Used for [aggregation pipelines](#aggregation-pipeline). Whenever this property is set, the adapter will use the `collection.aggregate` method instead of the `collection.find` method. The `pipeline` property should be an array of [aggregation stages](https://www.mongodb.com/docs/manual/reference/operator/aggregation-pipeline/).
+Used for [aggregation pipelines](#aggregation-pipeline). Whenever this property is set, the adapter will use the `model.aggregate` method instead of the `model.find` method. The `pipeline` property should be an array of [aggregation stages](https://www.mongodb.com/docs/manual/reference/operator/aggregation-pipeline/).
 
 #### params.mongodb
 
@@ -199,7 +199,7 @@ See the MongoDB documentation for instructions on performing full-text search us
 
 In Feathers v5 Dove, we added support for the full power of MongoDB's Aggregation Framework and blends it seamlessly with the familiar Feathers Query syntax. The `find` method automatically uses the aggregation pipeline when `params.pipeline` is set.
 
-The Aggregation Framework is accessed through the mongoClient's `collection.aggregate` method, which accepts an array of "stages". Each stage contains an operator which describes an operation to apply to the previous step's data. Each stage applies the operation to the results of the previous step. It’s now possible to perform any of the [Aggregation Stages](https://www.mongodb.com/docs/upcoming/reference/operator/aggregation-pipeline/) like `$lookup` and `$unwind`, integration with the normal Feathers queries.
+The Aggregation Framework is accessed through the mongoClient's `model.aggregate` method, which accepts an array of "stages". Each stage contains an operator which describes an operation to apply to the previous step's data. Each stage applies the operation to the results of the previous step. It’s now possible to perform any of the [Aggregation Stages](https://www.mongodb.com/docs/upcoming/reference/operator/aggregation-pipeline/) like `$lookup` and `$unwind`, integration with the normal Feathers queries.
 
 Here's how it works with the operators that match the Feathers Query syntax. Let's convert the following Feathers query:
 

--- a/docs/api/databases/mongodb.md
+++ b/docs/api/databases/mongodb.md
@@ -66,8 +66,7 @@ MongoDB adapter specific options are:
 
 The [common API options](./common.md#options) are:
 
-- `id {string}` (_optional_, default: `'_id'`) - The name of the id field property. By design, MongoDB will always add an `_id` property.
-- `id {string}` (_optional_) - The name of the id field property (usually set by default to `id` or `_id`).
+- `id {string}` (_optional_, default: `'_id'`) - The name of the id field property. By design, MongoDB will always add an `_id` property. But you can choose to use a different property as your primary key.
 - `paginate {Object}` (_optional_) - A [pagination object](#pagination) containing a `default` and `max` page size
 - `multi {string[]|boolean}` (_optional_, default: `false`) - Allow `create` with arrays and `patch` and `remove` with id `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
 
@@ -79,19 +78,19 @@ There are additionally several legacy options in the [common API options](./comm
 
 ### aggregateRaw(params)
 
-The `find` method has been split into separate utilities for converting params into different types of MongoDB requests. By default, requests are processed by this method and are run through the MongoDB Aggregation Pipeline. This method returns a raw MongoDB Cursor object, which can be used to perform custom pagination or in custom server scripts, if desired.
+The `find` method has been split into separate utilities for converting params into different types of MongoDB requests. When using `params.pipeline`, the `aggregateRaw` method is used to convert the Feathers params into a MongoDB aggregation pipeline with the `model.aggregate` method. This method returns a raw MongoDB Cursor object, which can be used to perform custom pagination or in custom server scripts, if desired.
 
 ### findRaw(params)
 
-`findRaw(params)` is used when `params.mongodb` is set to retrieve data using `params.mongodb` as the `FindOptions` object. This method returns a raw MongoDB Cursor object, which can be used to perform custom pagination or in custom server scripts, if desired.
+`findRaw(params)` This method is used when there is no `params.pipeline` and uses the common `model.find` method. It returns a raw MongoDB Cursor object, which can be used to perform custom pagination or in custom server scripts, if desired.
 
 ### makeFeathersPipeline(params)
 
-`makeFeathersPipeline(params)` takes a set of Feathers params and converts them to a pipeline array, ready to pass to `collection.aggregate`. This utility comprises the bulk of the `aggregateRaw` functionality, but does not use `params.pipeline`.
+`makeFeathersPipeline(params)` takes a set of Feathers params and converts them to a pipeline array, ready to pass to `modal.aggregate`. This utility comprises the bulk of the `aggregateRaw` functionality, but does not use `params.pipeline`.
 
 ### Custom Params
 
-The `@feathersjs/mongodb` adapter utilizes two custom params which control adapter-specific features: `params.pipeline` and `params.mongodb`.
+The `@feathersjs/mongodb` adapter utilizes three custom params which control adapter-specific features: `params.pipeline`, `params.mongodb`, and `params.adapter`.
 
 #### params.adapter
 
@@ -99,11 +98,11 @@ Allows to dynamically set the [adapter options](#options) (like the `Model` coll
 
 #### params.pipeline
 
-Used for [aggregation pipelines](#aggregation-pipeline).
+Used for [aggregation pipelines](#aggregation-pipeline). Whenever this property is set, the adapter will use the `collection.aggregate` method instead of the `collection.find` method. The `pipeline` property should be an array of [aggregation stages](https://www.mongodb.com/docs/manual/reference/operator/aggregation-pipeline/).
 
 #### params.mongodb
 
-When making a [service method](/api/services.md) call, `params` can contain an`mongodb` property (for example, `{upsert: true}`) which allows modifying the options used to run the MongoDB query. The adapter will use the `collection.find` method and not the [aggregation pipeline](#aggregation-pipeline) when you use `params.mongodb`.
+When making a [service method](/api/services.md) call, `params` can contain an`mongodb` property (for example, `{ upsert: true }`) which allows modifying the options used to run the MongoDB query. This param can be used for both find and aggregation queries.
 
 ## Transactions
 
@@ -198,7 +197,7 @@ See the MongoDB documentation for instructions on performing full-text search us
 
 ## Aggregation Pipeline
 
-In Feathers v5 Dove, we added support for the full power of MongoDB's Aggregation Framework and blends it seamlessly with the familiar Feathers Query syntax. All `find` queries now use the Aggregation Framework, by default.
+In Feathers v5 Dove, we added support for the full power of MongoDB's Aggregation Framework and blends it seamlessly with the familiar Feathers Query syntax. The `find` method automatically uses the aggregation pipeline when `params.pipeline` is set.
 
 The Aggregation Framework is accessed through the mongoClient's `collection.aggregate` method, which accepts an array of "stages". Each stage contains an operator which describes an operation to apply to the previous step's data. Each stage applies the operation to the results of the previous step. It’s now possible to perform any of the [Aggregation Stages](https://www.mongodb.com/docs/upcoming/reference/operator/aggregation-pipeline/) like `$lookup` and `$unwind`, integration with the normal Feathers queries.
 

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -309,6 +309,7 @@ export class MongoDbAdapter<
       return data
     }
 
+    /* TODO: This seems a little funky. The user shouldn't need to have service.options.paginate to count documents necessarily. Shouldn't this just always return { total: 123 } if no pagination option? Else it always return an empty array. Or we can keep it this way, and document that you can use `this.countDocuments` if you don't have paginate option. Just seems weird. */
     if (filters.$limit === 0) {
       return page({
         total: await this.countDocuments(params),
@@ -320,10 +321,12 @@ export class MongoDbAdapter<
 
     if (params.paginate === false) {
       const data = await result.then((result) => result.toArray())
-      return page({
-        total: data.length,
-        data: data as Result[]
-      })
+      return data as Result[]
+      /* TODO: Wait...how does the below code work? Is there somewhere else that is handling params.paginate only returning an array? Comment the return statement above and uncomment this block...shouldn't that throw an error? */
+      // return page({
+      //   total: data.length,
+      //   data: data as Result[]
+      // })
     }
 
     const [data, total] = await Promise.all([
@@ -348,7 +351,6 @@ export class MongoDbAdapter<
     const setId = (item: any) => {
       const entry = Object.assign({}, item)
 
-      // Generate a MongoId if we use a custom id
       if (this.id !== '_id' && typeof entry[this.id] === 'undefined') {
         return {
           [this.id]: new ObjectId().toHexString(),
@@ -573,10 +575,3 @@ export class MongoDbAdapter<
       .catch(errorHandler)
   }
 }
-
-// function hasAggregation(params: AdapterParams) {
-//   if (!params.query || Object.keys(params.query).length === 0) {
-//     return false
-//   }
-//   return true
-// }

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -219,6 +219,28 @@ export class MongoDbAdapter<
       ...projection
     }
 
+    if (params.pipeline) {
+      const aggregateParams = {
+        ...params,
+        query: {
+          ...params.query,
+          $and: (params.query.$and || []).concat({
+            [this.id]: this.getObjectId(id)
+          })
+        }
+      }
+      return this.aggregateRaw(aggregateParams)
+        .then((result) => result.toArray())
+        .then(([data]) => {
+          if (data === undefined) {
+            throw new NotFound(`No record found for id '${id}'`)
+          }
+
+          return data
+        })
+        .catch(errorHandler)
+    }
+
     return this.getModel(params)
       .then((model) => model.findOne(query, findOptions))
       .then((data) => {

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -453,21 +453,21 @@ export class MongoDbAdapter<
     const model = await this.getModel(params)
     const {
       query,
-      filters: { $select }
+      filters: { $select, $sort }
     } = this.filterQuery(id, params)
-    const deleteOptions = { ...params.mongodb }
     const findParams = {
       ...params,
       paginate: false,
       query: {
         ...query,
-        $select
+        $select,
+        $sort
       }
     }
 
     return this._findOrGet(id, findParams)
       .then(async (items) => {
-        await model.deleteMany(query, deleteOptions)
+        await model.deleteMany(query, params.mongodb)
         return items
       })
       .catch(errorHandler)

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -224,6 +224,8 @@ export class MongoDbAdapter<
         ...params,
         query: {
           ...params.query,
+          // TODO: Do we need this $and like its needed in find?
+          // Or should it just be `[this.id]: this.getObjectId(id)`
           $and: (params.query.$and || []).concat({
             [this.id]: this.getObjectId(id)
           })

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -219,7 +219,7 @@ export class MongoDbAdapter<
       ...projection
     }
 
-    if (params.pipeline) {
+    if (!params.mongodb && params.pipeline) {
       const aggregateParams = {
         ...params,
         query: {

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -159,7 +159,10 @@ export class MongoDbAdapter<
     return pipeline
   }
 
-  getProjection(select: string[] | { [key: string]: number }) {
+  getProjection(select?: string[] | { [key: string]: number }) {
+    if (!select) {
+      return undefined
+    }
     if (Array.isArray(select)) {
       if (!select.includes(this.id)) {
         select = [this.id, ...select]
@@ -208,10 +211,9 @@ export class MongoDbAdapter<
       query,
       filters: { $select }
     } = this.filterQuery(id, params)
-    const projection = $select ? this.getProjection($select) : {}
     const findOptions: FindOptions = {
       ...params.mongodb,
-      projection
+      projection: this.getProjection($select)
     }
 
     if (params.pipeline) {
@@ -307,10 +309,9 @@ export class MongoDbAdapter<
 
       return entry
     }
-    const projection = params.query?.$select ? this.getProjection(params.query.$select) : {}
     const findOptions: FindOptions = {
       ...params.mongodb,
-      projection
+      projection: this.getProjection(params.query?.$select)
     }
 
     const promise = Array.isArray(data)
@@ -385,12 +386,10 @@ export class MongoDbAdapter<
       return this._findOrGet(id, findParams).catch(errorHandler)
     }
 
-    const projection = $select ? this.getProjection($select) : {}
-
     const result = await model.findOneAndUpdate(query, replacement, {
       ...(params.mongodb as FindOneAndUpdateOptions),
       returnDocument: 'after',
-      projection
+      projection: this.getProjection($select)
     })
 
     if (result.value === null) {
@@ -411,12 +410,10 @@ export class MongoDbAdapter<
     } = this.filterQuery(id, params)
     const model = await this.getModel(params)
 
-    const projection = $select ? this.getProjection($select) : {}
-
     const result = await model.findOneAndReplace(query, this.normalizeId(id, data), {
       ...(params.mongodb as FindOneAndReplaceOptions),
       returnDocument: 'after',
-      projection
+      projection: this.getProjection($select)
     })
 
     if (result.value === null) {

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -465,10 +465,20 @@ export class MongoDbAdapter<
       }
     }
 
-    return this._findOrGet(id, findParams)
-      .then(async (items) => {
-        await model.deleteMany(query, params.mongodb)
-        return items
+    if (id === null) {
+      return this._find(findParams)
+        .then(async (result) => {
+          const idList = (result as Result[]).map((item: any) => item[this.id])
+          await model.deleteMany({ [this.id]: { $in: idList } }, params.mongodb)
+          return result
+        })
+        .catch(errorHandler)
+    }
+
+    return this._get(id, findParams)
+      .then(async (result) => {
+        await model.deleteOne({ [this.id]: id }, params.mongodb)
+        return result
       })
       .catch(errorHandler)
   }

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -424,6 +424,8 @@ export class MongoDbAdapter<
         }
       }
 
+      console.log(findParams, params)
+
       return this._find(findParams)
         .then(async (result) => {
           const idList = (result as Result[]).map((item: any) => item[this.id])

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -424,8 +424,6 @@ export class MongoDbAdapter<
         }
       }
 
-      console.log(findParams, params)
-
       return this._find(findParams)
         .then(async (result) => {
           const idList = (result as Result[]).map((item: any) => item[this.id])

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -255,6 +255,7 @@ export class MongoDbAdapter<
           })
         }
       }
+
       return this.aggregateRaw(aggregateParams)
         .then((result) => result.toArray())
         .then(([result]) => {

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -190,10 +190,6 @@ export class MongoDbAdapter<
     return select
   }
 
-  async _findOrGet(id: NullableAdapterId, params: ServiceParams) {
-    return id === null ? await this._find(params) : await this._get(id, params)
-  }
-
   normalizeId<D>(id: NullableAdapterId, data: D): D {
     if (this.id === '_id') {
       // Default Mongo IDs cannot be updated. The Mongo library handles

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -268,8 +268,8 @@ export class MongoDbAdapter<
     }
 
     const findOptions: FindOptions = {
-      ...params.mongodb,
-      projection: this.getProjection($select)
+      projection: this.getProjection($select),
+      ...params.mongodb
     }
 
     return this.getModel(params)
@@ -331,6 +331,10 @@ export class MongoDbAdapter<
     data: Data | Data[],
     params: ServiceParams = {} as ServiceParams
   ): Promise<Result | Result[]> {
+    if (Array.isArray(data) && !this.allowsMulti('create', params)) {
+      throw new MethodNotAllowed('Can not create multiple entries')
+    }
+
     const model = await this.getModel(params)
     const setId = (item: any) => {
       const entry = Object.assign({}, item)
@@ -344,22 +348,30 @@ export class MongoDbAdapter<
 
       return entry
     }
-    const findOptions: FindOptions = {
-      ...params.mongodb,
-      projection: this.getProjection(params.query?.$select)
+
+    if (Array.isArray(data)) {
+      const created = await model.insertMany(data.map(setId), params.mongodb).catch(errorHandler)
+      return this._find({
+        ...params,
+        paginate: false,
+        query: {
+          _id: { $in: Object.values(created.insertedIds) },
+          $select: params.query?.$select
+        }
+      })
     }
 
-    const promise = Array.isArray(data)
-      ? model
-          .insertMany(data.map(setId), params.mongodb)
-          .then((result) =>
-            model.find({ _id: { $in: Object.values(result.insertedIds) } }, findOptions).toArray()
-          )
-      : model
-          .insertOne(setId(data), params.mongodb)
-          .then((result) => model.findOne({ _id: result.insertedId }, findOptions))
-
-    return promise.catch(errorHandler)
+    const created = await model.insertOne(setId(data), params.mongodb).catch(errorHandler)
+    const result = await this._find({
+      ...params,
+      paginate: false,
+      query: {
+        _id: created.insertedId,
+        $select: params.query?.$select,
+        $limit: 1
+      }
+    })
+    return result[0]
   }
 
   async _patch(id: null, data: PatchData, params?: ServiceParams): Promise<Result[]>
@@ -381,20 +393,25 @@ export class MongoDbAdapter<
       filters: { $sort, $select }
     } = this.filterQuery(id, params)
 
-    const replacement = Object.keys(data).reduce((current, key) => {
-      const value = (data as any)[key]
+    const replacement = Object.keys(data).reduce(
+      (current, key) => {
+        const value = (data as any)[key]
 
-      if (key.charAt(0) !== '$') {
-        current.$set = {
-          ...current.$set,
-          [key]: value
+        if (key.charAt(0) !== '$') {
+          current.$set[key] = value
+        } else if (key === '$set') {
+          current.$set = {
+            ...current.$set,
+            ...value
+          }
+        } else {
+          current[key] = value
         }
-      } else {
-        current[key] = value
-      }
 
-      return current
-    }, {} as any)
+        return current
+      },
+      { $set: {} } as any
+    )
 
     if (id === null) {
       const findParams = {
@@ -444,9 +461,9 @@ export class MongoDbAdapter<
     }
 
     const updateOptions: FindOneAndUpdateOptions = {
+      projection: this.getProjection($select),
       ...(params.mongodb as FindOneAndUpdateOptions),
-      returnDocument: 'after',
-      projection: this.getProjection($select)
+      returnDocument: 'after'
     }
 
     return model
@@ -493,9 +510,9 @@ export class MongoDbAdapter<
     }
 
     const replaceOptions: FindOneAndReplaceOptions = {
+      projection: this.getProjection($select),
       ...(params.mongodb as FindOneAndReplaceOptions),
-      returnDocument: 'after',
-      projection: this.getProjection($select)
+      returnDocument: 'after'
     }
 
     return model

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -255,7 +255,7 @@ export class MongoDbAdapter<
       return this.aggregateRaw(aggregateParams)
         .then((result) => result.toArray())
         .then(([result]) => {
-          if (result === undefined) {
+          if (!result) {
             throw new NotFound(`No record found for id '${id}'`)
           }
 
@@ -272,7 +272,7 @@ export class MongoDbAdapter<
     return this.getModel(params)
       .then((model) => model.findOne(query, findOptions))
       .then((result) => {
-        if (result == null) {
+        if (!result) {
           throw new NotFound(`No record found for id '${id}'`)
         }
 
@@ -466,10 +466,10 @@ export class MongoDbAdapter<
     return model
       .findOneAndUpdate(query, replacement, updateOptions)
       .then((result) => {
-        if (result.value === null) {
+        if (!result) {
           throw new NotFound(`No record found for id '${id}'`)
         }
-        return result.value as Result
+        return result as Result
       })
       .catch(errorHandler)
   }
@@ -515,10 +515,10 @@ export class MongoDbAdapter<
     return model
       .findOneAndReplace(query, replacement, replaceOptions)
       .then((result) => {
-        if (result.value === null) {
+        if (!result) {
           throw new NotFound(`No record found for id '${id}'`)
         }
-        return result.value as Result
+        return result as Result
       })
       .catch(errorHandler)
   }
@@ -568,10 +568,10 @@ export class MongoDbAdapter<
     return model
       .findOneAndDelete(query, deleteOptions)
       .then((result) => {
-        if (result.value === null) {
+        if (!result) {
           throw new NotFound(`No record found for id '${id}'`)
         }
-        return result.value as Result
+        return result as Result
       })
       .catch(errorHandler)
   }

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -83,6 +83,11 @@ const testSuite = adapterTests([
   'params.adapter + multi'
 ])
 
+const defaultPaginate = {
+  default: 10,
+  max: 50
+}
+
 describe('Feathers MongoDB Service', () => {
   const personSchema = {
     $id: 'Person',
@@ -473,6 +478,19 @@ describe('Feathers MongoDB Service', () => {
       })
       assert.deepEqual(result[0].person, bob)
       assert.equal(result.length, 1)
+    })
+
+    it('can count documents with aggregation', async () => {
+      const service = app.service('people')
+      const paginateBefore = service.options.paginate
+      service.options.paginate = defaultPaginate
+      const query = { age: { $gte: 25 } }
+      const findResult = await app.service('people').find({ query })
+      const aggregationResult = await app.service('people').find({ query, pipeline: [] })
+
+      assert.deepStrictEqual(findResult, aggregationResult)
+
+      service.options.paginate = paginateBefore
     })
 
     it('can use aggregation in _get', async () => {

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -507,6 +507,23 @@ describe('Feathers MongoDB Service', () => {
     })
   })
 
+  // TODO: Should this test be part of the adapterTests?
+  describe('Updates mutated query', () => {
+    it('Can re-query mutated data', async () => {
+      const dave = await app.service('people').create({ name: 'Dave' })
+      const result = await app
+        .service('people')
+        .update(dave._id, { name: 'Marshal' }, { query: { name: 'Dave' } })
+
+      assert.deepStrictEqual(result, {
+        ...dave,
+        name: 'Marshal'
+      })
+
+      app.service('people').remove(dave._id)
+    })
+  })
+
   testSuite(app, errors, 'people', '_id')
   testSuite(app, errors, 'people-customid', 'customid')
 })

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -488,7 +488,7 @@ describe('Feathers MongoDB Service', () => {
       const findResult = await app.service('people').find({ query })
       const aggregationResult = await app.service('people').find({ query, pipeline: [] })
 
-      assert.deepStrictEqual(findResult, aggregationResult)
+      assert.deepStrictEqual(findResult.total, aggregationResult.total)
 
       service.options.paginate = paginateBefore
     })
@@ -521,9 +521,44 @@ describe('Feathers MongoDB Service', () => {
       app.service('people').remove(dave._id)
     })
 
+    it('can use aggregation in _patch', async () => {
+      const dave = await app.service('people').create({ name: 'Dave' })
+      const result = await app.service('people').patch(
+        dave._id,
+        {
+          name: 'Marshal'
+        },
+        {
+          pipeline: [{ $addFields: { aggregation: true } }]
+        }
+      )
+
+      assert.deepStrictEqual(result, { ...dave, name: 'Marshal', aggregation: true })
+
+      app.service('people').remove(dave._id)
+    })
+
     it('can use aggregation and query in _update', async () => {
       const dave = await app.service('people').create({ name: 'Dave' })
       const result = await app.service('people').update(
+        dave._id,
+        {
+          name: 'Marshal'
+        },
+        {
+          query: { name: 'Dave' },
+          pipeline: [{ $addFields: { aggregation: true } }]
+        }
+      )
+
+      assert.deepStrictEqual(result, { ...dave, name: 'Marshal', aggregation: true })
+
+      app.service('people').remove(dave._id)
+    })
+
+    it('can use aggregation and query in _patch', async () => {
+      const dave = await app.service('people').create({ name: 'Dave' })
+      const result = await app.service('people').patch(
         dave._id,
         {
           name: 'Marshal'

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -474,6 +474,21 @@ describe('Feathers MongoDB Service', () => {
       assert.deepEqual(result[0].person, bob)
       assert.equal(result.length, 1)
     })
+
+    it('can use aggregation in _get', async () => {
+      const dave = await app.service('people').create({ name: 'Dave', age: 25 })
+      const result1 = await app.service('people').get(dave._id, {
+        query: { $select: ['name'] }
+      })
+      const result2 = await app.service('people').get(dave._id, {
+        query: { $select: ['name'] },
+        pipeline: []
+      })
+
+      assert.deepStrictEqual(result1, result2)
+
+      app.service('people').remove(dave._id)
+    })
   })
 
   describe('query validation', () => {

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -389,6 +389,28 @@ describe('Feathers MongoDB Service', () => {
       assert.strictEqual(patched[0].friends?.length, 2)
     })
 
+    it('can use $limit in patch', async () => {
+      const data = { name: 'ddd' }
+      const query = { $limit: 1 }
+
+      // TODO: Why is $limit not working?
+
+      const result = await peopleService.patch(null, data, {
+        query
+      })
+
+      assert.strictEqual(result.length, 1)
+      assert.strictEqual(result[0].name, 'ddd')
+
+      const pipelineResult = await peopleService.patch(null, data, {
+        pipeline: [],
+        query
+      })
+
+      assert.strictEqual(pipelineResult.length, 1)
+      assert.strictEqual(pipelineResult[0].name, 'ddd')
+    })
+
     it('overrides default index selection using hint param if present', async () => {
       const indexed = await peopleService.create({
         name: 'Indexed',

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -504,6 +504,31 @@ describe('Feathers MongoDB Service', () => {
       app.service('people').remove(dave._id)
     })
 
+    it('can use aggregation in _create', async () => {
+      const dave = (await app.service('people').create(
+        { name: 'Dave' },
+        {
+          pipeline: [{ $addFields: { aggregation: true } }]
+        }
+      )) as any
+
+      assert.deepStrictEqual(dave.aggregation, true)
+
+      app.service('people').remove(dave._id)
+    })
+
+    it('can use aggregation in multi _create', async () => {
+      app.service('people').options.multi = true
+      const dave = (await app.service('people').create([{ name: 'Dave' }], {
+        pipeline: [{ $addFields: { aggregation: true } }]
+      })) as any
+
+      assert.deepStrictEqual(dave[0].aggregation, true)
+
+      app.service('people').options.multi = false
+      app.service('people').remove(dave[0]._id)
+    })
+
     it('can use aggregation in _update', async () => {
       const dave = await app.service('people').create({ name: 'Dave' })
       const result = await app.service('people').update(
@@ -535,6 +560,26 @@ describe('Feathers MongoDB Service', () => {
 
       assert.deepStrictEqual(result, { ...dave, name: 'Marshal', aggregation: true })
 
+      app.service('people').remove(dave._id)
+    })
+
+    it('can use aggregation in multi _patch', async () => {
+      app.service('people').options.multi = true
+      const dave = await app.service('people').create({ name: 'Dave' })
+      const result = await app.service('people').patch(
+        null,
+        {
+          name: 'Marshal'
+        },
+        {
+          query: { _id: dave._id },
+          pipeline: [{ $addFields: { aggregation: true } }]
+        }
+      )
+
+      assert.deepStrictEqual(result[0], { ...dave, name: 'Marshal', aggregation: true })
+
+      app.service('people').options.multi = false
       app.service('people').remove(dave._id)
     })
 
@@ -588,6 +633,20 @@ describe('Feathers MongoDB Service', () => {
       } catch (error: any) {
         assert.strictEqual(error.name, 'NotFound', 'Got a NotFound Feathers error')
       }
+    })
+
+    it('can use aggregation in multi _remove', async () => {
+      app.service('people').options.multi = true
+      const dave = await app.service('people').create({ name: 'Dave' })
+      const result = await app.service('people').remove(null, {
+        query: { _id: dave._id },
+        pipeline: [{ $addFields: { aggregation: true } }]
+      })
+
+      assert.deepStrictEqual(result[0], { ...dave, aggregation: true })
+
+      app.service('people').options.multi = false
+      // app.service('people').remove(dave._id)
     })
   })
 

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -760,16 +760,79 @@ describe('Feathers MongoDB Service', () => {
   describe('Updates mutated query', () => {
     it('Can re-query mutated data', async () => {
       const dave = await app.service('people').create({ name: 'Dave' })
-      const result = await app
+      const dave2 = await app.service('people').create({ name: 'Dave' })
+      app.service('people').options.multi = true
+
+      const updated = await app
         .service('people')
         .update(dave._id, { name: 'Marshal' }, { query: { name: 'Dave' } })
 
-      assert.deepStrictEqual(result, {
+      assert.deepStrictEqual(updated, {
         ...dave,
         name: 'Marshal'
       })
 
+      const patched = await app
+        .service('people')
+        .patch(dave._id, { name: 'Dave' }, { query: { name: 'Marshal' } })
+
+      assert.deepStrictEqual(patched, {
+        ...dave,
+        name: 'Dave'
+      })
+
+      const updatedPipeline = await app
+        .service('people')
+        .update(dave._id, { name: 'Marshal' }, { query: { name: 'Dave' }, pipeline: [] })
+
+      assert.deepStrictEqual(updatedPipeline, {
+        ...dave,
+        name: 'Marshal'
+      })
+
+      const patchedPipeline = await app
+        .service('people')
+        .patch(dave._id, { name: 'Dave' }, { query: { name: 'Marshal' }, pipeline: [] })
+
+      assert.deepStrictEqual(patchedPipeline, {
+        ...dave,
+        name: 'Dave'
+      })
+
+      const multiPatch = await app
+        .service('people')
+        .patch(null, { name: 'Marshal' }, { query: { name: 'Dave' } })
+
+      assert.deepStrictEqual(multiPatch, [
+        {
+          ...dave,
+          name: 'Marshal'
+        },
+        {
+          ...dave2,
+          name: 'Marshal'
+        }
+      ])
+
+      const multiPatchPipeline = await app
+        .service('people')
+        .patch(null, { name: 'Dave' }, { query: { name: 'Marshal' }, pipeline: [] })
+
+      assert.deepStrictEqual(multiPatchPipeline, [
+        {
+          ...dave,
+          name: 'Dave'
+        },
+        {
+          ...dave2,
+          name: 'Dave'
+        }
+      ])
+
+      app.service('people').options.multi = false
+
       app.service('people').remove(dave._id)
+      app.service('people').remove(dave2._id)
     })
   })
 

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -393,22 +393,90 @@ describe('Feathers MongoDB Service', () => {
       const data = { name: 'ddd' }
       const query = { $limit: 1 }
 
-      // TODO: Why is $limit not working?
-
-      const result = await peopleService.patch(null, data, {
+      const result = await peopleService._patch(null, data, {
         query
       })
 
       assert.strictEqual(result.length, 1)
       assert.strictEqual(result[0].name, 'ddd')
 
-      const pipelineResult = await peopleService.patch(null, data, {
+      const pipelineResult = await peopleService._patch(null, data, {
         pipeline: [],
         query
       })
 
       assert.strictEqual(pipelineResult.length, 1)
       assert.strictEqual(pipelineResult[0].name, 'ddd')
+    })
+
+    it('can use $limit in remove', async () => {
+      const query = { $limit: 1 }
+
+      const result = await peopleService._remove(null, {
+        query
+      })
+
+      assert.strictEqual(result.length, 1)
+
+      const pipelineResult = await peopleService._remove(null, {
+        pipeline: [],
+        query
+      })
+
+      assert.strictEqual(pipelineResult.length, 1)
+    })
+
+    it('can use $sort in patch', async () => {
+      const updated = await peopleService._patch(
+        null,
+        { name: 'ddd' },
+        {
+          query: { $limit: 1, $sort: { name: -1 } }
+        }
+      )
+
+      const result = await peopleService.find({
+        paginate: false,
+        query: { $limit: 1, $sort: { name: -1 } }
+      })
+
+      assert.strictEqual(updated.length, 1)
+      assert.strictEqual(result[0].name, 'ddd')
+
+      const pipelineUpdated = await peopleService._patch(
+        null,
+        { name: 'eee' },
+        {
+          pipeline: [],
+          query: { $limit: 1, $sort: { name: -1 } }
+        }
+      )
+
+      const pipelineResult = await peopleService.find({
+        paginate: false,
+        pipeline: [],
+        query: { $limit: 1, $sort: { name: -1 } }
+      })
+
+      assert.strictEqual(pipelineUpdated.length, 1)
+      assert.strictEqual(pipelineResult[0].name, 'eee')
+    })
+
+    it('can use $sort in remove', async () => {
+      const removed = await peopleService._remove(null, {
+        query: { $limit: 1, $sort: { name: -1 } }
+      })
+
+      assert.strictEqual(removed.length, 1)
+      assert.strictEqual(removed[0].name, 'ccc')
+
+      const pipelineRemoved = await peopleService._remove(null, {
+        pipeline: [],
+        query: { $limit: 1, $sort: { name: -1 } }
+      })
+
+      assert.strictEqual(pipelineRemoved.length, 1)
+      assert.strictEqual(pipelineRemoved[0].name, 'aaa')
     })
 
     it('overrides default index selection using hint param if present', async () => {


### PR DESCRIPTION
This PR's aim is to improve/extend the usage of the aggregation framework to be used on all methods. But, it also solves a number of bugs and improves general performance.

**Get Method**
This method can now use the aggregation pipeline.

**Find Method**
We have accomplished better performance when not using the pipeline. This is mainly accomplished with how `filters.$limit === 0` now only counts the docs and doesn't do the actual `model.find` because it's not needed.

**Create Method**
This method can now use the aggregation pipeline.

**Update Method**
This method can now use the aggregation pipeline. It also solves https://github.com/feathersjs/feathers/issues/3365 and https://github.com/feathersjs/feathers/issues/3363. This is accomplished by using `findOneAndReplace` instead of `replaceOne`. Because `findOneAndReplace` actually returns the updated document, there is no need for the two other lookups.

**Patch Method**
This method can now use the aggregation pipeline. It should also get a performance boost with the usage of `findOneAndUpdate` when possible. It now supports `$sort`, `$limit`, and `$skip` for multi. I am not sure why these operators were not supported before, but it seems like a valuable query to have access to.

**Remove Method**
This method can now use the aggregation pipeline. It should also get a performance boost with the usage of `findOneAndDelete` when possible. It now supports `$sort`, `$limit`, and `$skip` for multi. I am not sure why these operators were not supported before, but it seems like a valuable query to have access to.


