### PR TITLE
fix(knex): Fix total calculation

### DIFF
--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -166,10 +166,11 @@ export class KnexAdapter<
   async _find(params?: ServiceParams): Promise<Paginated<Result> | Result[]>
   async _find(params: ServiceParams = {} as ServiceParams): Promise<Paginated<Result> | Result[]> {
     const { filters, paginate } = this.filterQuery(params)
-    const { name, id } = this.getOptions(params)
+    const { Model, name, id } = this.getOptions(params)
     const builder = params.knex ? params.knex.clone() : this.createQuery(params)
-    const countBuilder = builder.clone().clearSelect().clearOrder().count(`${name}.${id} as total`)
-
+    const countBuilder = Model.count(`* as total`)
+      .with('subquery', builder.clone().clearOrder())
+      .from('subquery')
     // Handle $limit
     if (filters.$limit) {
       builder.limit(filters.$limit)


### PR DESCRIPTION
### Summary


- [X] Tell us about the problem your pull request is solving.
  - When the query contains `DISTINCT` or `GROUP BY`, incorrect `total` is being returned. This PR fixes it by calculating the count using a subquery. More details below:
  - When `DISTINCT` clause is used, `clearSelect()` removes the `DISTINCT` clause in the countBuilder query, hence returning non-distinct count. For eg:
    - ```sql
      SELECT DISTINCT `users.*` FROM `users` WHERE ....
      ```
    - is converted to
    - ```sql
      SELECT `*` FROM `users` WHERE ...
      ```
    - losing the distinct property of the query.
  - When `GROUP BY` clause is used, `GROUP BY` is applied on ``COUNT(`${name}.${id}`)``, which is useless, because rows returned by `COUNT` will not contain any column other than `total` to `GROUP BY`. Hence non-distinct rows are returned again.
  - Hence the solution is, to wrap the main query into a subquery, and count the rows returned by it, which is what this PR does.
- [ ] Are there any open issues that are related to this?
  - No. But this is a bug, I can create an issue if necessary.
- [ ] Is this PR dependent on PRs in other repos?
  - No