### PR TITLE
fix: Make handling of async iterables consistent

### DIFF
--- a/packages/feathers/fixtures/index.ts
+++ b/packages/feathers/fixtures/index.ts
@@ -19,10 +19,14 @@ export class ResponseTestService {
     })
   }
 
-  async *get(id: string) {
-    for (let i = 1; i <= 5; i++) {
-      yield { message: `Hello ${id} ${i}` }
+  async get(id: string) {
+    const generator = async function* () {
+      for (let i = 1; i <= 5; i++) {
+        yield { message: `Hello ${id} ${i}` }
+      }
     }
+
+    return generator()
   }
 
   async options(_params: Params) {

--- a/packages/feathers/src/client/fetch.test.ts
+++ b/packages/feathers/src/client/fetch.test.ts
@@ -110,11 +110,11 @@ describe('fetch REST connector', function () {
     await expect(() => service.internalMethod({})).rejects.toThrow(MethodNotAllowed)
   })
 
-  it('supports event streams', async () => {
+  it('supports async iterable streams', async () => {
     const messages: any[] = []
+    const stream = await app.service('test').get('test')
 
-    // TODO investigate need for additional await
-    for await (const data of await app.service('test').get('test')) {
+    for await (const data of stream) {
       messages.push(data)
     }
 

--- a/packages/feathers/src/hooks/function.test.ts
+++ b/packages/feathers/src/hooks/function.test.ts
@@ -485,4 +485,17 @@ describe('feathers/hooks function', () => {
     assert.strictEqual(await fn('Dave'), 'Hello Dave')
     assert.strictEqual(await fn(), 'Hello Bertho')
   })
+
+  it('returning an async iterator directly errors', () => {
+    const iterable = async function* () {
+      yield 'Hello'
+      yield 'World'
+    }
+
+    const fn = hooks(iterable, [])
+
+    expect(() => fn()).rejects.toThrow(
+      'Function must return a Promise that resolves to an async iterable, not the iterable directly'
+    )
+  })
 })

--- a/packages/feathers/src/hooks/hooks.ts
+++ b/packages/feathers/src/hooks/hooks.ts
@@ -43,7 +43,15 @@ export function functionHooks<F>(fn: F, managerOrMiddleware: HookOptions) {
     // Runs the actual original method if `ctx.result` is not already set
     hookChain.push((ctx, next) => {
       if (!Object.prototype.hasOwnProperty.call(context, 'result')) {
-        return Promise.resolve(original.apply(this, ctx.arguments)).then((result) => {
+        const returnValue = original.apply(this, ctx.arguments)
+
+        if (returnValue[Symbol.asyncIterator]) {
+          throw new Error(
+            'Function must return a Promise that resolves to an async iterable, not the iterable directly'
+          )
+        }
+
+        return Promise.resolve(returnValue).then((result) => {
           ctx.result = result
 
           return next()


### PR DESCRIPTION
Because of the hook system which always requires a promise, streaming through async iterables can only be done by returning a promise the resolves to an async iterable, not the async iterable directly (in which case we are throwing an error now).