### PR TITLE
fix(knex): Adds Error Handler to knex _update and _patch function

### DIFF
--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -322,7 +322,7 @@ export class KnexAdapter<
       return result
     }, {})
 
-    await this.db(params).update(newObject, '*', { includeTriggerModifications: true }).where(this.id, id)
+    await this.db(params).update(newObject, '*', { includeTriggerModifications: true }).where(this.id, id).catch(errorHandler)
 
     return this._get(id, params)
   }


### PR DESCRIPTION
### Summary

Currently Knex errors for _patch and _update bubble up without formatting and thus might reveal a lot of information about the underlying DB that is inappropriate for the end user.  This makes error handling more uniform across the library.

From code commits, I could not see a reason why error catching was not added.

