### PR TITLE
fix(mongodb): Fix mongo count

### DIFF
--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -213,6 +213,7 @@ export class MongoDbAdapter<
     if (params.pipeline) {
       const aggregateParams = {
         ...params,
+        paginate: false,
         query: {
           ...params.query,
           $select: [this.id],

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -225,6 +225,9 @@ export class MongoDbAdapter<
         }
       }
       const [result] = await this.aggregateRaw(aggregateParams).then((result) => result.toArray())
+      if (!result) {
+        return 0
+      }
       return result.total
     }
 

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -148,16 +148,16 @@ export class MongoDbAdapter<
       pipeline.push({ $sort: filters.$sort })
     }
 
-    if (filters.$select !== undefined) {
-      pipeline.push({ $project: this.getProjection(filters.$select) })
-    }
-
     if (filters.$skip !== undefined) {
       pipeline.push({ $skip: filters.$skip })
     }
 
     if (filters.$limit !== undefined) {
       pipeline.push({ $limit: filters.$limit })
+    }
+
+    if (filters.$select !== undefined) {
+      pipeline.push({ $project: this.getProjection(filters.$select) })
     }
 
     return pipeline
@@ -167,6 +167,7 @@ export class MongoDbAdapter<
     if (!select) {
       return undefined
     }
+
     if (Array.isArray(select)) {
       if (!select.includes(this.id)) {
         select = [this.id, ...select]

--- a/packages/mongodb/src/adapter.ts
+++ b/packages/mongodb/src/adapter.ts
@@ -214,6 +214,7 @@ export class MongoDbAdapter<
       const aggregateParams = {
         ...params,
         paginate: false,
+        pipeline: [...params.pipeline, { $count: 'total' }],
         query: {
           ...params.query,
           $select: [this.id],
@@ -222,8 +223,8 @@ export class MongoDbAdapter<
           $limit: undefined
         }
       }
-      const result = await this.aggregateRaw(aggregateParams).then((result) => result.toArray())
-      return result.length
+      const [result] = await this.aggregateRaw(aggregateParams).then((result) => result.toArray())
+      return result.total
     }
 
     const model = await this.getModel(params)

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -29,6 +29,7 @@ const testSuite = adapterTests([
   '.remove + multi',
   '.remove + multi no pagination',
   '.remove + id + query id',
+  '.remove + NotFound',
   '.update',
   '.update + $select',
   '.update + id + query',

--- a/packages/mongodb/test/index.test.ts
+++ b/packages/mongodb/test/index.test.ts
@@ -83,11 +83,6 @@ const testSuite = adapterTests([
   'params.adapter + multi'
 ])
 
-const defaultPaginate = {
-  default: 10,
-  max: 50
-}
-
 describe('Feathers MongoDB Service', () => {
   const personSchema = {
     $id: 'Person',
@@ -573,12 +568,19 @@ describe('Feathers MongoDB Service', () => {
     it('can count documents with aggregation', async () => {
       const service = app.service('people')
       const paginateBefore = service.options.paginate
-      service.options.paginate = defaultPaginate
-      const query = { age: { $gte: 25 } }
-      const findResult = await app.service('people').find({ query })
-      const aggregationResult = await app.service('people').find({ query, pipeline: [] })
 
-      assert.deepStrictEqual(findResult.total, aggregationResult.total)
+      const test = async (paginate: any) => {
+        service.options.paginate = paginate
+        const query = { age: { $gte: 25 } }
+        const findResult = await app.service('people').find({ query })
+        const aggregationResult = await app.service('people').find({ query, pipeline: [] })
+        assert.deepStrictEqual(findResult.total, aggregationResult.total)
+      }
+
+      await test({ default: 10, max: 50 })
+      // There are 2 people with age >= 25.
+      // Test that aggregation works when results are less than default
+      await test({ default: 1, max: 50 })
 
       service.options.paginate = paginateBefore
     })


### PR DESCRIPTION
This PR fixes a bug in the mongo package that caused a miscount when counting documents while using the aggregation pipeline. I recently installed this in a large production app and caught a couple of bugs that the tests had not. 

0f1deb642ad4a4585c17aa2bf4eaec8fd7152ca0 - Add `paginate: false` to ensure counting all documents.

e6595b8d3c2dc6fbc32084fb980f3f85805b75f5 - Use the pipeline's `$count` operator for better performance.

e126577a47081733d18adb11a96e0fce3a6d93e7 - Rearrange the pipeline so that it skips and limits before projecting (aka select). Mongo supposedly optimizes the pipeline steps, but its still make sense to me and reads better if we skip/limit before projection.

927f357232dfd8f7cb946db4e67f4725dbb27e4e - Add 1 missing test from the generic test suite.

Please let me know anything I can do to move this PR through quickly. It is critical bug in a production app and I cannot roll it back easily.