### PR TITLE
feat: Chainable @hooks().params() decorator with hookMixin support

### DIFF
--- a/packages/feathers/src/hooks.ts
+++ b/packages/feathers/src/hooks.ts
@@ -148,6 +148,51 @@ export function createContext(service: Service, method: string, data: HookContex
   return createContext(data) as HookContext
 }
 
+/**
+ * Creates property descriptors for Feathers-specific context properties.
+ * Used to add app, path, service, method, etc. to hook contexts.
+ */
+function createFeathersContextProps<A>(
+  app: A,
+  path: string,
+  method: string,
+  service: FeathersService<A>
+): PropertyDescriptorMap {
+  return {
+    app: { value: app, enumerable: true, writable: true },
+    path: { value: path, enumerable: true, writable: true },
+    method: { value: method, enumerable: true, writable: true },
+    service: { value: service, enumerable: true, writable: true },
+    event: { value: null, enumerable: true, writable: true },
+    type: { value: 'around', enumerable: true, writable: true },
+    statusCode: {
+      enumerable: true,
+      get(this: HookContext) {
+        return this.http?.status
+      },
+      set(this: HookContext, value: number) {
+        this.http = this.http || {}
+        this.http.status = value
+      }
+    }
+  }
+}
+
+/**
+ * Converts PropertyDescriptorMap to HookContextData for use with HookManager.props()
+ */
+function propsFromDescriptors(descriptors: PropertyDescriptorMap): HookContextData {
+  const props: HookContextData = {}
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    if ('value' in descriptor) {
+      props[key] = descriptor.value
+    } else {
+      Object.defineProperty(props, key, descriptor)
+    }
+  }
+  return props
+}
+
 export class FeathersHookManager<A> extends HookManager {
   constructor(
     public app: A,
@@ -186,23 +231,9 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
 
   const hookMethods = getHookMethods(service, options)
 
-  // Feathers-specific props to add to all method contexts
-  const feathersProps: HookContextData = {
-    app: this,
-    path,
-    service,
-    event: null,
-    type: 'around',
-    get statusCode() {
-      return (this as any).http?.status
-    },
-    set statusCode(value: number) {
-      ;(this as any).http = (this as any).http || {}
-      ;(this as any).http.status = value
-    }
-  }
-
   const serviceMethodHooks = hookMethods.reduce((res, method) => {
+    const feathersContextProps = createFeathersContextProps(this, path, method, service)
+
     // Check if the method already has params configured via @hooks().params()
     const existingManager = getManager((service as any)[method])
     const existingParams = existingManager?.getParams()
@@ -210,33 +241,15 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
     // If the method already has custom params from a decorator, we need to
     // enhance the existing wrapper with Feathers context. We do this by:
     // 1. Creating a FeathersHookManager as a parent (for collectMiddleware)
-    // 2. Regenerating the Context class with Feathers props on the prototype
+    // 2. Adding Feathers props to the existing Context prototype
     if (existingParams && existingManager) {
       const wrapper = (service as any)[method]
-      // Set up FeathersHookManager as parent for middleware collection
       const feathersManager = new FeathersHookManager<A>(this, method)
       setManager(wrapper, feathersManager)
-      // Add Feathers props directly to the existing Context prototype
+
       const contextProto = wrapper.Context?.prototype
       if (contextProto) {
-        Object.defineProperties(contextProto, {
-          app: { value: this, enumerable: true, writable: true },
-          path: { value: path, enumerable: true, writable: true },
-          method: { value: method, enumerable: true, writable: true },
-          service: { value: service, enumerable: true, writable: true },
-          event: { value: null, enumerable: true, writable: true },
-          type: { value: 'around', enumerable: true, writable: true },
-          statusCode: {
-            enumerable: true,
-            get() {
-              return this.http?.status
-            },
-            set(value: number) {
-              this.http = this.http || {}
-              this.http.status = value
-            }
-          }
-        })
+        Object.defineProperties(contextProto, feathersContextProps)
       }
       return res
     }
@@ -244,10 +257,9 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
     // Use default params for this method
     const params = (defaultServiceArguments as any)[method] || ['data', 'params']
 
-    res[method] = new FeathersHookManager<A>(this, method).params(...params).props({
-      ...feathersProps,
-      method
-    })
+    res[method] = new FeathersHookManager<A>(this, method)
+      .params(...params)
+      .props(propsFromDescriptors(feathersContextProps))
 
     return res
   }, {} as BaseHookMap)

--- a/packages/feathers/src/hooks.ts
+++ b/packages/feathers/src/hooks.ts
@@ -148,11 +148,45 @@ export function createContext(service: Service, method: string, data: HookContex
   return createContext(data) as HookContext
 }
 
+/** Shared statusCode property descriptor */
+const statusCodeDescriptor: PropertyDescriptor = {
+  enumerable: true,
+  get(this: HookContext) {
+    return this.http?.status
+  },
+  set(this: HookContext, value: number) {
+    this.http = this.http || {}
+    this.http.status = value
+  }
+}
+
 /**
- * Creates property descriptors for Feathers-specific context properties.
- * Used to add app, path, service, method, etc. to hook contexts.
+ * Creates Feathers-specific context properties as HookContextData.
+ * Used with HookManager.props() for standard service methods.
  */
-function createFeathersContextProps<A>(
+function createFeathersProps<A>(
+  app: A,
+  path: string,
+  method: string,
+  service: FeathersService<A>
+): HookContextData {
+  const props: HookContextData = {
+    app,
+    path,
+    method,
+    service,
+    event: null,
+    type: 'around'
+  }
+  Object.defineProperty(props, 'statusCode', statusCodeDescriptor)
+  return props
+}
+
+/**
+ * Creates Feathers-specific context properties as PropertyDescriptorMap.
+ * Used with Object.defineProperties() for decorated methods.
+ */
+function createFeathersDescriptors<A>(
   app: A,
   path: string,
   method: string,
@@ -165,32 +199,8 @@ function createFeathersContextProps<A>(
     service: { value: service, enumerable: true, writable: true },
     event: { value: null, enumerable: true, writable: true },
     type: { value: 'around', enumerable: true, writable: true },
-    statusCode: {
-      enumerable: true,
-      get(this: HookContext) {
-        return this.http?.status
-      },
-      set(this: HookContext, value: number) {
-        this.http = this.http || {}
-        this.http.status = value
-      }
-    }
+    statusCode: statusCodeDescriptor
   }
-}
-
-/**
- * Converts PropertyDescriptorMap to HookContextData for use with HookManager.props()
- */
-function propsFromDescriptors(descriptors: PropertyDescriptorMap): HookContextData {
-  const props: HookContextData = {}
-  for (const [key, descriptor] of Object.entries(descriptors)) {
-    if ('value' in descriptor) {
-      props[key] = descriptor.value
-    } else {
-      Object.defineProperty(props, key, descriptor)
-    }
-  }
-  return props
 }
 
 export class FeathersHookManager<A> extends HookManager {
@@ -232,8 +242,6 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
   const hookMethods = getHookMethods(service, options)
 
   const serviceMethodHooks = hookMethods.reduce((res, method) => {
-    const feathersContextProps = createFeathersContextProps(this, path, method, service)
-
     // Check if the method already has params configured via @hooks().params()
     const existingManager = getManager((service as any)[method])
     const existingParams = existingManager?.getParams()
@@ -249,7 +257,7 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
 
       const contextProto = wrapper.Context?.prototype
       if (contextProto) {
-        Object.defineProperties(contextProto, feathersContextProps)
+        Object.defineProperties(contextProto, createFeathersDescriptors(this, path, method, service))
       }
       return res
     }
@@ -259,7 +267,7 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
 
     res[method] = new FeathersHookManager<A>(this, method)
       .params(...params)
-      .props(propsFromDescriptors(feathersContextProps))
+      .props(createFeathersProps(this, path, method, service))
 
     return res
   }, {} as BaseHookMap)

--- a/packages/feathers/src/hooks.ts
+++ b/packages/feathers/src/hooks.ts
@@ -1,5 +1,6 @@
 import {
   getManager,
+  setManager,
   HookContextData,
   HookManager,
   HookMap as BaseHookMap,
@@ -185,23 +186,67 @@ export function hookMixin<A>(this: A, service: FeathersService<A>, path: string,
 
   const hookMethods = getHookMethods(service, options)
 
+  // Feathers-specific props to add to all method contexts
+  const feathersProps: HookContextData = {
+    app: this,
+    path,
+    service,
+    event: null,
+    type: 'around',
+    get statusCode() {
+      return (this as any).http?.status
+    },
+    set statusCode(value: number) {
+      ;(this as any).http = (this as any).http || {}
+      ;(this as any).http.status = value
+    }
+  }
+
   const serviceMethodHooks = hookMethods.reduce((res, method) => {
+    // Check if the method already has params configured via @hooks().params()
+    const existingManager = getManager((service as any)[method])
+    const existingParams = existingManager?.getParams()
+
+    // If the method already has custom params from a decorator, we need to
+    // enhance the existing wrapper with Feathers context. We do this by:
+    // 1. Creating a FeathersHookManager as a parent (for collectMiddleware)
+    // 2. Regenerating the Context class with Feathers props on the prototype
+    if (existingParams && existingManager) {
+      const wrapper = (service as any)[method]
+      // Set up FeathersHookManager as parent for middleware collection
+      const feathersManager = new FeathersHookManager<A>(this, method)
+      setManager(wrapper, feathersManager)
+      // Add Feathers props directly to the existing Context prototype
+      const contextProto = wrapper.Context?.prototype
+      if (contextProto) {
+        Object.defineProperties(contextProto, {
+          app: { value: this, enumerable: true, writable: true },
+          path: { value: path, enumerable: true, writable: true },
+          method: { value: method, enumerable: true, writable: true },
+          service: { value: service, enumerable: true, writable: true },
+          event: { value: null, enumerable: true, writable: true },
+          type: { value: 'around', enumerable: true, writable: true },
+          statusCode: {
+            enumerable: true,
+            get() {
+              return this.http?.status
+            },
+            set(value: number) {
+              this.http = this.http || {}
+              this.http.status = value
+            }
+          }
+        })
+      }
+      return res
+    }
+
+    // Use default params for this method
     const params = (defaultServiceArguments as any)[method] || ['data', 'params']
 
     res[method] = new FeathersHookManager<A>(this, method).params(...params).props({
-      app: this,
-      path,
-      method,
-      service,
-      event: null,
-      type: 'around',
-      get statusCode() {
-        return this.http?.status
-      },
-      set statusCode(value: number) {
-        this.http = this.http || {}
-        this.http.status = value
-      }
+      ...feathersProps,
+      method
     })
 
     return res

--- a/packages/feathers/src/hooks/base.ts
+++ b/packages/feathers/src/hooks/base.ts
@@ -128,6 +128,20 @@ export class HookManager {
     return this
   }
 
+  /**
+   * Creates a shallow clone of this HookManager with copies of all configuration.
+   * Useful for creating modified versions without mutating the original.
+   */
+  clone(): this {
+    const clone = new (this.constructor as new () => this)()
+    clone._parent = this._parent
+    clone._middleware = this._middleware
+    clone._params = this._params
+    clone._props = this._props ? { ...this._props } : null
+    clone._defaults = this._defaults
+    return clone
+  }
+
   getDefaults(self: any, args: any[], context: HookContext): HookContextData | null {
     const defaults = typeof this._defaults === 'function' ? this._defaults(self, args, context) : null
     const previous = this._parent?.getDefaults(self, args, context)

--- a/packages/feathers/src/hooks/decorator.test.ts
+++ b/packages/feathers/src/hooks/decorator.test.ts
@@ -2,6 +2,142 @@ import { describe, expect, it } from 'vitest'
 import assert from 'assert'
 import { HookContext, hooks, middleware, NextFunction } from './index.js'
 
+describe('feathers/hooks chainable decorator', () => {
+  it('supports @hooks([]).params() chainable syntax', async () => {
+    const calls: string[] = []
+
+    class TestService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          calls.push(`before: id=${ctx.id}, data=${JSON.stringify(ctx.data)}`)
+          await next()
+          calls.push(`after: result=${JSON.stringify(ctx.result)}`)
+        }
+      ]).params('id', 'data'))
+      async myMethod(id: string, data: any) {
+        return { id, data }
+      }
+    }
+
+    const svc = new TestService()
+    const result = await svc.myMethod('123', { foo: 'bar' })
+
+    expect(result).toEqual({ id: '123', data: { foo: 'bar' } })
+    expect(calls).toEqual([
+      'before: id=123, data={"foo":"bar"}',
+      'after: result={"id":"123","data":{"foo":"bar"}}'
+    ])
+  })
+
+  it('supports @hooks([]).props() chainable syntax', async () => {
+    let capturedCtx: HookContext | null = null
+
+    class TestService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          capturedCtx = ctx
+          await next()
+        }
+      ]).props({ customProp: 'customValue' }))
+      async myMethod() {
+        return 'done'
+      }
+    }
+
+    const svc = new TestService()
+    await svc.myMethod()
+
+    expect(capturedCtx).not.toBeNull()
+    expect(capturedCtx!.customProp).toBe('customValue')
+  })
+
+  it('supports @hooks([]).defaults() chainable syntax', async () => {
+    let capturedCtx: HookContext | null = null
+
+    class TestService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          capturedCtx = ctx
+          await next()
+        }
+      ]).defaults(() => ({ timestamp: 12345 })))
+      async myMethod() {
+        return 'done'
+      }
+    }
+
+    const svc = new TestService()
+    await svc.myMethod()
+
+    expect(capturedCtx).not.toBeNull()
+    expect(capturedCtx!.timestamp).toBe(12345)
+  })
+
+  it('supports chaining multiple methods', async () => {
+    let capturedCtx: HookContext | null = null
+
+    class TestService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          capturedCtx = ctx
+          await next()
+        }
+      ])
+        .params('id', 'params')
+        .props({ service: 'messages' })
+        .defaults(() => ({ timestamp: 99999 })))
+      async status(id: string, params: any) {
+        return { id, status: 'active' }
+      }
+    }
+
+    const svc = new TestService()
+    const result = await svc.status('456', { user: 'test' })
+
+    expect(result).toEqual({ id: '456', status: 'active' })
+    expect(capturedCtx).not.toBeNull()
+    expect(capturedCtx!.id).toBe('456')
+    expect(capturedCtx!.params).toEqual({ user: 'test' })
+    expect(capturedCtx!.service).toBe('messages')
+    expect(capturedCtx!.timestamp).toBe(99999)
+  })
+
+  it('works with empty middleware array', async () => {
+    class TestService {
+      @(hooks([]).params('message'))
+      async process(message: string) {
+        return { processed: message }
+      }
+    }
+
+    const svc = new TestService()
+    const result = await svc.process('hello')
+
+    expect(result).toEqual({ processed: 'hello' })
+  })
+
+  it('chainable decorator still works as regular decorator', async () => {
+    const calls: string[] = []
+
+    class TestService {
+      @hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          calls.push('hook ran')
+          await next()
+        }
+      ])
+      async regularMethod() {
+        return 'done'
+      }
+    }
+
+    const svc = new TestService()
+    await svc.regularMethod()
+
+    expect(calls).toEqual(['hook ran'])
+  })
+})
+
 describe('feathers/hooks decorator', () => {
   it('hook decorator on method and classes with inheritance', async () => {
     const expectedName = 'David NameFromTopLevel NameFromDummyClass'

--- a/packages/feathers/src/hooks/decorator.test.ts
+++ b/packages/feathers/src/hooks/decorator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import assert from 'assert'
 import { HookContext, hooks, middleware, NextFunction } from './index.js'
+import { feathers } from '../index.js'
 
 describe('feathers/hooks chainable decorator', () => {
   it('supports @hooks([]).params() chainable syntax', async () => {
@@ -201,5 +202,155 @@ describe('feathers/hooks decorator', () => {
 
   it('error cases', () => {
     expect(() => hooks([])({}, 'test', { value: 'not a function' })).toThrow('Can not apply hooks.')
+  })
+})
+
+describe('hookMixin respects @hooks().params()', () => {
+  it('uses custom params from @hooks().params() instead of defaults', async () => {
+    let capturedCtx: HookContext | null = null
+
+    class MessageService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          capturedCtx = ctx
+          await next()
+        }
+      ]).params('message', 'options'))
+      async create(message: string, options?: any) {
+        return { message, options }
+      }
+    }
+
+    const app = feathers().use('messages', new MessageService(), {
+      methods: ['create']
+    })
+
+    const result = await app.service('messages').create('Hello world', { notify: true })
+
+    expect(result).toEqual({ message: 'Hello world', options: { notify: true } })
+    expect(capturedCtx).not.toBeNull()
+    // The context should have message and options, NOT the default data/params
+    expect(capturedCtx!.message).toBe('Hello world')
+    expect(capturedCtx!.options).toEqual({ notify: true })
+    // These should be undefined since we're using custom params
+    expect(capturedCtx!.data).toBeUndefined()
+  })
+
+  it('falls back to default params when @hooks().params() is not used', async () => {
+    let capturedCtx: HookContext | null = null
+
+    class MessageService {
+      @hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          capturedCtx = ctx
+          await next()
+        }
+      ])
+      async create(data: any, params?: any) {
+        return data
+      }
+    }
+
+    const app = feathers().use('messages', new MessageService(), {
+      methods: ['create']
+    })
+
+    const result = await app.service('messages').create({ text: 'Hello' }, { user: 'test' })
+
+    expect(result).toEqual({ text: 'Hello' })
+    expect(capturedCtx).not.toBeNull()
+    // Should use default create params: data, params
+    expect(capturedCtx!.data).toEqual({ text: 'Hello' })
+    expect(capturedCtx!.params).toEqual({ user: 'test' })
+  })
+
+  it('respects custom params for custom methods', async () => {
+    let capturedCtx: HookContext | null = null
+
+    class NotificationService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          capturedCtx = ctx
+          await next()
+        }
+      ]).params('userId', 'message', 'priority'))
+      async notify(userId: string, message: string, priority: number) {
+        return { userId, message, priority, sent: true }
+      }
+    }
+
+    const app = feathers().use('notifications', new NotificationService(), {
+      methods: ['notify']
+    })
+
+    const result = await app.service('notifications').notify('user123', 'You have mail', 1)
+
+    expect(result).toEqual({ userId: 'user123', message: 'You have mail', priority: 1, sent: true })
+    expect(capturedCtx).not.toBeNull()
+    expect(capturedCtx!.userId).toBe('user123')
+    expect(capturedCtx!.message).toBe('You have mail')
+    expect(capturedCtx!.priority).toBe(1)
+  })
+
+  it('allows hooks to modify custom params before method execution', async () => {
+    class GreetingService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          // Modify the name before method runs
+          ctx.name = ctx.name.toUpperCase()
+          await next()
+        }
+      ]).params('name'))
+      async greet(name: string) {
+        return `Hello, ${name}!`
+      }
+    }
+
+    const app = feathers().use('greetings', new GreetingService(), {
+      methods: ['greet']
+    })
+
+    const result = await app.service('greetings').greet('david')
+
+    expect(result).toBe('Hello, DAVID!')
+  })
+
+  it('works with chained params, props, and defaults on registered service', async () => {
+    let capturedCtx: HookContext | null = null
+
+    class StatusService {
+      @(hooks([
+        async (ctx: HookContext, next: NextFunction) => {
+          capturedCtx = ctx
+          await next()
+        }
+      ])
+        .params('id', 'options')
+        .props({ serviceName: 'status' })
+        .defaults(() => ({ timestamp: 99999 })))
+      async check(id: string, options?: any) {
+        return { id, status: 'ok' }
+      }
+    }
+
+    const app = feathers().use('status', new StatusService(), {
+      methods: ['check']
+    })
+
+    const result = await app.service('status').check('server-1', { verbose: true })
+
+    expect(result).toEqual({ id: 'server-1', status: 'ok' })
+    expect(capturedCtx).not.toBeNull()
+    // Custom params
+    expect(capturedCtx!.id).toBe('server-1')
+    expect(capturedCtx!.options).toEqual({ verbose: true })
+    // Props from .props()
+    expect(capturedCtx!.serviceName).toBe('status')
+    // Defaults from .defaults()
+    expect(capturedCtx!.timestamp).toBe(99999)
+    // Service-level props added by hookMixin
+    expect(capturedCtx!.app).toBe(app)
+    expect(capturedCtx!.path).toBe('status')
+    expect(capturedCtx!.method).toBe('check')
   })
 })

--- a/packages/feathers/src/hooks/decorator.test.ts
+++ b/packages/feathers/src/hooks/decorator.test.ts
@@ -87,7 +87,7 @@ describe('feathers/hooks chainable decorator', () => {
         .params('id', 'params')
         .props({ service: 'messages' })
         .defaults(() => ({ timestamp: 99999 })))
-      async status(id: string, params: any) {
+      async status(id: string, _params: any) {
         return { id, status: 'active' }
       }
     }
@@ -246,7 +246,7 @@ describe('hookMixin respects @hooks().params()', () => {
           await next()
         }
       ])
-      async create(data: any, params?: any) {
+      async create(data: any, _params?: any) {
         return data
       }
     }
@@ -328,7 +328,7 @@ describe('hookMixin respects @hooks().params()', () => {
         .params('id', 'options')
         .props({ serviceName: 'status' })
         .defaults(() => ({ timestamp: 99999 })))
-      async check(id: string, options?: any) {
+      async check(id: string, _options?: any) {
         return { id, status: 'ok' }
       }
     }

--- a/packages/feathers/src/hooks/hooks.ts
+++ b/packages/feathers/src/hooks/hooks.ts
@@ -117,9 +117,13 @@ export function objectHooks(obj: any, hooks: HookMap | AsyncMiddleware[]) {
  * @hooks([]).params('id', 'data')
  * async myMethod(id: string, data: any) {}
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFunction = (...args: any[]) => any
+
 export interface ChainableHookDecorator {
-  // Callable as a decorator
-  (target: any, context: DecoratorContext): any
+  // Callable as a class or method decorator
+  <T extends AnyFunction>(target: T, context: ClassDecoratorContext): T
+  <T extends AnyFunction>(target: T, context: ClassMethodDecoratorContext): T
 
   // Chainable methods that return a new decorator
   params(...params: string[]): ChainableHookDecorator
@@ -128,47 +132,37 @@ export interface ChainableHookDecorator {
 }
 
 function createChainableDecorator(manager: HookManager): ChainableHookDecorator {
-  const decorator = (target: any, context: DecoratorContext) => {
+  const decorator = <T extends AnyFunction>(
+    target: T,
+    context: ClassDecoratorContext | ClassMethodDecoratorContext
+  ): T => {
     if (context.kind === 'class') {
-      setManager(target.prototype, manager)
+      setManager((target as any).prototype, manager)
       return target
     } else if (context.kind === 'method') {
       const method = String(context.name)
-      return functionHooks(target, manager.props({ method }))
+      return functionHooks(target, manager.props({ method })) as T
     }
 
     throw new Error('Can not apply hooks.')
   }
 
-  // Add chainable methods
-  decorator.params = (...params: string[]) => {
-    const newManager = new HookManager()
-    newManager._parent = manager._parent
-    newManager._middleware = manager._middleware
-    newManager._props = manager._props ? { ...manager._props } : null
-    newManager._defaults = manager._defaults
-    newManager._params = params
-    return createChainableDecorator(newManager)
+  decorator.params = (...params: string[]): ChainableHookDecorator => {
+    const clone = manager.clone()
+    clone._params = params
+    return createChainableDecorator(clone)
   }
 
-  decorator.props = (props: HookContextData) => {
-    const newManager = new HookManager()
-    newManager._parent = manager._parent
-    newManager._middleware = manager._middleware
-    newManager._params = manager._params
-    newManager._defaults = manager._defaults
-    newManager._props = manager._props ? { ...manager._props, ...props } : { ...props }
-    return createChainableDecorator(newManager)
+  decorator.props = (props: HookContextData): ChainableHookDecorator => {
+    const clone = manager.clone()
+    clone._props = clone._props ? { ...clone._props, ...props } : { ...props }
+    return createChainableDecorator(clone)
   }
 
-  decorator.defaults = (defaults: HookDefaultsInitializer) => {
-    const newManager = new HookManager()
-    newManager._parent = manager._parent
-    newManager._middleware = manager._middleware
-    newManager._params = manager._params
-    newManager._props = manager._props ? { ...manager._props } : null
-    newManager._defaults = defaults
-    return createChainableDecorator(newManager)
+  decorator.defaults = (defaults: HookDefaultsInitializer): ChainableHookDecorator => {
+    const clone = manager.clone()
+    clone._defaults = defaults
+    return createChainableDecorator(clone)
   }
 
   return decorator as ChainableHookDecorator

--- a/packages/feathers/src/hooks/hooks.ts
+++ b/packages/feathers/src/hooks/hooks.ts
@@ -147,23 +147,14 @@ function createChainableDecorator(manager: HookManager): ChainableHookDecorator 
     throw new Error('Can not apply hooks.')
   }
 
-  decorator.params = (...params: string[]): ChainableHookDecorator => {
-    const clone = manager.clone()
-    clone._params = params
-    return createChainableDecorator(clone)
-  }
+  decorator.params = (...params: string[]): ChainableHookDecorator =>
+    createChainableDecorator(manager.clone().params(...params))
 
-  decorator.props = (props: HookContextData): ChainableHookDecorator => {
-    const clone = manager.clone()
-    clone._props = clone._props ? { ...clone._props, ...props } : { ...props }
-    return createChainableDecorator(clone)
-  }
+  decorator.props = (props: HookContextData): ChainableHookDecorator =>
+    createChainableDecorator(manager.clone().props(props))
 
-  decorator.defaults = (defaults: HookDefaultsInitializer): ChainableHookDecorator => {
-    const clone = manager.clone()
-    clone._defaults = defaults
-    return createChainableDecorator(clone)
-  }
+  decorator.defaults = (defaults: HookDefaultsInitializer): ChainableHookDecorator =>
+    createChainableDecorator(manager.clone().defaults(defaults))
 
   return decorator as ChainableHookDecorator
 }

--- a/packages/feathers/src/hooks/hooks.ts
+++ b/packages/feathers/src/hooks/hooks.ts
@@ -3,6 +3,8 @@ import {
   convertOptions,
   HookContext,
   HookContextData,
+  HookDefaultsInitializer,
+  HookManager,
   HookOptions,
   setManager,
   setMiddleware
@@ -102,10 +104,31 @@ export function objectHooks(obj: any, hooks: HookMap | AsyncMiddleware[]) {
   return obj
 }
 
-export const hookDecorator = (managerOrMiddleware?: HookOptions) => {
-  return (target: any, context: DecoratorContext) => {
-    const manager = convertOptions(managerOrMiddleware)
+/**
+ * A chainable decorator that can be used with or without chaining.
+ *
+ * @example
+ * // Without chaining
+ * @hooks([middleware])
+ * async myMethod() {}
+ *
+ * @example
+ * // With chaining
+ * @hooks([]).params('id', 'data')
+ * async myMethod(id: string, data: any) {}
+ */
+export interface ChainableHookDecorator {
+  // Callable as a decorator
+  (target: any, context: DecoratorContext): any
 
+  // Chainable methods that return a new decorator
+  params(...params: string[]): ChainableHookDecorator
+  props(props: HookContextData): ChainableHookDecorator
+  defaults(defaults: HookDefaultsInitializer): ChainableHookDecorator
+}
+
+function createChainableDecorator(manager: HookManager): ChainableHookDecorator {
+  const decorator = (target: any, context: DecoratorContext) => {
     if (context.kind === 'class') {
       setManager(target.prototype, manager)
       return target
@@ -116,4 +139,42 @@ export const hookDecorator = (managerOrMiddleware?: HookOptions) => {
 
     throw new Error('Can not apply hooks.')
   }
+
+  // Add chainable methods
+  decorator.params = (...params: string[]) => {
+    const newManager = new HookManager()
+    newManager._parent = manager._parent
+    newManager._middleware = manager._middleware
+    newManager._props = manager._props ? { ...manager._props } : null
+    newManager._defaults = manager._defaults
+    newManager._params = params
+    return createChainableDecorator(newManager)
+  }
+
+  decorator.props = (props: HookContextData) => {
+    const newManager = new HookManager()
+    newManager._parent = manager._parent
+    newManager._middleware = manager._middleware
+    newManager._params = manager._params
+    newManager._defaults = manager._defaults
+    newManager._props = manager._props ? { ...manager._props, ...props } : { ...props }
+    return createChainableDecorator(newManager)
+  }
+
+  decorator.defaults = (defaults: HookDefaultsInitializer) => {
+    const newManager = new HookManager()
+    newManager._parent = manager._parent
+    newManager._middleware = manager._middleware
+    newManager._params = manager._params
+    newManager._props = manager._props ? { ...manager._props } : null
+    newManager._defaults = defaults
+    return createChainableDecorator(newManager)
+  }
+
+  return decorator as ChainableHookDecorator
+}
+
+export const hookDecorator = (managerOrMiddleware?: HookOptions): ChainableHookDecorator => {
+  const manager = convertOptions(managerOrMiddleware)
+  return createChainableDecorator(manager)
 }

--- a/packages/feathers/src/hooks/index.ts
+++ b/packages/feathers/src/hooks/index.ts
@@ -1,6 +1,6 @@
 import { AsyncMiddleware } from './compose.js'
 import { HookContext, HookContextConstructor, HookContextData, HookManager, HookOptions } from './base.js'
-import { functionHooks, hookDecorator, HookMap, objectHooks } from './hooks.js'
+import { ChainableHookDecorator, functionHooks, hookDecorator, HookMap, objectHooks } from './hooks.js'
 
 export * from './hooks.js'
 export * from './compose.js'
@@ -68,9 +68,21 @@ export function hooks<O>(obj: O | (new (...args: any[]) => O), hookMap: HookMap<
 
 /**
  * Decorate a class method with hooks.
+ * Returns a chainable decorator that supports .params(), .props(), and .defaults()
+ *
+ * @example
+ * // Without chaining
+ * @hooks([middleware])
+ * async myMethod() {}
+ *
+ * @example
+ * // With chaining for custom params
+ * @hooks([]).params('id', 'data')
+ * async myMethod(id: string, data: any) {}
+ *
  * @param manager The hooks settings
  */
-export function hooks<_T = any>(manager?: HookOptions): any
+export function hooks<_T = any>(manager?: HookOptions): ChainableHookDecorator
 
 // Fallthrough to actual implementation
 export function hooks(...args: any[]) {

--- a/website/content/api/hooks-chainable-params.md
+++ b/website/content/api/hooks-chainable-params.md
@@ -35,8 +35,8 @@ import { hooks, HookContext, NextFunction } from '@feathersjs/feathers'
 class NotificationService {
   @(hooks([
     async (context: HookContext, next: NextFunction) => {
-      console.log(context.userId)   // 'user123'
-      console.log(context.message)  // 'Hello!'
+      console.log(context.userId) // 'user123'
+      console.log(context.message) // 'Hello!'
       console.log(context.priority) // 1
       await next()
     }
@@ -81,9 +81,9 @@ All chainable methods can be combined:
 class StatusService {
   @(hooks([
     async (context: HookContext, next: NextFunction) => {
-      console.log(context.id)          // from params
+      console.log(context.id) // from params
       console.log(context.serviceName) // from props
-      console.log(context.timestamp)   // from defaults
+      console.log(context.timestamp) // from defaults
       await next()
     }
   ])
@@ -109,13 +109,13 @@ class MessageService {
       // Custom params from decorator
       console.log(context.recipientId)
       console.log(context.content)
-      
+
       // Feathers context (automatically added)
       console.log(context.app)
-      console.log(context.path)    // 'messages'
+      console.log(context.path) // 'messages'
       console.log(context.service)
-      console.log(context.method)  // 'send'
-      
+      console.log(context.method) // 'send'
+
       await next()
     }
   ]).params('recipientId', 'content'))

--- a/website/content/api/hooks-chainable-params.md
+++ b/website/content/api/hooks-chainable-params.md
@@ -1,0 +1,180 @@
+<!--
+  PENDING INTEGRATION: This documentation is for a new feature added in the
+  hooks-chainable-params branch. It should be integrated into the main hooks.md
+  documentation during the v6-documentation rewrite.
+-->
+
+# Chainable Hook Decorator with Custom Params
+
+This document covers the chainable `@hooks()` decorator syntax that allows defining custom method parameters for hook context.
+
+## Overview
+
+By default, Feathers service methods use predefined parameter names in the hook context:
+
+- `find`: `params`
+- `get`: `id`, `params`
+- `create`: `data`, `params`
+- `update`: `id`, `data`, `params`
+- `patch`: `id`, `data`, `params`
+- `remove`: `id`, `params`
+
+The chainable `@hooks()` decorator allows you to define custom parameter names for methods that don't follow these conventions, such as custom service methods with unique signatures.
+
+## Chainable Syntax
+
+The `@hooks()` decorator returns a chainable object with the following methods:
+
+### `.params(...names)`
+
+Defines the parameter names that will be available on the hook context.
+
+```ts
+import { hooks, HookContext, NextFunction } from '@feathersjs/feathers'
+
+class NotificationService {
+  @(hooks([
+    async (context: HookContext, next: NextFunction) => {
+      console.log(context.userId)   // 'user123'
+      console.log(context.message)  // 'Hello!'
+      console.log(context.priority) // 1
+      await next()
+    }
+  ]).params('userId', 'message', 'priority'))
+  async notify(userId: string, message: string, priority: number) {
+    return { sent: true }
+  }
+}
+```
+
+### `.props(properties)`
+
+Adds static properties to the hook context.
+
+```ts
+class MyService {
+  @(hooks([]).props({ serviceName: 'notifications', version: 2 }))
+  async process(data: any) {
+    return data
+  }
+}
+```
+
+### `.defaults(initializer)`
+
+Provides default values for the hook context via an initializer function.
+
+```ts
+class MyService {
+  @(hooks([]).defaults(() => ({ timestamp: Date.now() })))
+  async process(data: any) {
+    return data
+  }
+}
+```
+
+### Chaining Multiple Methods
+
+All chainable methods can be combined:
+
+```ts
+class StatusService {
+  @(hooks([
+    async (context: HookContext, next: NextFunction) => {
+      console.log(context.id)          // from params
+      console.log(context.serviceName) // from props
+      console.log(context.timestamp)   // from defaults
+      await next()
+    }
+  ])
+    .params('id', 'options')
+    .props({ serviceName: 'status' })
+    .defaults(() => ({ timestamp: Date.now() })))
+  async check(id: string, options?: any) {
+    return { id, status: 'ok' }
+  }
+}
+```
+
+## Using with Feathers Services
+
+When a class with decorated methods is registered as a Feathers service, the custom params are preserved and Feathers-specific context properties (`app`, `path`, `service`, `method`) are automatically added.
+
+```ts
+import { feathers, hooks, HookContext, NextFunction } from '@feathersjs/feathers'
+
+class MessageService {
+  @(hooks([
+    async (context: HookContext, next: NextFunction) => {
+      // Custom params from decorator
+      console.log(context.recipientId)
+      console.log(context.content)
+      
+      // Feathers context (automatically added)
+      console.log(context.app)
+      console.log(context.path)    // 'messages'
+      console.log(context.service)
+      console.log(context.method)  // 'send'
+      
+      await next()
+    }
+  ]).params('recipientId', 'content'))
+  async send(recipientId: string, content: string) {
+    return { sent: true, to: recipientId }
+  }
+}
+
+const app = feathers()
+
+app.use('messages', new MessageService(), {
+  methods: ['send']
+})
+
+// Call the service
+await app.service('messages').send('user123', 'Hello!')
+```
+
+## Modifying Custom Params in Hooks
+
+Just like standard params (`data`, `id`, etc.), custom params can be modified in hooks:
+
+```ts
+class GreetingService {
+  @(hooks([
+    async (context: HookContext, next: NextFunction) => {
+      // Transform the name before the method runs
+      context.name = context.name.toUpperCase()
+      await next()
+    }
+  ]).params('name'))
+  async greet(name: string) {
+    return `Hello, ${name}!`
+  }
+}
+
+const service = new GreetingService()
+await service.greet('david') // Returns: "Hello, DAVID!"
+```
+
+## Backward Compatibility
+
+The decorator continues to work without chaining for standard usage:
+
+```ts
+// These are equivalent
+@hooks([myHook])
+async myMethod() {}
+
+@(hooks([myHook]))
+async myMethod() {}
+```
+
+## When to Use Custom Params
+
+Custom params are useful when:
+
+1. **Custom service methods** have signatures that don't match standard CRUD operations
+2. **Internal methods** need specific parameter handling
+3. **Integration with external systems** requires non-standard method signatures
+
+For standard service methods (`find`, `get`, `create`, `update`, `patch`, `remove`), the default params work automatically and don't need to be specified.


### PR DESCRIPTION
## Summary

Adds a chainable `@hooks().params()` decorator syntax that allows defining custom parameter names for hook context on service methods. When registered as a Feathers service, `hookMixin` respects these custom params instead of overriding them with defaults.

## Usage

```ts
class NotificationService {
  @(hooks([
    async (ctx, next) => {
      console.log(ctx.userId)   // Custom param
      console.log(ctx.message)  // Custom param  
      console.log(ctx.app)      // Feathers context still available
      await next()
    }
  ]).params('userId', 'message'))
  async notify(userId: string, message: string) {
    return { sent: true }
  }
}

const app = feathers().use('notifications', new NotificationService(), {
  methods: ['notify']
})

await app.service('notifications').notify('user123', 'Hello!')
```

## Chainable Methods

- `.params(...names)` - Define context parameter names
- `.props(properties)` - Add static properties to context
- `.defaults(initializer)` - Provide default values via function

All can be chained:
```ts
@(hooks([])
  .params('id', 'data')
  .props({ serviceName: 'messages' })
  .defaults(() => ({ timestamp: Date.now() })))
```

## Changes

- **`packages/feathers/src/hooks/base.ts`** - Added `clone()` method to `HookManager`
- **`packages/feathers/src/hooks/hooks.ts`** - Added `ChainableHookDecorator` interface and `createChainableDecorator()`
- **`packages/feathers/src/hooks.ts`** - Modified `hookMixin()` to detect and respect custom params from decorators
- **`packages/feathers/src/hooks/decorator.test.ts`** - Added 11 new tests
- **`website/content/api/hooks-chainable-params.md`** - Documentation (pending integration into docs rewrite)

## Why

Previously, custom service methods were limited to the default hook context params (`data`, `params`, `id`). If you had a method like `notify(userId, message)`, hooks would receive `ctx.data` and `ctx.params` instead of `ctx.userId` and `ctx.message`.

This change allows:
- Custom methods to have meaningful, descriptive context properties
- Hooks to work naturally with any method signature
- Better developer experience when building services with non-CRUD methods

Based on [this comment](https://github.com/feathersjs/feathers/pull/3638#issuecomment-2572569338).