### PR TITLE
fix(generators): Use module format for JS Knex migrations

### DIFF
--- a/packages/generators/src/connection/templates/knex.tpl.ts
+++ b/packages/generators/src/connection/templates/knex.tpl.ts
@@ -55,13 +55,13 @@ export const generate = (ctx: ConnectionGeneratorContext) =>
     .then(renderSource(knexfile, toFile('knexfile')))
     .then(
       mergeJSON<ConnectionGeneratorContext>(
-        {
+        (ctx) => ({
           scripts: {
             migrate: 'knex migrate:latest',
-            'migrate:make': 'knex migrate:make',
+            'migrate:make': 'knex migrate:make' + ctx.language === 'js' ? ' -x mjs' : '',
             test: 'cross-env NODE_ENV=test npm run migrate && npm run mocha'
           }
-        },
+        }),
         toFile('package.json')
       )
     )


### PR DESCRIPTION
Closes https://github.com/feathersjs/feathers/issues/3435