### PR TITLE
fix(schema): Fix setting dispatch on existing nested objects

### DIFF
--- a/packages/schema/src/hooks/resolve.ts
+++ b/packages/schema/src/hooks/resolve.ts
@@ -157,6 +157,12 @@ export const resolveExternal =
       const status = context.params.resolve
       const { isPaginated, data } = getResult(context)
       const resolveAndGetDispatch = async (current: any) => {
+        const currentExistingDispatch = getDispatch(current)
+
+        if (currentExistingDispatch !== null) {
+          return currentExistingDispatch
+        }
+
         const resolved = await runResolvers(resolvers, current, context, status)
         const currentDispatch = Object.keys(resolved).reduce(
           (res, key) => {

--- a/packages/schema/test/hooks.test.ts
+++ b/packages/schema/test/hooks.test.ts
@@ -187,6 +187,13 @@ describe('@feathersjs/schema/hooks', () => {
     })
   })
 
+  it('resolves safe dispatch with static data', async () => {
+    const service = app.service('custom')
+
+    await service.find()
+    assert.deepStrictEqual(await service.find(), [{ message: 'Hello' }])
+  })
+
   it('resolves data for custom methods', async () => {
     const result = await app.service('messages').customMethod({ message: 'Hello' })
     const user = {


### PR DESCRIPTION
If you have a custom service that uses `resolveExternal` and returns internal objects we should not get a symbol redefinition error.