### PR TITLE
fix(knex): use driver name to identify client

### DIFF
--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -239,8 +239,8 @@ export class KnexAdapter<
       return Promise.all(data.map((current) => this._create(current, params)))
     }
 
-    const { client } = this.db(params).client.config
-    const returning = RETURNING_CLIENTS.includes(client as string) ? [this.id] : []
+    const { client } = this.db(params)
+    const returning = RETURNING_CLIENTS.includes(client.driverName) ? [this.id] : []
     const rows: any = await this.db(params)
       .insert(data, returning, { includeTriggerModifications: true })
       .catch(errorHandler)


### PR DESCRIPTION
In `@feathers/knex`, when inserting data, use the `client.driverName` property to identify the clients that can return fields when inserting instead of the client config as a string.

### Problem

The current implementation of `@feathersjs/knex` expects the client to be passed as a string when initializing Knex. Example:

```
const db: Knex = knex({
      client: "pg",
      connection: "postgres://postgres:postgres@localhost:5432/api",
});
```

However, a client can be passed as a class instance to Knex instead of a string. Example:

```
const db: Knex = knex({
    client: ClientPgLite,
    dialect: "postgres",
    connection: {},
});
```

(The example is for using https://github.com/czeidler/knex-pglite)

When passing the client as an object, `@feathersjs/knex` throws an error because it cannot identify the client as a returning client (even though, in this example, the client is a derivative of the `pg` client and is a returning client):

```
ERROR:  TypeError: Cannot read properties of undefined (reading 'id')
          at KnexService._create (/node_modules/.pnpm/@feathersjs+knex@5.0.29_knex@3.1.0/node_modules/@feathersjs/knex/src/adapter.ts:247:33)
          at processTicksAndRejections (node:internal/process/task_queues:95:5)
          at KnexService.<anonymous> (/node_modules/.pnpm/@feathersjs+schema@5.0.29_typescript@5.5.4/node_modules/@feathersjs/schema/src/hooks/resolve.ts:97:5)
          at KnexService.<anonymous> (/node_modules/.pnpm/@feathersjs+schema@5.0.29_typescript@5.5.4/node_modules/@feathersjs/schema/src/hooks/resolve.ts:150:5)
          at KnexService.logError (/packages/feathers/dist/index.js:45:5)
          at /node_modules/.pnpm/@feathersjs+koa@5.0.29_typescript@5.5.4/node_modules/@feathersjs/koa/src/rest.ts:36:21
          at /node_modules/.pnpm/@feathersjs+koa@5.0.29_typescript@5.5.4/node_modules/@feathersjs/koa/src/handlers.ts:6:5
```

The error happens at https://github.com/feathersjs/feathers/blob/dove/packages/knex/src/adapter.ts#L242

### Solution

This PR fixes the issue by switching to `client.driverName` for identifying the client.

`client.driverName` is a string that contains the driver name:

- When the client is provided as a string in the config, `client.driverName` will have the same value as `client.config` (`pg`, `postgresql`, etc.)
- When the client is provided as a class instance in the config, `client.driverName` will have the name of the driver as a string