### PR TITLE
fix: paginate type for _find

### DIFF
--- a/packages/adapter-commons/src/declarations.ts
+++ b/packages/adapter-commons/src/declarations.ts
@@ -93,9 +93,11 @@ export interface InternalServiceMethods<
    *
    * @param _params - Service call parameters {@link Params}
    */
-  _find(_params?: Params & { paginate?: PaginationOptions }): Promise<Paginated<Result>>
-  _find(_params?: Params & { paginate: false }): Promise<Result[]>
-  _find(params?: Params): Promise<Result[] | Paginated<Result>>
+  _find(_params?: Params & { paginate: PaginationOptions }): Promise<Paginated<Result>>
+  _find(_params?: Params & { paginate?: false }): Promise<Result[]>
+  _find(
+    params?: (Params & { paginate: PaginationOptions }) | (Params & { paginate?: false })
+  ): Promise<Result[] | Paginated<Result>>
 
   /**
    * Retrieve a single resource matching the given ID, skipping any service-level hooks.

--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -119,9 +119,11 @@ export abstract class AdapterBase<
    *
    * @param _params - Service call parameters {@link ServiceParams}
    */
-  abstract _find(_params?: ServiceParams & { paginate?: PaginationOptions }): Promise<Paginated<Result>>
-  abstract _find(_params?: ServiceParams & { paginate: false }): Promise<Result[]>
-  abstract _find(params?: ServiceParams): Promise<Result[] | Paginated<Result>>
+  abstract _find(_params?: ServiceParams & { paginate: PaginationOptions }): Promise<Paginated<Result>>
+  abstract _find(_params?: ServiceParams & { paginate?: false }): Promise<Result[]>
+  abstract _find(
+    params?: (ServiceParams & { paginate: PaginationOptions }) | (ServiceParams & { paginate?: false })
+  ): Promise<Result[] | Paginated<Result>>
 
   /**
    * Retrieve a single resource matching the given ID, skipping any service-level hooks.

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -340,7 +340,7 @@ export interface PaginationOptions {
   max?: number
 }
 
-export type PaginationParams = false | PaginationOptions
+export type PaginationParams = PaginationOptions
 
 export interface Http {
   /**

--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -161,10 +161,11 @@ export class KnexAdapter<
     }
   }
 
-  async _find(params?: ServiceParams & { paginate?: PaginationOptions }): Promise<Paginated<Result>>
-  async _find(params?: ServiceParams & { paginate: false }): Promise<Result[]>
-  async _find(params?: ServiceParams): Promise<Paginated<Result> | Result[]>
-  async _find(params: ServiceParams = {} as ServiceParams): Promise<Paginated<Result> | Result[]> {
+  async _find(params?: ServiceParams & { paginate: PaginationOptions }): Promise<Paginated<Result>>
+  async _find(params?: ServiceParams & { paginate?: false }): Promise<Result[]>
+  async _find(
+    params?: (ServiceParams & { paginate: PaginationOptions }) | (ServiceParams & { paginate?: false })
+  ): Promise<Paginated<Result> | Result[]> {
     const { filters, paginate } = this.filterQuery(params)
     const { name, id } = this.getOptions(params)
     const builder = params.knex ? params.knex.clone() : this.createQuery(params)


### PR DESCRIPTION
### Summary

`paginate` types have been an issue for Feathers for a while, this PR shows a possible fix. 



### Other Information

https://github.com/feathersjs/feathers/issues/3079