### PR TITLE
docs(Typebox): Schema for allowed query properties

### DIFF
--- a/docs/api/schema/typebox.md
+++ b/docs/api/schema/typebox.md
@@ -97,7 +97,7 @@ const messageQuerySchema = querySyntax(messageQueryProperties)
 type MessageQuery = Static<typeof messageQuerySchema>
 ```
 
-Additional special query properties [that are not already included in the query syntax](../databases/querying.md) like `$ilike` can be added like this:
+Additional special query properties [that are not already included in the query syntax](../databases/querying.md) like `$regex` can be added like this:
 
 ```ts
 import { querySyntax } from '@feathersjs/typebox'
@@ -108,10 +108,10 @@ const messageQueryProperties = Type.Pick(messageSchema, ['id', 'text', 'createdA
 })
 const messageQuerySchema = Type.Intersect(
   [
-    // This will additionally allow querying for `{ name: { $ilike: 'Dav%' } }`
+    // This will additionally allow querying for `{ name: { $regex: 'Dav', $options: 'i' } }`
     querySyntax(messageQueryProperties, {
       name: {
-        $ilike: Type.String()
+        $regex: Type.String(), $options: Type.String()
       }
     }),
     // Add additional query properties here
@@ -119,6 +119,18 @@ const messageQuerySchema = Type.Intersect(
   ],
   { additionalProperties: false }
 )
+```
+
+Finally, in the class module, add the operators:
+
+```ts
+export const getOptions = (app: Application): MongoDBAdapterOptions => {
+  return {
+    paginate: app.get('paginate'),
+    Model: app.get('mongodbClient').then((db) => db.collection('example')),
+    operators: ['$regex', '$options'] // add the operators
+  }
+}
 ```
 
 To allow additional query properties outside of the query syntax use the intersection type:


### PR DESCRIPTION
Replace $ilike with a complete example using $regex

### Summary

- [ ] Tell us about the problem your pull request is solving.
I recently had an issue using $regex with mongodb. I tried finding a solution in the docs but it wasn't complete (it missed an extra step which was marked as deprecated but without it, adding extra operators doesn't work). This PR adds a better example in the docs to avoid frustrations for other developers in the future.
- [ ] Are there any open issues that are related to this?
Yes issue [#3431[(https://github.com/feathersjs/feathers/issues/3431)
- [ ] Is this PR dependent on PRs in other repos?
No