### PR TITLE
fix(commons): skip prototype-polluting keys in _.merge

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -75,6 +75,10 @@ export const _ = {
   merge(target: any, source: any) {
     if (_.isObject(target) && _.isObject(source)) {
       Object.keys(source).forEach((key) => {
+        // Skip prototype-polluting keys (e.g. JSON-parsed `__proto__`)
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+          return
+        }
         if (_.isObject(source[key])) {
           if (!target[key]) {
             Object.assign(target, { [key]: {} })

--- a/packages/commons/test/utils.test.ts
+++ b/packages/commons/test/utils.test.ts
@@ -212,5 +212,14 @@ describe('@feathersjs/commons utils', () => {
 
       assert.equal(_.merge('hello', {}), 'hello')
     })
+
+    it('merge does not pollute Object.prototype', () => {
+      _.merge({}, JSON.parse('{"__proto__":{"polluted":"x"}}'))
+      _.merge({}, JSON.parse('{"constructor":{"prototype":{"polluted2":"y"}}}'))
+      assert.strictEqual(({} as any).polluted, undefined)
+      assert.strictEqual(({} as any).polluted2, undefined)
+      assert.strictEqual((Object.prototype as any).polluted, undefined)
+      assert.strictEqual((Object.prototype as any).polluted2, undefined)
+    })
   })
 })


### PR DESCRIPTION
### Summary

The recursive `_.merge` helper in `@feathersjs/commons` iterates `Object.keys(source)`. When the source came from `JSON.parse('{"__proto__":...}')`, `__proto__` is returned as an own-enumerable key, so the recursive call resolves `target['__proto__']` to `Object.prototype` and writes onto it.

This adds the standard guard to skip `__proto__`, `constructor`, and `prototype` keys during iteration.

### Changes
- `src/index.ts`: skip the three prototype-mutating keys in the merge loop.
- `test/utils.test.ts`: regression test confirming a JSON-parsed `__proto__`/`constructor.prototype` source no longer mutates `Object.prototype`, fresh objects, or the target.

### Notes
- No public API change — `merge` still works for all documented input shapes.
- Reported by Andrew Ridings (@ridingsa). Reimplemented here as a maintainer commit (supersedes #3687) so the change lands under a reviewed, verified commit.

Reported-by: Andrew Ridings (@ridingsa)