### PR TITLE
fix(knex): Add tableOptions parameter for inheritance on knex adapter options to pass on knex builder

### DIFF
--- a/docs/api/databases/knex.md
+++ b/docs/api/databases/knex.md
@@ -62,6 +62,7 @@ The Knex specific adapter options are:
 - `Model {Knex}` (**required**) - The KnexJS database instance
 - `name {string}` (**required**) - The name of the table
 - `schema {string}` (_optional_) - The name of the schema table prefix (example: `schema.table`)
+- `tableOptions {only: boolean` (_optional_) - Argument for passing options to knex db builder. ONLY keyword is used before the tableName to discard inheriting tables' data. (https://knexjs.org/guide/query-builder.html#common)
 
 The [common API options](./common.md#options) are:
 

--- a/docs/api/databases/knex.md
+++ b/docs/api/databases/knex.md
@@ -62,7 +62,7 @@ The Knex specific adapter options are:
 - `Model {Knex}` (**required**) - The KnexJS database instance
 - `name {string}` (**required**) - The name of the table
 - `schema {string}` (_optional_) - The name of the schema table prefix (example: `schema.table`)
-- `tableOptions {only: boolean` (_optional_) - Argument for passing options to knex db builder. ONLY keyword is used before the tableName to discard inheriting tables' data. (https://knexjs.org/guide/query-builder.html#common)
+- `tableOptions {only: boolean` (_optional_) - For PostgreSQL only. Argument for passing options to knex db builder. ONLY keyword is used before the tableName to discard inheriting tables' data. (https://knexjs.org/guide/query-builder.html#common)
 
 The [common API options](./common.md#options) are:
 

--- a/docs/api/databases/knex.md
+++ b/docs/api/databases/knex.md
@@ -64,6 +64,7 @@ The Knex specific adapter options are:
 - `schema {string}` (_optional_) - The name of the schema table prefix (example: `schema.table`)
 - `tableOptions {only: boolean` (_optional_) - For PostgreSQL only. Argument for passing options to knex db builder. ONLY keyword is used before the tableName to discard inheriting tables' data. (https://knexjs.org/guide/query-builder.html#common)
 
+
 The [common API options](./common.md#options) are:
 
 - `id {string}` (_optional_, default: `'id'`) - The name of the id field property. By design, Knex will always add an `id` property.

--- a/packages/knex/src/adapter.ts
+++ b/packages/knex/src/adapter.ts
@@ -69,7 +69,7 @@ export class KnexAdapter<
   }
 
   db(params?: ServiceParams) {
-    const { Model, name, schema } = this.getOptions(params)
+    const { Model, name, schema, tableOptions } = this.getOptions(params)
 
     if (params && params.transaction && params.transaction.trx) {
       const { trx } = params.transaction
@@ -77,7 +77,7 @@ export class KnexAdapter<
       return schema ? (trx.withSchema(schema).table(name) as Knex.QueryBuilder) : trx(name)
     }
 
-    return schema ? (Model.withSchema(schema).table(name) as Knex.QueryBuilder) : Model(name)
+    return schema ? (Model.withSchema(schema).table(name) as Knex.QueryBuilder) : Model(name, tableOptions)
   }
 
   knexify(knexQuery: Knex.QueryBuilder, query: Query = {}, parentKey?: string): Knex.QueryBuilder {

--- a/packages/knex/src/declarations.ts
+++ b/packages/knex/src/declarations.ts
@@ -5,6 +5,9 @@ export interface KnexAdapterOptions extends AdapterServiceOptions {
   Model: Knex
   name: string
   schema?: string
+  tableOptions?: {
+    only?: boolean
+  }
 }
 
 export interface KnexAdapterTransaction {


### PR DESCRIPTION
Add support on knex adapter to passe tableOptions on the Knex builder in order to support the option  ONLY that discard the inheriting tables - **For PostgreSQL only**

Today the feathesjs-knex package was not able to pass the option:
```
{
  only: true
}
```
Here is the knex doc: https://knexjs.org/guide/query-builder.html#common

I propose a new knex specific adapter option called: tableOptions to be used on the getOptions method of the service class.

this can be passed on the db method on the knex adapter and therfore to the 

```
Model(name, tableOptions)
```


