### PR TITLE
fix(oauth): return updated object `value` key instead of complex patched object that causes crash

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -166,7 +166,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
 
     const authEntity = !existingEntity
       ? await this.createEntity(profile, params)
-      : await this.updateEntity(existingEntity, profile, params)
+      : (await this.updateEntity(existingEntity, profile, params)).value
 
     return {
       authentication: { strategy: this.name },


### PR DESCRIPTION
OAuth is not working since the object returned from patch function is a complex object composed by `value` item that contains the payload of the user account.

There are not other open issues that are related to this and this PR is not dependent on PRs in other repos.
