### PR TITLE
fix(authentication-oauth): Use actual URL origin comparison for origin check

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -144,11 +144,11 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
       return null
     }
 
-    const redirectUrl = `${redirect}${queryRedirect}`
-
     if (queryRedirect) {
       validateRedirectOrigin(redirect, queryRedirect)
     }
+
+    const redirectUrl = `${redirect}${queryRedirect}`
     const separator = redirectUrl.endsWith('?') ? '' : redirect.indexOf('#') !== -1 ? '?' : '#'
     const authResult: AuthenticationResult = data
     const query = authResult.accessToken

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -11,6 +11,45 @@ import qs from 'qs'
 
 const debug = createDebug('@feathersjs/authentication-oauth/strategy')
 
+/**
+ * Validates that appending a user-supplied path to a base URL does not change the origin.
+ * Uses both URL resolution and string concatenation checks to catch all open redirect vectors:
+ * authority injection (@), protocol-relative (//), backslash, and domain suffix attacks.
+ *
+ * @throws NotAuthenticated if the redirect path would change the URL origin
+ */
+function validateRedirectOrigin(baseUrl: string, redirectPath: string) {
+  let allowedOrigin: string
+
+  try {
+    allowedOrigin = new URL(baseUrl).origin
+  } catch {
+    // baseUrl is a relative path (e.g. /home) — no open redirect risk
+    return
+  }
+
+  try {
+    // URL resolution catches protocol-relative (//) and backslash attacks
+    // e.g. new URL('//attacker.com', 'https://target.com') → https://attacker.com
+    const resolvedUrl = new URL(redirectPath, baseUrl)
+
+    if (resolvedUrl.origin !== allowedOrigin) {
+      throw new NotAuthenticated('Invalid redirect path.')
+    }
+
+    // String concatenation check catches domain suffix attacks
+    // e.g. 'https://target.com' + '.evil.com' → https://target.com.evil.com
+    const concatenatedUrl = new URL(`${baseUrl}${redirectPath}`)
+
+    if (concatenatedUrl.origin !== allowedOrigin) {
+      throw new NotAuthenticated('Invalid redirect path.')
+    }
+  } catch (error: any) {
+    if (error instanceof NotAuthenticated) throw error
+    throw new NotAuthenticated('Invalid redirect path.')
+  }
+}
+
 export interface OAuthProfile {
   id?: string | number
   [key: string]: any
@@ -105,18 +144,11 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
       return null
     }
 
-    // Validate redirect parameter to prevent open redirect via URL authority injection
-    // Only allow relative paths starting with / to prevent:
-    // - @attacker.com -> https://target.com@attacker.com (authority injection)
-    // - .attacker.com -> https://target.com.attacker.com (domain suffix attack)
-    // - -attacker.com -> https://target.com-attacker.com (domain suffix attack)
-    // - //attacker.com -> protocol-relative redirect
-    // - \attacker.com -> backslash redirect
-    if (queryRedirect && (!/^\//.test(queryRedirect) || /[@\\]|\/\//.test(queryRedirect))) {
-      throw new NotAuthenticated('Invalid redirect path.')
-    }
-
     const redirectUrl = `${redirect}${queryRedirect}`
+
+    if (queryRedirect) {
+      validateRedirectOrigin(redirect, queryRedirect)
+    }
     const separator = redirectUrl.endsWith('?') ? '' : redirect.indexOf('#') !== -1 ? '?' : '#'
     const authResult: AuthenticationResult = data
     const query = authResult.accessToken


### PR DESCRIPTION
This is a follow-up to https://github.com/feathersjs/feathers/pull/3653 and https://github.com/feathersjs/feathers/pull/3669 and uses the proper `URL` constructor to check the redirects instead of an arbitrary regex. Still passes all tests for existing vulnerabilities.