### PR TITLE
docs(authentication): Fix broken link to property resolvers

### DIFF
--- a/docs/api/authentication/local.md
+++ b/docs/api/authentication/local.md
@@ -158,7 +158,7 @@ app.service('users').hooks({
 
 ### passwordHash
 
-The `passwordHash` utility provides a [property resolver function](../schema//resolvers.md#property-resolvers) that uses a local strategy to securely [hash the password](#hashpassword-password) before storing it in the database. The following options are available:
+The `passwordHash` utility provides a [property resolver function](../schema/resolvers.md#property-resolvers) that uses a local strategy to securely [hash the password](#hashpassword-password) before storing it in the database. The following options are available:
 
 - `strategy` - The name of the local strategy (usually `'local'`)
 - `service` - The path of the authentication service (will use `app.get('defaultAuthentication')` by default)


### PR DESCRIPTION
Due to a doubled slash character, the link leads to a 404 page.