### PR TITLE
fix(generators): better types for enabled methods

### DIFF
--- a/packages/generators/src/service/templates/service.tpl.ts
+++ b/packages/generators/src/service/templates/service.tpl.ts
@@ -41,7 +41,7 @@ ${
     ? `import { ${camelName}Path, ${camelName}Methods } from './${fileName}.shared'`
     : `
 export const ${camelName}Path = '${path}'
-export const ${camelName}Methods = ['find', 'get', 'create', 'patch', 'remove'] as const`
+export const ${camelName}Methods: Array<keyof ${className}> = ['find', 'get', 'create', 'patch', 'remove']`
 }
 
 export * from './${fileName}.class'

--- a/packages/generators/src/service/templates/shared.tpl.ts
+++ b/packages/generators/src/service/templates/shared.tpl.ts
@@ -29,7 +29,7 @@ export type ${upperName}ClientService = Pick<
 
 export const ${camelName}Path = '${path}'
 
-export const ${camelName}Methods = ['find', 'get', 'create', 'patch', 'remove'] as const
+export const ${camelName}Methods: Array<keyof ${className}> = ['find', 'get', 'create', 'patch', 'remove']
 
 export const ${camelName}Client = (client: ClientApplication) => {
   const connection = client.get('connection')


### PR DESCRIPTION
### Summary

Provides better types for the `enabledMethods` array

Fix's an incompatibility when using `feathers-swagger` [security property](https://feathersjs-ecosystem.github.io/feathers-swagger/#/api?id=swaggerswaggeruioptions)