### PR TITLE
feat: Add externalMethods option for transport exposure (#3457)

### DIFF
--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -29,9 +29,16 @@ export interface ServiceOptions<MethodTypes = string> {
    */
   events?: string[] | readonly string[]
   /**
-   * A list of service methods that should be available __externally__ to clients
+   * A list of service methods that `all` hooks will apply to.
+   * Defaults to the standard service methods (find, get, create, update, patch, remove)
+   * that exist on the service.
    */
   methods?: MethodTypes[] | readonly MethodTypes[]
+  /**
+   * A list of service methods that should be available __externally__ to clients
+   * via transports like HTTP or WebSockets. Defaults to `methods` if not specified.
+   */
+  externalMethods?: MethodTypes[] | readonly MethodTypes[]
   /**
    * Provide a full list of events that this service should emit to clients.
    * Unlike the `events` option, this will not be merged with the default events.

--- a/packages/feathers/src/service.ts
+++ b/packages/feathers/src/service.ts
@@ -35,6 +35,10 @@ export function getHookMethods(service: any, options: ServiceOptions) {
     .concat(methods)
 }
 
+export function getExternalMethods(options: ServiceOptions): readonly string[] {
+  return options.externalMethods || options.methods || []
+}
+
 export function getServiceOptions(service: any): ServiceOptions {
   return service[SERVICE]
 }
@@ -44,12 +48,15 @@ export const normalizeServiceOptions = (service: any, options: ServiceOptions = 
     methods = defaultServiceMethods.filter((method) => typeof service[method] === 'function'),
     events = service.events || []
   } = options
+  // externalMethods defaults to methods for backwards compatibility
+  const externalMethods = options.externalMethods || methods
   const serviceEvents = options.serviceEvents || defaultServiceEvents.concat(events)
 
   return {
     ...options,
     events,
     methods,
+    externalMethods,
     serviceEvents
   }
 }

--- a/packages/transport-commons/src/socket/index.ts
+++ b/packages/transport-commons/src/socket/index.ts
@@ -1,4 +1,10 @@
-import { Application, getServiceOptions, Params, RealTimeConnection } from '@feathersjs/feathers'
+import {
+  Application,
+  getServiceOptions,
+  getExternalMethods,
+  Params,
+  RealTimeConnection
+} from '@feathersjs/feathers'
 import { channels } from '../channels'
 import { routing } from '../routing'
 import { getDispatcher, runMethod } from './utils'
@@ -43,9 +49,9 @@ export function socket({ done, emit, socketMap, socketKey, getParams }: SocketOp
     done.then((provider) =>
       provider.on('connection', (connection: any) => {
         const methodHandlers = Object.keys(app.services).reduce((result, name) => {
-          const { methods } = getServiceOptions(app.service(name))
+          const externalMethods = getExternalMethods(getServiceOptions(app.service(name)))
 
-          methods.forEach((method) => {
+          externalMethods.forEach((method) => {
             if (!result[method]) {
               result[method] = (...args: any[]) => {
                 const [path, ...rest] = args

--- a/packages/transport-commons/src/socket/utils.ts
+++ b/packages/transport-commons/src/socket/utils.ts
@@ -3,7 +3,8 @@ import {
   Application,
   RealTimeConnection,
   createContext,
-  getServiceOptions
+  getServiceOptions,
+  getExternalMethods
 } from '@feathersjs/feathers'
 import { NotFound, MethodNotAllowed, BadRequest } from '@feathersjs/errors'
 import { createDebug } from '@feathersjs/commons'
@@ -97,10 +98,10 @@ export async function runMethod(
     }
 
     const { service, params: route = {} } = lookup
-    const { methods } = getServiceOptions(service)
+    const externalMethods = getExternalMethods(getServiceOptions(service))
 
-    // Only service methods are allowed
-    if (!methods.includes(method)) {
+    // Only externally exposed service methods are allowed
+    if (!externalMethods.includes(method)) {
       throw new MethodNotAllowed(`Method '${method}' not allowed on service '${path}'`)
     }
 


### PR DESCRIPTION
## Summary

This PR adds support for the `externalMethods` option to control which service methods are exposed via transports (HTTP/WebSockets), addressing #3457.

## Changes

### @feathersjs/feathers
- Added `externalMethods` to `ServiceOptions` interface
- Added `getExternalMethods()` helper function  
- Updated `normalizeServiceOptions()` to include `externalMethods` (defaults to `methods` for backwards compatibility)

### @feathersjs/transport-commons
- Updated `socket/utils.ts` to use `externalMethods` for method validation
- Updated `socket/index.ts` to use `externalMethods` for handler registration

## Usage

```typescript
app.use('myService', new MyService(), {
  // Methods that receive 'all' hooks
  methods: ['find', 'get', 'create', 'internalAction'],
  // Methods exposed via transports (defaults to methods if not specified)
  externalMethods: ['find', 'get', 'create']
})
```

## Backwards Compatibility

- If `externalMethods` is not specified, it defaults to `methods`
- Existing code works without modification

## Related

- Fixes #3457
- Companion PR for v6: (to be created from `v6-hooks-all-methods` branch)