### PR TITLE
docs: Fix typo on node config link

### DIFF
--- a/docs/guides/cli/custom-environment-variables.md
+++ b/docs/guides/cli/custom-environment-variables.md
@@ -19,7 +19,7 @@ This sets `app.get('port')` using the `PORT` environment variable (if it is avai
 
 <BlockQuote type="tip">
 
-See the [node-config custom envrionment variable](https://github.com/node-config/node-config/wiki/Environment-Variables#custom-environment-variables) documentation for more information.
+See the [node-config custom environment variable](https://github.com/node-config/node-config/wiki/Environment-Variables#custom-environment-variables) documentation for more information.
 
 </BlockQuote>
 


### PR DESCRIPTION
See the node-config custom envrionment variable documentation for more information.

### Summary
Fix typo 
![image](https://github.com/feathersjs/feathers/assets/17402105/a2dd22d4-4077-467e-9e90-97c084c97c9d)
