### PR TITLE
fix(feathers): skip prototype-polluting keys in _.merge

### DIFF
--- a/packages/feathers/src/commons.test.ts
+++ b/packages/feathers/src/commons.test.ts
@@ -213,5 +213,14 @@ describe('feathers/commons utils', () => {
 
       assert.equal(_.merge('hello', {}), 'hello')
     })
+
+    it('merge does not pollute Object.prototype', () => {
+      _.merge({}, JSON.parse('{"__proto__":{"polluted":"x"}}'))
+      _.merge({}, JSON.parse('{"constructor":{"prototype":{"polluted2":"y"}}}'))
+      assert.strictEqual(({} as any).polluted, undefined)
+      assert.strictEqual(({} as any).polluted2, undefined)
+      assert.strictEqual((Object.prototype as any).polluted, undefined)
+      assert.strictEqual((Object.prototype as any).polluted2, undefined)
+    })
   })
 })

--- a/packages/feathers/src/commons.ts
+++ b/packages/feathers/src/commons.ts
@@ -75,6 +75,10 @@ export const _ = {
   merge(target: any, source: any) {
     if (_.isObject(target) && _.isObject(source)) {
       Object.keys(source).forEach((key) => {
+        // Skip prototype-polluting keys (e.g. JSON-parsed `__proto__`)
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+          return
+        }
         if (_.isObject(source[key])) {
           if (!target[key]) {
             Object.assign(target, { [key]: {} })


### PR DESCRIPTION
### Summary

The recursive `_.merge` helper in `packages/feathers/src/commons.ts` iterates `Object.keys(source)`. When the source object came from `JSON.parse('{"__proto__":...}')`, `__proto__` is returned as an own-enumerable key (unlike the object-literal form), so the recursive call resolves `target['__proto__']` to `Object.prototype` and writes onto it.

This adds the standard guard to skip `__proto__`, `constructor`, and `prototype` keys during iteration — the same remediation lodash applies in `baseSet`.

### Changes
- `commons.ts`: skip the three prototype-mutating keys in the merge loop.
- `commons.test.ts`: regression test confirming a JSON-parsed `__proto__`/`constructor.prototype` source no longer mutates `Object.prototype`, fresh objects, or the target.

### Notes
- No public API change — `merge` still works for all documented input shapes.
- Reported by Andrew Ridings (@ridingsa). This is the v6 counterpart of the same fix for the published `@feathersjs/commons` package (see #3690, which supersedes #3687).

Reported-by: Andrew Ridings (@ridingsa)