### PR TITLE
docs: Update anonymous hook to support around hooks

### DIFF
--- a/docs/cookbook/authentication/anonymous.md
+++ b/docs/cookbook/authentication/anonymous.md
@@ -68,16 +68,20 @@ Next, we create a hook called `allow-anonymous` that sets `params.authentication
 import { Hook, HookContext } from '@feathersjs/feathers';
 
 export default (): Hook => {
-  return async (context: HookContext) => {
+  return async (context: HookContext, next?: NextFunction) => {
     const { params } = context;
 
-    if(params.provider && !params.authentication) {
+    if (params.provider && !params.authentication) {
       context.params = {
         ...params,
         authentication: {
           strategy: 'anonymous'
         }
       }
+    }
+
+    if (next) {
+      await next();
     }
 
     return context;


### PR DESCRIPTION
The current anonymous hook in the documentation doesn't work with around hooks since it doesn't have the `next` param
https://feathersjs.com/cookbook/authentication/anonymous.html
```
return async (context: HookContext) => {
```

This PR adds a optional `next` param so it can be used in both before & around hooks, making it consistent with the authenticate hook
https://feathersjs.com/api/authentication/hook
```
It can be used as a before or around hook.
```