### PR TITLE
fix: update socket.io-client to 4.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20248,9 +20248,9 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.4.tgz",
-      "integrity": "sha512-wh+OkeF0rAVCrABWQBaEjLfb7DVPotMbu0cgWgyR0v6eA4EoVnAwcIeIbcdTE3GT/H3kbdLl7OoH2+asoDRIIg==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -25102,7 +25102,7 @@
         "@types/node": "^20.11.26",
         "mocha": "^10.3.0",
         "shx": "^0.3.4",
-        "socket.io-client": "^4.7.4",
+        "socket.io-client": "^4.7.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.2"
       },

--- a/packages/socketio-client/package.json
+++ b/packages/socketio-client/package.json
@@ -66,7 +66,7 @@
     "@types/node": "^20.11.26",
     "mocha": "^10.3.0",
     "shx": "^0.3.4",
-    "socket.io-client": "^4.7.4",
+    "socket.io-client": "^4.7.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.2"
   },


### PR DESCRIPTION
### Summary

Hi
This is simply to update the socket.io client dependency version to fix the issue related to disconnection and timeout behavior
related: https://github.com/socketio/socket.io/issues/4964

I am aware that this PR is probably not needed due to `^`, but here it goes anyway 