### PR TITLE
docs: Update auth0.md to use correct import name for oauth configuration 

### DIFF
--- a/docs/cookbook/authentication/auth0.md
+++ b/docs/cookbook/authentication/auth0.md
@@ -40,7 +40,7 @@ In `src/authentication.ts` like this:
 import { ServiceAddons, Params } from '@feathersjs/feathers';
 import { AuthenticationService, JWTStrategy } from '@feathersjs/authentication';
 import { LocalStrategy } from '@feathersjs/authentication-local';
-import { expressOauth, OAuthStrategy, OAuthProfile } from '@feathersjs/authentication-oauth';
+import { oauth, OAuthStrategy, OAuthProfile } from '@feathersjs/authentication-oauth';
 
 import { Application } from './declarations';
 
@@ -69,7 +69,7 @@ export default function(app: Application) {
   authentication.register('auth0', new Auth0Strategy());
 
   app.use('/authentication', authentication);
-  app.configure(expressOauth());
+  app.configure(oauth());
 }
 ```
 


### PR DESCRIPTION
Update import name of OAuth configure

### Summary

The name of the OAuth configure function has changed. The current code in Auth0 cookbook doesn’t work with v5.

This PR changes the code example to use the same import name from the updated OAuth guide.

- [ ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If this is a new feature, please remember to add the appropriate documentation in their respective pages in the `docs` folder.

Thanks for contributing to Feathers! :heart:
