### PR TITLE
docs(schema): update typebox extended config

### DIFF
--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -1463,49 +1463,49 @@ In addition to JSON schema types, TypeBox provides several extended types that a
 Utilities in this section require updating `src/schemas/validators.ts` to the Extended Ajv Configuration, as shown here: 
 
 ```ts
-import { TypeGuard } from '@sinclair/typebox/guard'
-import { Value }     from '@sinclair/typebox/value'
-import { Type }      from '@sinclair/typebox'
-import addFormats    from 'ajv-formats'
-import Ajv           from 'ajv'
+import { TypeGuard } from '@sinclair/typebox'
+import { Value } from '@sinclair/typebox/value'
+import addFormats from 'ajv-formats'
+import type { Options } from 'ajv'
+import Ajv from 'ajv'
 
 function schemaOf(schemaOf: string, value: unknown, schema: unknown) {
   switch (schemaOf) {
     case 'Constructor':
-      return TypeGuard.TConstructor(schema) && Value.Check(schema, value) // not supported
+      return TypeGuard.IsConstructor(schema) && Value.Check(schema, value) // not supported
     case 'Function':
-      return TypeGuard.TFunction(schema) && Value.Check(schema, value) // not supported
+      return TypeGuard.IsFunction(schema) && Value.Check(schema, value) // not supported
     case 'Date':
-      return TypeGuard.TDate(schema) && Value.Check(schema, value)
+      return TypeGuard.IsDate(schema) && Value.Check(schema, value)
     case 'Promise':
-      return TypeGuard.TPromise(schema) && Value.Check(schema, value) // not supported
+      return TypeGuard.IsPromise(schema) && Value.Check(schema, value) // not supported
     case 'Uint8Array':
-      return TypeGuard.TUint8Array(schema) && Value.Check(schema, value)
+      return TypeGuard.IsUint8Array(schema) && Value.Check(schema, value)
     case 'Undefined':
-      return TypeGuard.TUndefined(schema) && Value.Check(schema, value) // not supported
+      return TypeGuard.IsUndefined(schema) && Value.Check(schema, value) // not supported
     case 'Void':
-      return TypeGuard.TVoid(schema) && Value.Check(schema, value)
+      return TypeGuard.IsVoid(schema) && Value.Check(schema, value)
     default:
       return false
   }
 }
 
-export function createAjv() {
-  return addFormats(new Ajv({}), [
-    'date-time', 
-    'time', 
-    'date', 
-    'email',  
-    'hostname', 
-    'ipv4', 
-    'ipv6', 
-    'uri', 
-    'uri-reference', 
+export function createAjv(options: Options = {}) {
+  return addFormats(new Ajv(options), [
+    'date-time',
+    'time',
+    'date',
+    'email',
+    'hostname',
+    'ipv4',
+    'ipv6',
+    'uri',
+    'uri-reference',
     'uuid',
-    'uri-template', 
-    'json-pointer', 
-    'relative-json-pointer', 
-    'regex'
+    'uri-template',
+    'json-pointer',
+    'relative-json-pointer',
+    'regex',
   ])
   .addKeyword({ type: 'object', keyword: 'instanceOf', validate: schemaOf })
   .addKeyword({ type: 'null', keyword: 'typeOf', validate: schemaOf })
@@ -1517,17 +1517,8 @@ export function createAjv() {
   .addKeyword('maxByteLength')
 }
 
-const ajv = createAjv()
-
-const R = ajv.validate(Type.Object({                 // const R = true
-  buffer: Type.Uint8Array(),
-  date: Type.Date(),
-  void: Type.Void()
-}), {
-  buffer: new Uint8Array(),
-  date: new Date(),
-  void: null
-})
+export const dataValidator: Ajv = createAjv({})
+export const queryValidator: Ajv = createAjv({ coerceTypes: true })
 ```
 
 If you see an error stating `Error: strict mode: unknown keyword: "instanceOf"`, it's likely because you need to extend your configuration, as shown above.


### PR DESCRIPTION
Docs for `@sinclair/typebox@>0.32.0`

Resolves #3381

Added exports that get generated in the original `src/validators.ts` (`dataValidator` & `queryValidator`) for easier copy-pasta. 

Removed some unused demo code at the end, which seems redundant or may be better suited for a separate box beneath the [closing paragraph](https://github.com/feathersjs/feathers/blob/43e752653271566e8a397a8b82cd6e45fcbc6768/docs/api/schema/typebox.md#L1533) of the section.