### PR TITLE
fix(generators): Use cross-platform ES module __dirname

### DIFF
--- a/packages/generators/src/app/index.ts
+++ b/packages/generators/src/app/index.ts
@@ -1,6 +1,7 @@
 import { sep, dirname } from 'path'
 import chalk from 'chalk'
 import { prompt, runGenerators, fromFile, copyFiles, toFile } from '@featherscloud/pinion'
+import { fileURLToPath } from 'url'
 import {
   FeathersBaseContext,
   FeathersAppInfo,
@@ -11,7 +12,7 @@ import {
 import { generate as connectionGenerator, prompts as connectionPrompts } from '../connection/index.js'
 
 // Set __dirname in es module
-const __dirname = dirname(new URL(import.meta.url).pathname)
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export interface AppGeneratorData extends FeathersAppInfo {
   /**

--- a/packages/generators/src/authentication/index.ts
+++ b/packages/generators/src/authentication/index.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import { dirname } from 'path'
 import { runGenerators, prompt } from '@featherscloud/pinion'
+import { fileURLToPath } from 'url'
 import {
   addVersions,
   checkPreconditions,
@@ -11,7 +12,7 @@ import {
 import { generate as serviceGenerator, ServiceGeneratorContext } from '../service/index.js'
 
 // Set __dirname in es module
-const __dirname = dirname(new URL(import.meta.url).pathname)
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export interface AuthenticationGeneratorContext extends ServiceGeneratorContext {
   service: string

--- a/packages/generators/src/commons.ts
+++ b/packages/generators/src/commons.ts
@@ -16,9 +16,10 @@ import {
 import ts from 'typescript'
 import prettier, { Options as PrettierOptions } from 'prettier'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 // Set __dirname in es module
-const __dirname = dirname(new URL(import.meta.url).pathname)
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export const { version } = JSON.parse(fs.readFileSync(join(__dirname, '..', 'package.json')).toString())
 

--- a/packages/generators/src/connection/index.ts
+++ b/packages/generators/src/connection/index.ts
@@ -1,5 +1,6 @@
 import { dirname } from 'path'
 import { runGenerator, prompt, mergeJSON, toFile, when } from '@featherscloud/pinion'
+import { fileURLToPath } from 'url'
 import chalk from 'chalk'
 import {
   install,
@@ -12,7 +13,7 @@ import {
 } from '../commons.js'
 
 // Set __dirname in es module
-const __dirname = dirname(new URL(import.meta.url).pathname)
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export interface ConnectionGeneratorContext extends FeathersBaseContext {
   name?: string

--- a/packages/generators/src/hook/index.ts
+++ b/packages/generators/src/hook/index.ts
@@ -1,10 +1,11 @@
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
 import { prompt, runGenerators } from '@featherscloud/pinion'
 import _ from 'lodash'
 import { checkPreconditions, FeathersBaseContext, initializeBaseContext } from '../commons.js'
 
 // Set __dirname in es module
-const __dirname = dirname(new URL(import.meta.url).pathname)
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export interface HookGeneratorContext extends FeathersBaseContext {
   name: string

--- a/packages/generators/src/service/index.ts
+++ b/packages/generators/src/service/index.ts
@@ -1,10 +1,8 @@
 import { dirname } from 'path'
 import _ from 'lodash'
 import { runGenerator, runGenerators, prompt } from '@featherscloud/pinion'
+import { fileURLToPath } from 'url'
 import chalk from 'chalk'
-
-// Set __dirname in es module
-const __dirname = dirname(new URL(import.meta.url).pathname)
 
 import {
   checkPreconditions,
@@ -14,6 +12,9 @@ import {
   getDatabaseAdapter,
   initializeBaseContext
 } from '../commons.js'
+
+// Set __dirname in es module
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export interface ServiceGeneratorContext extends FeathersBaseContext {
   /**


### PR DESCRIPTION
More ES module shenanigans because they actually don't work well 😞 