### PR TITLE
fix(commons): skip __proto__ / constructor / prototype keys in _.merge

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -75,6 +75,19 @@ export const _ = {
   merge(target: any, source: any) {
     if (_.isObject(target) && _.isObject(source)) {
       Object.keys(source).forEach((key) => {
+        // Skip prototype-chain-mutating keys. `Object.keys` returns
+        // `__proto__` as an own enumerable when the source object came
+        // from `JSON.parse('{"__proto__":...}')`; without this filter
+        // the recursive `_.merge(target[key], source[key])` below
+        // resolves `target['__proto__']` to `Object.prototype` and
+        // writes attacker-controlled keys onto it.
+        if (
+          key === '__proto__' ||
+          key === 'constructor' ||
+          key === 'prototype'
+        ) {
+          return
+        }
         if (_.isObject(source[key])) {
           if (!target[key]) {
             Object.assign(target, { [key]: {} })

--- a/packages/commons/test/utils.test.ts
+++ b/packages/commons/test/utils.test.ts
@@ -212,5 +212,25 @@ describe('@feathersjs/commons utils', () => {
 
       assert.equal(_.merge('hello', {}), 'hello')
     })
+
+    it('merge does not mutate Object.prototype via __proto__ keys', () => {
+      // `Object.keys` returns `__proto__` as an own enumerable key when the
+      // source object came from `JSON.parse('{"__proto__":...}')`. Without
+      // the filter in the merge implementation, the recursive call resolves
+      // `target['__proto__']` to `Object.prototype` and writes attacker-
+      // controlled keys onto it (affecting every plain object in the
+      // process).
+      const target = {} as any
+      _.merge(target, JSON.parse('{"__proto__":{"polluted":"X"}}'))
+      assert.strictEqual(({} as any).polluted, undefined)
+      assert.strictEqual((Object.prototype as any).polluted, undefined)
+      assert.strictEqual(target.polluted, undefined)
+
+      // Same protection for `constructor` and `prototype` keys (the rest
+      // of the standard prototype-mutating triad).
+      _.merge(target, JSON.parse('{"constructor":{"prototype":{"polluted2":"Y"}}}'))
+      assert.strictEqual(({} as any).polluted2, undefined)
+      assert.strictEqual((Object.prototype as any).polluted2, undefined)
+    })
   })
 })


### PR DESCRIPTION
### Summary

The recursive `_.merge` implementation in `@feathersjs/commons` iterates `Object.keys(source)` and calls `_.merge(target[key], source[key])` for nested objects. `Object.keys` returns `__proto__` as an own-enumerable key when the source object came from `JSON.parse('{"__proto__":...}')` — unlike the object-literal `{__proto__: ...}` form, JSON-parsed `__proto__` is an own enumerable property, not the prototype slot.

Without filtering those keys, the recursive call resolves `target['__proto__']` to `Object.prototype` (since it's truthy, the `if (!target[key])` branch is skipped) and writes onto it. The same shape applies to `constructor.prototype` chains.

This PR adds the standard prototype-mutating-key filter (`__proto__`, `constructor`, `prototype`) inside the iteration — the same fix lodash applies in `baseSet`, cosmiconfig applies in its `merge`, and several other widely-used libraries have landed for the same bug class.

### Diff (3 lines of substantive change)

```diff
       merge(target: any, source: any) {
         if (_.isObject(target) && _.isObject(source)) {
           Object.keys(source).forEach((key) => {
+            // Skip prototype-chain-mutating keys.
+            if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+              return
+            }
             if (_.isObject(source[key])) {
               if (!target[key]) {
                 Object.assign(target, { [key]: {} })
               }
               _.merge(target[key], source[key])
             } else {
               Object.assign(target, { [key]: source[key] })
             }
           })
         }
         return target
       }
```

### Tests

- All 21 existing `packages/commons` tests pass.
- One new test added under the existing `_` `describe` block confirming that passing a `{"__proto__":...}` JSON-parsed source does not mutate `Object.prototype`, fresh-`{}` reads, or the target object. Also covers the `constructor.prototype` shape.

Run output:

```
> @feathersjs/commons@5.0.44 test
> mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts

  .....................

  21 passing (5ms)
```

### Notes

- No public API change — `merge` continues to work for all documented input shapes; only the (likely-unintended) prototype mutation is removed.
- I've separately emailed the package maintainers about the impact context for this change. Happy to discuss either here or there.
