### PR TITLE
Fix custom hook methods for typed client

### DIFF
--- a/packages/feathers/src/service.ts
+++ b/packages/feathers/src/service.ts
@@ -32,7 +32,7 @@ export function getHookMethods(service: any, options: ServiceOptions) {
 
   return (defaultServiceMethods as any as string[])
     .filter((m) => typeof service[m] === 'function' && !methods.includes(m))
-    .concat(methods)
+    .concat(methods.filter((m) => typeof service[m] === 'function'))
 }
 
 export function getServiceOptions(service: any): ServiceOptions {


### PR DESCRIPTION
When building typed client from backend, if any service have custom methods on it, the client typescript will pick up as error "Can not apply hooks".

To fix this issue I added filtering to make sure the method is available as function.
I ran this feathers locally, bundle client, and test it on client, it works as a fix.

Fixes issue https://github.com/feathersjs/feathers/issues/3576
