### PR TITLE
fix: Add compatibility exports

### DIFF
--- a/packages/feathers/src/http/index.ts
+++ b/packages/feathers/src/http/index.ts
@@ -12,6 +12,7 @@ export type HttpParams<Q> = Params<Q> & {
 
 export * from './middleware.js'
 export * from './sse.service.js'
+export * from './utils.js'
 
 export const serviceToHttpMethod = {
   find: 'GET',

--- a/packages/feathers/src/index.ts
+++ b/packages/feathers/src/index.ts
@@ -10,7 +10,12 @@ export function feathers<T = any, S = any>() {
 feathers.setDebug = setDebug
 
 export { version, Feathers }
+export { Channel } from './channel/base.js'
+export { CombinedChannel } from './channel/combined.js'
+export * as channelUtils from './channel/mixin.js'
+
 export * from './hooks.js'
 export * from './declarations.js'
 export * from './service.js'
 export * from './debug.js'
+export * from './router.js'


### PR DESCRIPTION
This is needed to be mostly backwards compatible with v5