### PR TITLE
fix(commons): skip prototype-polluting keys in _.merge

### DIFF
--- a/packages/commons/src/utils.ts
+++ b/packages/commons/src/utils.ts
@@ -75,6 +75,11 @@ export const _ = {
   merge (target: any, source: any) {
     if (_.isObject(target) && _.isObject(source)) {
       Object.keys(source).forEach(key => {
+        // Skip prototype-polluting keys (e.g. JSON-parsed `__proto__`)
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+          return;
+        }
+
         if (_.isObject(source[key])) {
           if (!target[key]) {
             Object.assign(target, { [key]: {} });

--- a/packages/commons/test/utils.test.ts
+++ b/packages/commons/test/utils.test.ts
@@ -167,6 +167,15 @@ describe('@feathersjs/commons utils', () => {
 
       assert.equal(_.merge('hello', {}), 'hello');
     });
+
+    it('merge does not pollute Object.prototype', () => {
+      _.merge({}, JSON.parse('{"__proto__":{"polluted":"x"}}'));
+      _.merge({}, JSON.parse('{"constructor":{"prototype":{"polluted2":"y"}}}'));
+      assert.strictEqual(({} as any).polluted, undefined);
+      assert.strictEqual(({} as any).polluted2, undefined);
+      assert.strictEqual((Object.prototype as any).polluted, undefined);
+      assert.strictEqual((Object.prototype as any).polluted2, undefined);
+    });
   });
 
   describe('makeUrl', function () {


### PR DESCRIPTION
### Summary

Backport of the Dove fix for [GHSA-28xv-ph75-77wh](https://github.com/feathersjs/feathers/security/advisories/GHSA-28xv-ph75-77wh) / [CVE-2026-54335](https://github.com/advisories/GHSA-28xv-ph75-77wh) to Crow (Feathers 4.x).

The recursive `_.merge` helper in `@feathersjs/commons` iterates `Object.keys(source)`. When the source came from `JSON.parse('{"__proto__":...}')`, `__proto__` is returned as an own-enumerable key, so the recursive call resolves `target['__proto__']` to `Object.prototype` and writes onto it.

This adds the standard guard to skip `__proto__`, `constructor`, and `prototype` keys during iteration — the same remediation as dove #3690 / `@feathersjs/commons@5.0.45`.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
- [x] Is this PR dependent on PRs in other repos?

Related: #3690 (dove), #3687 (original report by @ridingsa), GHSA-28xv-ph75-77wh.

No dependency on other repos.

### Changes

- `packages/commons/src/utils.ts`: skip the three prototype-mutating keys in the merge loop.
- `packages/commons/test/utils.test.ts`: regression test confirming a JSON-parsed `__proto__` / `constructor.prototype` source no longer mutates `Object.prototype`.

### Notes

- No public API change — `merge` still works for all documented input shapes.
- After merge, publish `@feathersjs/commons@4.5.20` (and bump dependents as needed for the Crow release), then update GHSA-28xv-ph75-77wh with a Crow patched range (`<= 4.5.19` → `4.5.20`).

Reported-by: Andrew Ridings (@ridingsa)

### Verification

```
cd packages/commons && npm test
# 53 passing
```