### PR TITLE
chore: Replace events npm package with native ESM EventEmitter implementation

### DIFF
--- a/packages/feathers/package.json
+++ b/packages/feathers/package.json
@@ -90,7 +90,6 @@
   },
   "dependencies": {
     "@types/qs": "^6.14.0",
-    "events": "^3.3.0",
     "qs": "^6.14.0"
   },
   "devDependencies": {

--- a/packages/feathers/src/application.ts
+++ b/packages/feathers/src/application.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import { EventEmitter } from './events.js'
 import { HOOKS, hooks, middleware } from './hooks/index.js'
 
 import { stripSlashes } from './commons.js'

--- a/packages/feathers/src/channel/base.ts
+++ b/packages/feathers/src/channel/base.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import { EventEmitter } from '../events.js'
 import { RealTimeConnection } from '../declarations.js'
 
 export class Channel extends EventEmitter {

--- a/packages/feathers/src/declarations.ts
+++ b/packages/feathers/src/declarations.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import { EventEmitter } from './events.js'
 import type { Router } from './router.js'
 import { NextFunction, HookContext as BaseHookContext } from './hooks/index.js'
 
@@ -537,7 +537,7 @@ export type Publisher<T = any, A = Application, S = any> = (
   context: HookContext<A, S>
 ) => Channel | Channel[] | void | Promise<Channel | Channel[] | void>
 
-export interface Channel {
+export interface Channel extends EventEmitter {
   connections: RealTimeConnection[]
   data: any
   length: number

--- a/packages/feathers/src/events.test.ts
+++ b/packages/feathers/src/events.test.ts
@@ -1,8 +1,212 @@
-import { describe, it } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import assert from 'assert'
-import { EventEmitter } from 'events'
-
+import { EventEmitter } from '../src/events.js'
 import { feathers } from '../src/index.js'
+
+describe('EventEmitter', () => {
+  it('on and emit', () => {
+    const emitter = new EventEmitter()
+    const callback = vi.fn()
+
+    emitter.on('test', callback)
+    emitter.emit('test', 'a', 'b')
+
+    expect(callback).toHaveBeenCalledWith('a', 'b')
+  })
+
+  it('emit returns false when no listeners', () => {
+    const emitter = new EventEmitter()
+    expect(emitter.emit('test')).toBe(false)
+  })
+
+  it('emit returns true when listeners exist', () => {
+    const emitter = new EventEmitter()
+    emitter.on('test', () => {})
+    expect(emitter.emit('test')).toBe(true)
+  })
+
+  it('addListener is an alias for on', () => {
+    const emitter = new EventEmitter()
+    const callback = vi.fn()
+
+    emitter.addListener('test', callback)
+    emitter.emit('test', 'data')
+
+    expect(callback).toHaveBeenCalledWith('data')
+  })
+
+  it('once fires only once', () => {
+    const emitter = new EventEmitter()
+    const callback = vi.fn()
+
+    emitter.once('test', callback)
+    emitter.emit('test', 'first')
+    emitter.emit('test', 'second')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('first')
+  })
+
+  it('off removes a listener', () => {
+    const emitter = new EventEmitter()
+    const callback = vi.fn()
+
+    emitter.on('test', callback)
+    emitter.off('test', callback)
+    emitter.emit('test')
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('removeListener removes a listener', () => {
+    const emitter = new EventEmitter()
+    const callback = vi.fn()
+
+    emitter.on('test', callback)
+    emitter.removeListener('test', callback)
+    emitter.emit('test')
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('removeListener can remove a once listener by original reference', () => {
+    const emitter = new EventEmitter()
+    const callback = vi.fn()
+
+    emitter.once('test', callback)
+    emitter.removeListener('test', callback)
+    emitter.emit('test')
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('removeAllListeners for a specific event', () => {
+    const emitter = new EventEmitter()
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+    const cb3 = vi.fn()
+
+    emitter.on('a', cb1)
+    emitter.on('a', cb2)
+    emitter.on('b', cb3)
+
+    emitter.removeAllListeners('a')
+    emitter.emit('a')
+    emitter.emit('b')
+
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).not.toHaveBeenCalled()
+    expect(cb3).toHaveBeenCalled()
+  })
+
+  it('removeAllListeners with no argument removes all', () => {
+    const emitter = new EventEmitter()
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+
+    emitter.on('a', cb1)
+    emitter.on('b', cb2)
+
+    emitter.removeAllListeners()
+    emitter.emit('a')
+    emitter.emit('b')
+
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).not.toHaveBeenCalled()
+  })
+
+  it('listenerCount returns correct count', () => {
+    const emitter = new EventEmitter()
+
+    expect(emitter.listenerCount('test')).toBe(0)
+
+    emitter.on('test', () => {})
+    emitter.on('test', () => {})
+    expect(emitter.listenerCount('test')).toBe(2)
+  })
+
+  it('listeners returns a copy of the listener array', () => {
+    const emitter = new EventEmitter()
+    const cb = () => {}
+
+    emitter.on('test', cb)
+
+    const result = emitter.listeners('test')
+    expect(result).toEqual([cb])
+    expect(result).not.toBe((emitter as any).__events['test'])
+  })
+
+  it('listeners returns empty array for unknown event', () => {
+    const emitter = new EventEmitter()
+    expect(emitter.listeners('nope')).toEqual([])
+  })
+
+  it('multiple listeners fire in order', () => {
+    const emitter = new EventEmitter()
+    const order: number[] = []
+
+    emitter.on('test', () => order.push(1))
+    emitter.on('test', () => order.push(2))
+    emitter.on('test', () => order.push(3))
+    emitter.emit('test')
+
+    expect(order).toEqual([1, 2, 3])
+  })
+
+  it('removing a listener during emit does not skip others', () => {
+    const emitter = new EventEmitter()
+    const cb1 = vi.fn(() => emitter.removeListener('test', cb1))
+    const cb2 = vi.fn()
+
+    emitter.on('test', cb1)
+    emitter.on('test', cb2)
+    emitter.emit('test')
+
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+  })
+
+  it('works as a base class', () => {
+    class MyService extends EventEmitter {
+      value = 42
+    }
+
+    const svc = new MyService()
+    const callback = vi.fn()
+
+    svc.on('created', callback)
+    svc.emit('created', { id: 1 })
+
+    expect(callback).toHaveBeenCalledWith({ id: 1 })
+    expect(svc.value).toBe(42)
+  })
+
+  it('prototype methods can be mixed in via Object.assign', () => {
+    const obj: any = {}
+    Object.assign(obj, EventEmitter.prototype)
+
+    const callback = vi.fn()
+    obj.on('test', callback)
+    obj.emit('test', 'hello')
+
+    expect(callback).toHaveBeenCalledWith('hello')
+  })
+
+  it('chaining works on all mutating methods', () => {
+    const emitter = new EventEmitter()
+    const cb = () => {}
+
+    const result = emitter
+      .on('a', cb)
+      .addListener('b', cb)
+      .once('c', cb)
+      .off('a', cb)
+      .removeListener('b', cb)
+      .removeAllListeners('c')
+
+    expect(result).toBe(emitter)
+  })
+})
 
 describe('Service events', () => {
   it('app is an event emitter', async () => {

--- a/packages/feathers/src/events.ts
+++ b/packages/feathers/src/events.ts
@@ -11,11 +11,8 @@ function getEvents(self: any): Record<string, Listener[]> {
   return self.__events
 }
 
-export class EventEmitter {
-  __events: Record<string, Listener[]> = {}
-}
-
 export interface EventEmitter {
+  __events: Record<string, Listener[]>
   on(event: string, listener: Listener): this
   addListener(event: string, listener: Listener): this
   once(event: string, listener: Listener): this
@@ -26,6 +23,15 @@ export interface EventEmitter {
   listenerCount(event: string): number
   listeners(event: string): Listener[]
 }
+
+interface EventEmitterConstructor {
+  new (): EventEmitter
+  prototype: EventEmitter
+}
+
+export const EventEmitter = function (this: EventEmitter) {
+  this.__events = {}
+} as unknown as EventEmitterConstructor
 
 EventEmitter.prototype.on = function (event: string, listener: Listener) {
   const events = getEvents(this)

--- a/packages/feathers/src/events.ts
+++ b/packages/feathers/src/events.ts
@@ -1,7 +1,100 @@
-import { EventEmitter } from 'events'
 import { NextFunction } from './hooks/index.js'
 import { HookContext, FeathersService } from './declarations.js'
 import { getServiceOptions, defaultEventMap } from './service.js'
+
+export type Listener = (...args: any[]) => void
+
+function getEvents(self: any): Record<string, Listener[]> {
+  if (!self.__events) {
+    self.__events = {}
+  }
+  return self.__events
+}
+
+export class EventEmitter {
+  __events: Record<string, Listener[]> = {}
+}
+
+export interface EventEmitter {
+  on(event: string, listener: Listener): this
+  addListener(event: string, listener: Listener): this
+  once(event: string, listener: Listener): this
+  off(event: string, listener: Listener): this
+  removeListener(event: string, listener: Listener): this
+  removeAllListeners(event?: string): this
+  emit(event: string, ...args: any[]): boolean
+  listenerCount(event: string): number
+  listeners(event: string): Listener[]
+}
+
+EventEmitter.prototype.on = function (event: string, listener: Listener) {
+  const events = getEvents(this)
+  if (!events[event]) {
+    events[event] = []
+  }
+  events[event].push(listener)
+  return this
+}
+
+EventEmitter.prototype.addListener = function (event: string, listener: Listener) {
+  return this.on(event, listener)
+}
+
+EventEmitter.prototype.once = function (event: string, listener: Listener) {
+  const wrapped = (...args: any[]) => {
+    this.removeListener(event, wrapped)
+    listener.apply(this, args)
+  }
+  wrapped.listener = listener
+  return this.on(event, wrapped)
+}
+
+EventEmitter.prototype.off = function (event: string, listener: Listener) {
+  return this.removeListener(event, listener)
+}
+
+EventEmitter.prototype.removeListener = function (event: string, listener: Listener) {
+  const events = getEvents(this)
+  const listeners = events[event]
+  if (listeners) {
+    events[event] = listeners.filter((l: any) => l !== listener && l.listener !== listener)
+    if (events[event].length === 0) {
+      delete events[event]
+    }
+  }
+  return this
+}
+
+EventEmitter.prototype.removeAllListeners = function (event?: string) {
+  const events = getEvents(this)
+  if (event) {
+    delete events[event]
+  } else {
+    this.__events = {}
+  }
+  return this
+}
+
+EventEmitter.prototype.emit = function (event: string, ...args: any[]): boolean {
+  const listeners = getEvents(this)[event]
+  if (!listeners || listeners.length === 0) {
+    return false
+  }
+  for (const listener of [...listeners]) {
+    listener.apply(this, args)
+  }
+  return true
+}
+
+EventEmitter.prototype.listenerCount = function (event: string): number {
+  const listeners = getEvents(this)[event]
+  return listeners ? listeners.length : 0
+}
+
+EventEmitter.prototype.listeners = function (event: string): Listener[] {
+  const listeners = getEvents(this)[event]
+  return listeners ? [...listeners] : []
+}
 
 export async function eventHook(context: HookContext, next: NextFunction) {
   const { events } = getServiceOptions((context as any).self)

--- a/packages/feathers/src/index.ts
+++ b/packages/feathers/src/index.ts
@@ -10,6 +10,7 @@ export function feathers<T = any, S = any>() {
 feathers.setDebug = setDebug
 
 export { version, Feathers }
+export { EventEmitter } from './events.js'
 export { Channel } from './channel/base.js'
 export { CombinedChannel } from './channel/combined.js'
 export * as channelUtils from './channel/mixin.js'

--- a/packages/feathers/src/service.ts
+++ b/packages/feathers/src/service.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events'
 import { createSymbol } from './commons.js'
 import { ServiceOptions } from './declarations.js'
 
@@ -24,7 +23,17 @@ export const defaultEventMap = {
 export const defaultServiceEvents = Object.values(defaultEventMap)
 
 export const protectedMethods = Object.keys(Object.prototype)
-  .concat(Object.keys(EventEmitter.prototype))
+  .concat([
+    'on',
+    'addListener',
+    'once',
+    'off',
+    'removeListener',
+    'removeAllListeners',
+    'emit',
+    'listenerCount',
+    'listeners'
+  ])
   .concat([
     'all',
     'around',


### PR DESCRIPTION
Replaces the `events` npm package (a CJS browserify polyfill) with a lightweight, pure ESM `EventEmitter` written in TypeScript. This fixes compatibility issues with Node 24's stricter ESM/CJS interop.

**Problem:**
The `events@3.3.0` npm package is CommonJS. In Node 24, the tightened CJS named export detection causes `import { EventEmitter } from 'events'` to fail when it resolves to the npm polyfill instead of the Node built-in.

**Solution:**
- Added a native ESM `EventEmitter` implementation directly in `events.ts`
- Prototype methods are assigned as enumerable properties so `Object.assign` mixin pattern continues to work
- Lazy `__events` initialization supports both class inheritance and mixin usage
- Removed the `events` npm dependency from `package.json`
- `Channel` interface now extends `EventEmitter` for proper typing

**API surface implemented:** `on`, `addListener`, `once`, `off`, `removeListener`, `removeAllListeners`, `emit`, `listenerCount`, `listeners`

**Files changed (8):**
- `packages/feathers/src/events.ts` — EventEmitter implementation + existing event hooks
- `packages/feathers/src/events.test.ts` — 18 new EventEmitter unit tests merged with existing service event tests
- `packages/feathers/src/application.ts` — import update
- `packages/feathers/src/channel/base.ts` — import update
- `packages/feathers/src/declarations.ts` — import update, `Channel` interface extends `EventEmitter`
- `packages/feathers/src/service.ts` — inlined emitter method names in `protectedMethods`
- `packages/feathers/src/index.ts` — exports `EventEmitter`
- `packages/feathers/package.json` — removed `events` dependency

**Tests:** 371 passed, 1 skipped (pre-existing). TypeScript clean.