### PR TITLE
fix(knex): Fix Knex adapter date comparison queries

### DIFF
--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -86,7 +86,7 @@ export class KnexAdapter<
     return Object.keys(query || {}).reduce((currentQuery, key) => {
       const value = query[key]
 
-      if (_.isObject(value)) {
+      if (_.isObject(value) && !(value instanceof Date)) {
         return knexify(currentQuery, value, key)
       }
 


### PR DESCRIPTION
### Summary

- [ ] Currently the schema-driven development system claims that Type.Date is acceptable, but date comparison queries are silently ignored, e.g. `app.service('foo').find({ query: { closeTime: { $gt: new Date() } } })` just gets you all results.
- [ ] I have been unable to find a matching issue
- [ ] No dependencies on other PRs

### Other Information

The issue here is that a date is an object, so the code in knex/adapter tries to get the query operators as its keys and of course finds none so it just moves on. The fix here just lets a date be a date in comparisons, too.

**Problem** I of course want to include some unit tests for this. However, the typing in the tests somehow has been set up with `Omit` called on the enum for acceptable JSON Schema types - you can't make a json schema with a property that has `{ type: 'date' }` to feed into the the query syntax, so it's impossible to construct a proper test involving dates. I'll 'fess up and admit that I tried to figure this out for several hours on Monday but couldn't. 

If someone who knows the codebase better than I do can point me to where `{ type: 'date' }` is ruled out by the typing in there I'll get this finished. Apologies for not finding it myself but that's how it is and I'm hoping someone with more knowledge than me can help me with it. 

Thanks! And thanks also to @daffl and all contributors for making the best of all API frameworks in any language!
