### PR TITLE
fix(mongodb): let objectid keyword fail validation

### DIFF
--- a/packages/mongodb/src/converters.ts
+++ b/packages/mongodb/src/converters.ts
@@ -57,7 +57,7 @@ export const keywordObjectId = {
         parentData[parentDataProperty] = new ObjectId(value)
         return true
       } catch (error) {
-        throw new Error(`invalid objectid for property "${parentDataProperty}"`)
+        return false
       }
     }
   }

--- a/packages/mongodb/test/converters.test.ts
+++ b/packages/mongodb/test/converters.test.ts
@@ -89,7 +89,7 @@ describe('objectid keyword', () => {
     assert.equal(typeof data.otherId, 'string')
   })
 
-  it('fails on invalid objectids', async () => {
+  it('fails validation on invalid objectids', async () => {
     const schema = {
       type: 'object',
       properties: {
@@ -104,6 +104,28 @@ describe('objectid keyword', () => {
     }
     assert.equal(typeof data._id, 'string')
 
-    assert.throws(() => validate(data), /invalid objectid for property "_id"/)
+    assert.equal(validate(data), false)
+    assert.equal(validate.errors?.[0].keyword, 'objectid')
+  })
+
+  it('continues validating nullable unions when an objectid branch fails', async () => {
+    const nullableValidator = new Ajv({ coerceTypes: true, useDefaults: true })
+    nullableValidator.addKeyword(keywordObjectId)
+
+    const schema: any = {
+      type: 'object',
+      properties: {
+        refId: {
+          anyOf: [{ type: 'string', objectid: true }, { type: 'null' }],
+          default: null
+        }
+      },
+      additionalProperties: false
+    }
+    const validate = nullableValidator.compile(schema)
+    const data: { refId?: ObjectId | null } = {}
+
+    assert.equal(validate(data), true)
+    assert.equal(data.refId, null)
   })
 })


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving.

`keywordObjectId` currently throws when a string cannot be converted to a MongoDB `ObjectId`. That prevents AJV from treating the keyword as a normal branch failure, so `anyOf` / `oneOf` schemas cannot continue to another valid branch such as `null`.

This changes the keyword validator to return `false` on invalid ObjectId conversion, which lets AJV report a standard validation failure and continue evaluating union branches.

- [x] Are there any open issues that are related to this?

Closes #3685.

- [x] Is this PR dependent on PRs in other repos?

No.

### Other Information

Added regression coverage for nullable union validation and updated the invalid ObjectId test to assert a normal AJV validation failure instead of an uncaught exception.

Verification:

```console
source ~/.nvm/nvm.sh && nvm use 18.20.8 >/dev/null && npm_config_cache=/tmp/feathers-107-npm-cache npm test --workspace @feathersjs/mongodb -- --grep "objectid keyword"
source ~/.nvm/nvm.sh && nvm use 18.20.8 >/dev/null && npm_config_cache=/tmp/feathers-107-npm-cache npm test --workspace @feathersjs/mongodb -- --grep "ObjectId resolvers|objectid keyword"
source ~/.nvm/nvm.sh && nvm use 18.20.8 >/dev/null && npm_config_cache=/tmp/feathers-107-npm-cache npm run compile --workspace @feathersjs/mongodb
source ~/.nvm/nvm.sh && nvm use 18.20.8 >/dev/null && npm_config_cache=/tmp/feathers-107-npm-cache npx prettier --check packages/mongodb/src/converters.ts packages/mongodb/test/converters.test.ts
source ~/.nvm/nvm.sh && nvm use 18.20.8 >/dev/null && npm_config_cache=/tmp/feathers-107-npm-cache npx eslint packages/mongodb/src/converters.ts packages/mongodb/test/converters.test.ts
git diff --check
```