### PR TITLE
chore(dependencies): bump koa to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15141,9 +15141,9 @@
       }
     },
     "node_modules/koa": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-3.0.1.tgz",
-      "integrity": "sha512-oDxVkRwPOHhGlxKIDiDB2h+/l05QPtefD7nSqRgDfZt8P+QVYFWjfeK8jANf5O2YXjk8egd7KntvXKYx82wOag==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.1.tgz",
+      "integrity": "sha512-KDDuvpfqSK0ZKEO2gCPedNjl5wYpfj+HNiuVRlbhd1A88S3M0ySkdf2V/EJ4NWt5dwh5PXCdcenrKK2IQJAxsg==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.8",
@@ -27885,7 +27885,7 @@
         "@types/koa__cors": "^5.0.0",
         "@types/koa-qs": "^2.0.3",
         "@types/koa-static": "^4.0.4",
-        "koa": "^3.0.1",
+        "koa": "^3.1.1",
         "koa-body": "^6.0.1",
         "koa-compose": "^4.1.0",
         "koa-qs": "^3.0.0",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -59,7 +59,7 @@
     "@types/koa-qs": "^2.0.3",
     "@types/koa-static": "^4.0.4",
     "@types/koa__cors": "^5.0.0",
-    "koa": "^3.0.1",
+    "koa": "^3.1.1",
     "koa-body": "^6.0.1",
     "koa-compose": "^4.1.0",
     "koa-qs": "^3.0.0",


### PR DESCRIPTION
resolves https://github.com/advisories/GHSA-g8mr-fgfg-5qpc