### PR TITLE
fix(authentication-oauth): prevent open redirect via domain suffix attack

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -106,9 +106,13 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
     }
 
     // Validate redirect parameter to prevent open redirect via URL authority injection
-    // Reject characters that could change the URL's authority: @, //, \
-    // e.g., @attacker.com would make https://target.com@attacker.com redirect to attacker.com
-    if (queryRedirect && /[@\\]|^\/\/|\/\//.test(queryRedirect)) {
+    // Only allow relative paths starting with / to prevent:
+    // - @attacker.com -> https://target.com@attacker.com (authority injection)
+    // - .attacker.com -> https://target.com.attacker.com (domain suffix attack)
+    // - -attacker.com -> https://target.com-attacker.com (domain suffix attack)
+    // - //attacker.com -> protocol-relative redirect
+    // - \attacker.com -> backslash redirect
+    if (queryRedirect && (!/^\//.test(queryRedirect) || /[@\\]|\/\//.test(queryRedirect))) {
       throw new NotAuthenticated('Invalid redirect path.')
     }
 

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -86,6 +86,99 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
     })
   })
 
+  describe('open redirect via domain suffix attack', () => {
+    beforeEach(() => {
+      app.get('authentication').oauth.origins = ['https://target.com']
+    })
+
+    afterEach(() => {
+      delete app.get('authentication').oauth.origins
+    })
+
+    it('should reject redirect starting with dot (domain suffix attack)', async () => {
+      // Attack: ?redirect=.attacker.com -> https://target.com.attacker.com
+      await assert.rejects(
+        () =>
+          strategy.getRedirect(
+            { accessToken: 'testing' },
+            {
+              redirect: '.attacker.com',
+              headers: {
+                referer: 'https://target.com/login'
+              }
+            }
+          ),
+        {
+          name: 'NotAuthenticated'
+        }
+      )
+    })
+
+    it('should reject redirect starting with hyphen (domain suffix attack)', async () => {
+      // Attack: ?redirect=-attacker.com -> https://target.com-attacker.com
+      await assert.rejects(
+        () =>
+          strategy.getRedirect(
+            { accessToken: 'testing' },
+            {
+              redirect: '-attacker.com',
+              headers: {
+                referer: 'https://target.com/login'
+              }
+            }
+          ),
+        {
+          name: 'NotAuthenticated'
+        }
+      )
+    })
+
+    it('should reject redirect with bare domain', async () => {
+      // Attack: ?redirect=attacker.com -> https://target.comattacker.com
+      await assert.rejects(
+        () =>
+          strategy.getRedirect(
+            { accessToken: 'testing' },
+            {
+              redirect: 'attacker.com',
+              headers: {
+                referer: 'https://target.com/login'
+              }
+            }
+          ),
+        {
+          name: 'NotAuthenticated'
+        }
+      )
+    })
+
+    it('should allow valid relative path redirect', async () => {
+      const redirect = await strategy.getRedirect(
+        { accessToken: 'testing' },
+        {
+          redirect: '/dashboard',
+          headers: {
+            referer: 'https://target.com/login'
+          }
+        }
+      )
+      assert.equal(redirect, 'https://target.com/dashboard#access_token=testing')
+    })
+
+    it('should allow relative path with query string', async () => {
+      const redirect = await strategy.getRedirect(
+        { accessToken: 'testing' },
+        {
+          redirect: '/callback?state=abc',
+          headers: {
+            referer: 'https://target.com/login'
+          }
+        }
+      )
+      assert.ok(redirect!.startsWith('https://target.com/callback?state=abc'))
+    })
+  })
+
   describe('origin validation bypass via startsWith', () => {
     beforeEach(() => {
       app.get('authentication').oauth.origins = ['https://target.com']


### PR DESCRIPTION
## Summary

- Fixes incomplete validation of the `redirect` query parameter in OAuth strategy
- The existing regex blocks `@`, `\`, and `//` but allows domain suffix attacks via `.` and `-` characters
- Example: `?redirect=.attacker.com` produces `https://target.com.attacker.com`, leaking the OAuth access token to an attacker-controlled domain

## Changes

- **strategy.ts**: Require `queryRedirect` to start with `/` (relative path only), preventing all URL authority manipulation attacks
- **strategy.test.ts**: Add 5 test cases covering domain suffix attacks (`.attacker.com`, `-attacker.com`, bare domain) and valid relative path redirects

## Attack Vector

1. Attacker crafts: `GET /oauth/google?redirect=.attacker.com`
2. After OAuth callback, redirect becomes: `https://target.com.attacker.com#access_token=JWT_TOKEN`
3. If attacker registers `target.com.attacker.com`, they receive the victim's access token
4. Result: Full account takeover

## Test plan

- [x] Existing `@`, `\\`, `//` rejection tests still pass
- [x] New `.attacker.com` domain suffix attack is rejected
- [x] New `-attacker.com` domain suffix attack is rejected
- [x] New bare `attacker.com` redirect is rejected
- [x] Valid relative paths (`/dashboard`, `/callback?state=abc`) still work

Related to the fix in #3663 (CVE-2026-27191).