### PR TITLE
fix: Prioritize URL hash access tokens over stored tokens and clear s…

### DIFF
--- a/packages/authentication-client/src/core.ts
+++ b/packages/authentication-client/src/core.ts
@@ -114,16 +114,24 @@ export class AuthenticationClient {
   }
 
   /**
-   * Returns the access token from storage or the window location hash.
+   * Returns the access token from the window location hash or storage.
    *
-   * @returns The access token from storage or location hash
+   * @returns The access token from location hash or storage
    */
   getAccessToken(): Promise<string | null> {
-    return this.storage.getItem(this.options.storageKey).then((accessToken: string) => {
-      if (!accessToken && typeof window !== 'undefined' && window.location) {
-        return this.getFromLocation(window.location)
-      }
+    if (typeof window !== 'undefined' && window.location) {
+      return this.getFromLocation(window.location).then((urlToken) => {
+        if (urlToken) {
+          return this.removeAccessToken().then(() => urlToken)
+        }
 
+        return this.storage.getItem(this.options.storageKey).then((storageToken: string) => {
+          return storageToken || null
+        })
+      })
+    }
+
+    return this.storage.getItem(this.options.storageKey).then((accessToken: string) => {
       return accessToken || null
     })
   }

--- a/packages/authentication-client/test/index.test.ts
+++ b/packages/authentication-client/test/index.test.ts
@@ -96,6 +96,32 @@ describe('@feathersjs/authentication-client', () => {
     }
   })
 
+  it('getAccessToken prefers URL token over storage token (#3631)', async () => {
+    const auth = app.authentication
+    const storageToken = 'old-storage-token'
+    const urlToken = 'new-url-token'
+
+    await auth.setAccessToken(storageToken)
+
+    let stored = await auth.storage.getItem(auth.options.storageKey)
+    assert.strictEqual(stored, storageToken)
+
+    const originalWindow = (global as any).window
+      ; (global as any).window = {
+        location: { hash: `access_token=${urlToken}` }
+      }
+
+    try {
+      const token = await auth.getAccessToken()
+      assert.strictEqual(token, urlToken, 'Should return URL token over storage token')
+
+      stored = await auth.storage.getItem(auth.options.storageKey)
+      assert.strictEqual(stored, undefined, 'Storage should be cleared when URL token is used')
+    } finally {
+      ; (global as any).window = originalWindow
+    }
+  })
+
   it('authenticate, authentication hook, login event', async () => {
     const data = {
       strategy: 'testing'


### PR DESCRIPTION
Fix: Prioritize URL access tokens over storage when using magic links
Summary
This PR fixes an issue where getAccessToken prioritizes localStorage tokens over URL hash tokens, causing magic links to fail when users already have a stored token.

Problem: When implementing passwordless authentication via magic links, the getAccessToken method checks localStorage before examining the URL hash. This means users with a stale token in storage cannot authenticate via a fresh magic link - the old token is used instead of the new one from the URL.

Solution: Modified getAccessToken to:

Check the URL hash for an access token before checking storage
Return the URL token even if a different token exists in storage
Clear (remove) the stored token when a URL token is consumed
Related Issues
Fixes #3631
Other Information
This change aligns with the expected behavior described in the original issue - if a user provides a new token in the URL, Feathers should consume it instead of using the previous one from localStorage.

Use case: Magic links to applications where a user can open a specific page without requiring login first because the token is part of the URL. Previously, opening two different magic links in the same browser would fail because the first token was cached.

Changes:

packages/authentication-client/src/core.ts
 - Modified getAccessToken to prioritize URL tokens
Added test case to verify URL token priority behavior
