### PR TITLE
build(npm): bump koa to 2.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13758,9 +13758,9 @@
       }
     },
     "node_modules/koa": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.4.tgz",
-      "integrity": "sha512-7fNBIdrU2PEgLljXoPWoyY4r1e+ToWCmzS/wwMPbUNs7X+5MMET1ObhJBlUkF5uZG9B6QhM2zS1TsH6adegkiQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
+      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.5",
@@ -25223,7 +25223,7 @@
         "@types/koa__cors": "^5.0.0",
         "@types/koa-qs": "^2.0.3",
         "@types/koa-static": "^4.0.4",
-        "koa": "^2.15.4",
+        "koa": "^2.16.1",
         "koa-body": "^6.0.1",
         "koa-compose": "^4.1.0",
         "koa-qs": "^3.0.0",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -59,7 +59,7 @@
     "@types/koa-qs": "^2.0.3",
     "@types/koa-static": "^4.0.4",
     "@types/koa__cors": "^5.0.0",
-    "koa": "^2.15.4",
+    "koa": "^2.16.1",
     "koa-body": "^6.0.1",
     "koa-compose": "^4.1.0",
     "koa-qs": "^3.0.0",


### PR DESCRIPTION
resolves https://github.com/koajs/koa/security/advisories/GHSA-x2rg-q646-7m2v