### PR TITLE
docs: refer to correct object on request for express middleware

### DIFF
--- a/docs/api/express.md
+++ b/docs/api/express.md
@@ -524,7 +524,7 @@ The following options can be passed when creating a new error handler:
 
 ### authenticate()
 
-`express.authenticate(...strategies)` allows to protect an Express middleware with an [authentication service](./authentication/service.md) that has [strategies](./authentication/strategy.md) registered that can parse HTTP headers. It will set the authentication information on the `req` object (e.g. `req.user`). The following example protects the `/hello` endpoint with the JWT strategy (so the `Authorization: Bearer <JWT>` header needs to be set) and uses the user email to render the message:
+`express.authenticate(...strategies)` allows to protect an Express middleware with an [authentication service](./authentication/service.md) that has [strategies](./authentication/strategy.md) registered that can parse HTTP headers. It will set the authentication information on the `req.feathers` object (e.g. `req.feathers.user`). The following example protects the `/hello` endpoint with the JWT strategy (so the `Authorization: Bearer <JWT>` header needs to be set) and uses the user email to render the message:
 
 ```ts
 import { authenticate } from '@feathersjs/express'


### PR DESCRIPTION
### Summary

The Express documentation still refers to the `authenticate` middleware mutating the `req` object. Since v5 this is now on `req.feathers` instead.