### PR TITLE
fix: @feathersjs/memory update with query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27930,7 +27930,6 @@
       "license": "MIT",
       "dependencies": {
         "@feathersjs/adapter-commons": "^5.0.35",
-        "@feathersjs/commons": "^5.0.35",
         "@feathersjs/errors": "^5.0.35",
         "sift": "^17.1.3"
       },

--- a/packages/adapter-tests/src/methods.ts
+++ b/packages/adapter-tests/src/methods.ts
@@ -292,6 +292,9 @@ export default (test: AdapterMethodsTest, app: any, _errors: any, serviceName: s
         } catch (error: any) {
           assert.strictEqual(error.name, 'NotFound', 'Got a NotFound Feathers error')
         }
+
+        const updatedDoug = await service.get(doug[idProp])
+        assert.strictEqual(updatedDoug.name, 'Doug', 'Doug was not updated')
       })
 
       test('.update + NotFound', async () => {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@feathersjs/adapter-commons": "^5.0.35",
-    "@feathersjs/commons": "^5.0.35",
     "@feathersjs/errors": "^5.0.35",
     "sift": "^17.1.3"
   },

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,5 +1,4 @@
 import { BadRequest, MethodNotAllowed, NotFound } from '@feathersjs/errors'
-import { _ } from '@feathersjs/commons'
 import {
   sorter,
   select,
@@ -75,11 +74,11 @@ export class MemoryAdapter<
     const { paginate } = this.getOptions(params)
     const { query, filters } = this.getQuery(params)
 
-    let values = _.values(this.store)
+    let values = Object.values(this.store)
     const hasSkip = filters.$skip !== undefined
     const hasSort = filters.$sort !== undefined
     const hasLimit = filters.$limit !== undefined
-    const hasQuery = _.keys(query).length > 0
+    const hasQuery = Object.keys(query).length > 0
 
     if (hasSort) {
       values.sort(this.options.sorter(filters.$sort))
@@ -171,8 +170,8 @@ export class MemoryAdapter<
     }
 
     const id = (data as any)[this.id] || this._uId++
-    const current = _.extend({}, data, { [this.id]: id })
-    const result = (this.store[id] = current)
+    const current = { ...data, [this.id]: id }
+    const result = (this.store[id] = current as any)
 
     return _select(result, params, this.id) as Result
   }
@@ -183,13 +182,8 @@ export class MemoryAdapter<
     }
 
     const oldEntry = await this._get(id, params)
-    // We don't want our id to change type if it can be coerced
-    const oldId = (oldEntry as any)[this.id]
 
-    // eslint-disable-next-line eqeqeq
-    id = oldId == id ? oldId : id
-
-    this.store[id] = _.extend({}, data, { [this.id]: id })
+    this.store[id] = { ...data, [this.id]: (oldEntry as any)[this.id] } as Result
 
     return this._get(id, params)
   }
@@ -214,7 +208,11 @@ export class MemoryAdapter<
     const patchEntry = (entry: Result) => {
       const currentId = (entry as any)[this.id]
 
-      this.store[currentId] = _.extend(this.store[currentId], _.omit(data, this.id))
+      this.store[currentId] = {
+        ...this.store[currentId],
+        ...data,
+        [this.id]: (entry as any)[this.id]
+      }
 
       return _select(this.store[currentId], params, this.id)
     }

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -182,7 +182,7 @@ export class MemoryAdapter<
       throw new BadRequest("You can not replace multiple instances. Did you mean 'patch'?")
     }
 
-    const oldEntry = await this._get(id)
+    const oldEntry = await this._get(id, params)
     // We don't want our id to change type if it can be coerced
     const oldId = (oldEntry as any)[this.id]
 

--- a/packages/memory/test/index.test.ts
+++ b/packages/memory/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import adapterTests from '@feathersjs/adapter-tests'
-import errors from '@feathersjs/errors'
+import errors, { NotFound } from '@feathersjs/errors'
 import { feathers } from '@feathersjs/feathers'
 
 import { MemoryService } from '../src'
@@ -272,6 +272,34 @@ describe('Feathers Memory Service', () => {
           }
         }
       })
+    }
+  })
+
+  it('.update + id + query', async () => {
+    const people = app.service('people')
+    const person = await people.create({
+      name: 'test',
+      age: 42
+    })
+    try {
+      await assert.rejects(
+        () =>
+          people.update(
+            person.id,
+            {
+              name: 'Tester'
+            },
+            {
+              query: { name: 'person' }
+            }
+          ),
+        NotFound
+      )
+
+      const unchanged = await people.get(person.id)
+      assert.strictEqual(unchanged.name, person.name, 'name is still test')
+    } finally {
+      await people.remove(person.id)
     }
   })
 

--- a/packages/memory/test/index.test.ts
+++ b/packages/memory/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import adapterTests from '@feathersjs/adapter-tests'
-import errors, { NotFound } from '@feathersjs/errors'
+import errors from '@feathersjs/errors'
 import { feathers } from '@feathersjs/feathers'
 
 import { MemoryService } from '../src'
@@ -272,34 +272,6 @@ describe('Feathers Memory Service', () => {
           }
         }
       })
-    }
-  })
-
-  it('.update + id + query', async () => {
-    const people = app.service('people')
-    const person = await people.create({
-      name: 'test',
-      age: 42
-    })
-    try {
-      await assert.rejects(
-        () =>
-          people.update(
-            person.id,
-            {
-              name: 'Tester'
-            },
-            {
-              query: { name: 'person' }
-            }
-          ),
-        NotFound
-      )
-
-      const unchanged = await people.get(person.id)
-      assert.strictEqual(unchanged.name, person.name, 'name is still test')
-    } finally {
-      await people.remove(person.id)
     }
   })
 


### PR DESCRIPTION
TLDR:
`@feathersjs/memory`: `.update()` with a query (resulting in `NotFound`) updates data instead of preventing the change.

`adapter-tests` has a test case for `.update + id + query` but it produces a false positive (at least for `@feathersjs/memory`). It checks for `NotFound` but does not safely detect if definitely nothing was changed.

In case of an `.update()` with a query, the current implementation of `@feathersjs/memory` changes the data first, stores the changed data and then throws afterwards. 

So I included an explicit check in `@feathersjs/adapter-tests` and fixed it by passing `params` to the first `_.get()` in `update`.

While being at it, I also replaced `@feathersjs/commons` with native methods (third commit).