### PR TITLE
build(npm): bump koa to 2.15.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13579,9 +13579,10 @@
       }
     },
     "node_modules/koa": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
-      "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.4.tgz",
+      "integrity": "sha512-7fNBIdrU2PEgLljXoPWoyY4r1e+ToWCmzS/wwMPbUNs7X+5MMET1ObhJBlUkF5uZG9B6QhM2zS1TsH6adegkiQ==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -25079,7 +25080,7 @@
         "@types/koa__cors": "^5.0.0",
         "@types/koa-qs": "^2.0.3",
         "@types/koa-static": "^4.0.4",
-        "koa": "^2.15.3",
+        "koa": "^2.15.4",
         "koa-body": "^6.0.1",
         "koa-compose": "^4.1.0",
         "koa-qs": "^3.0.0",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -59,7 +59,7 @@
     "@types/koa-qs": "^2.0.3",
     "@types/koa-static": "^4.0.4",
     "@types/koa__cors": "^5.0.0",
-    "koa": "^2.15.3",
+    "koa": "^2.15.4",
     "koa-body": "^6.0.1",
     "koa-compose": "^4.1.0",
     "koa-qs": "^3.0.0",


### PR DESCRIPTION
resolves https://github.com/advisories/GHSA-593f-38f6-jp5m