### PR TITLE
fix(generators): register 'list' prompt type alias for newer inquirer…

### DIFF
--- a/packages/generators/src/commons.ts
+++ b/packages/generators/src/commons.ts
@@ -11,7 +11,8 @@ import {
   renderTemplate,
   inject,
   Location,
-  exec
+  exec,
+  getConfig
 } from '@featherscloud/pinion'
 import ts from 'typescript'
 import prettier, { Options as PrettierOptions } from 'prettier'
@@ -20,6 +21,13 @@ import { fileURLToPath } from 'url'
 
 // Set __dirname in es module
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Newer inquirer versions (post-9.3.x) renamed 'list' to 'select'. Register 'list' as an alias
+// so generators work regardless of which inquirer version is resolved at install time.
+const { prompt: pinionPrompt } = getConfig()
+if (!pinionPrompt.prompts?.list && pinionPrompt.prompts?.select) {
+  pinionPrompt.registerPrompt('list', pinionPrompt.prompts.select)
+}
 
 export const { version } = JSON.parse(fs.readFileSync(join(__dirname, '..', 'package.json')).toString())
 


### PR DESCRIPTION
### Summary

- **Problem:** Running `npx @feathersjs/cli generate app` (or any generator command) fails on newer installations with:

  ```
  Error: Prompt type "list" is not registered. Available prompt types: checkbox, confirm, editor, expand, input, number, password, rawlist, search, select
  ```

  The root cause is a breaking change in `inquirer` introduced in a post-9.3.x release: the `list` prompt type was renamed to `select`. Because `@featherscloud/pinion` declares `"inquirer": "^9.3.2"`, npm can resolve a newer version where `list` no longer exists — but all generator prompts use `type: 'list'`. The issue only manifested on global/npx installs where npm resolved the newer inquirer; local monorepo dev happened to pin to 9.3.8 (which still has `list`), masking it.

- **Fix:** Added a one-time compatibility shim in `packages/generators/src/commons.ts` that runs at module load. It accesses the inquirer prompt singleton via pinion's `getConfig()` and, if `list` is not registered but `select` is, registers `list` as an alias using `registerPrompt`. No prompt definitions were changed — generators continue to use `type: 'list'` and work regardless of which inquirer version npm resolves.

- **Related issues:** None found, but this affects anyone running the CLI via `npx` or a fresh global install where npm resolves a newer inquirer 9.x.

- **Dependent PRs in other repos:** None. The fix is self-contained in `@feathersjs/generators`.

### Other Information

The shim is a two-line guard that is a no-op on older inquirer versions that already have `list`, so there is no regression risk for existing installations:

```ts
const { prompt: pinionPrompt } = getConfig()
if (!pinionPrompt.prompts?.list && pinionPrompt.prompts?.select) {
  pinionPrompt.registerPrompt('list', pinionPrompt.prompts.select)
}
```
