### PR TITLE
fix(authentication-oauth): allow any port on loopback OAuth origins

### DIFF
--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -11,6 +11,41 @@ import qs from 'qs'
 
 const debug = createDebug('@feathersjs/authentication-oauth/strategy')
 
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+
+/** Strip IPv6 brackets so `[::1]` and `::1` compare the same. */
+function normalizeHostname(hostname: string) {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, '')
+}
+
+function isLoopbackHost(hostname: string) {
+  return LOOPBACK_HOSTS.has(normalizeHostname(hostname))
+}
+
+/**
+ * Match key for origin allowlisting.
+ * Non-loopback hosts use the full WHATWG origin (scheme + host + port).
+ * Loopback hosts drop the port so local frontends on any port can match a single allowlist entry.
+ */
+function originMatchKey(value: string) {
+  const url = new URL(value)
+  const host = normalizeHostname(url.hostname)
+
+  if (isLoopbackHost(host)) {
+    return `${url.protocol}//${host}`
+  }
+
+  return url.origin.toLowerCase()
+}
+
+function isOriginAllowed(refererOrigin: string, configured: string) {
+  try {
+    return originMatchKey(refererOrigin) === originMatchKey(configured)
+  } catch {
+    return false
+  }
+}
+
 /**
  * Validates that appending a user-supplied path to a base URL does not change the origin.
  * Uses both URL resolution and string concatenation checks to catch all open redirect vectors:
@@ -120,14 +155,15 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
         throw new NotAuthenticated(`Invalid referer "${referer}".`)
       }
 
-      // Compare full origins
-      const allowedOrigin = origins.find((current) => refererOrigin.toLowerCase() === current.toLowerCase())
+      // Exact origin match; loopback hosts also match any port (see originMatchKey).
+      // Always return the referer origin so redirects use the port the client came from.
+      const allowedOrigin = origins.find((current) => isOriginAllowed(refererOrigin, current))
 
       if (!allowedOrigin) {
         throw new NotAuthenticated(`Referer "${referer}" is not allowed.`)
       }
 
-      return allowedOrigin
+      return refererOrigin
     }
 
     return redirect

--- a/packages/authentication-oauth/src/strategy.ts
+++ b/packages/authentication-oauth/src/strategy.ts
@@ -11,7 +11,8 @@ import qs from 'qs'
 
 const debug = createDebug('@feathersjs/authentication-oauth/strategy')
 
-const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+// Local machine addresses: match any port when scheme + host are allowlisted.
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0'])
 
 /** Strip IPv6 brackets so `[::1]` and `::1` compare the same. */
 function normalizeHostname(hostname: string) {
@@ -44,6 +45,15 @@ function isOriginAllowed(refererOrigin: string, configured: string) {
   } catch {
     return false
   }
+}
+
+function originNotAllowedMessage(refererOrigin: string, origins: string[]) {
+  return (
+    `Referer origin "${refererOrigin}" is not allowed. ` +
+    `Configured origins: ${origins.join(', ')}. ` +
+    `Use a full origin (scheme + host + port when non-default). ` +
+    `Loopback hosts (localhost, 127.0.0.1, ::1, 0.0.0.0) match any port.`
+  )
 }
 
 /**
@@ -152,7 +162,9 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
       try {
         refererOrigin = new URL(referer).origin
       } catch {
-        throw new NotAuthenticated(`Invalid referer "${referer}".`)
+        throw new NotAuthenticated(
+          `Invalid referer "${referer}". Expected an absolute URL (e.g. http://localhost:3000).`
+        )
       }
 
       // Exact origin match; loopback hosts also match any port (see originMatchKey).
@@ -160,7 +172,7 @@ export class OAuthStrategy extends AuthenticationBaseStrategy {
       const allowedOrigin = origins.find((current) => isOriginAllowed(refererOrigin, current))
 
       if (!allowedOrigin) {
-        throw new NotAuthenticated(`Referer "${referer}" is not allowed.`)
+        throw new NotAuthenticated(originNotAllowedMessage(refererOrigin, origins))
       }
 
       return refererOrigin

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -202,7 +202,11 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
             }
           ),
         {
-          message: 'Referer "https://target.com.attacker.com/login" is not allowed.'
+          message:
+            'Referer origin "https://target.com.attacker.com" is not allowed. ' +
+            'Configured origins: https://target.com. ' +
+            'Use a full origin (scheme + host + port when non-default). ' +
+            'Loopback hosts (localhost, 127.0.0.1, ::1, 0.0.0.0) match any port.'
         }
       )
     })
@@ -220,7 +224,11 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
             }
           ),
         {
-          message: 'Referer "https://target.com-evil.attacker.com/login" is not allowed.'
+          message:
+            'Referer origin "https://target.com-evil.attacker.com" is not allowed. ' +
+            'Configured origins: https://target.com. ' +
+            'Use a full origin (scheme + host + port when non-default). ' +
+            'Loopback hosts (localhost, 127.0.0.1, ::1, 0.0.0.0) match any port.'
         }
       )
     })
@@ -305,6 +313,21 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
       assert.equal(redirect, 'http://[::1]:4173#access_token=testing')
     })
 
+    it('should allow any port on 0.0.0.0', async () => {
+      app.get('authentication').oauth.origins = ['http://0.0.0.0:3030']
+
+      const redirect = await strategy.getRedirect(
+        { accessToken: 'testing' },
+        {
+          headers: {
+            referer: 'http://0.0.0.0:5173/app'
+          }
+        }
+      )
+
+      assert.equal(redirect, 'http://0.0.0.0:5173#access_token=testing')
+    })
+
     it('should not treat localhost and 127.0.0.1 as the same host', async () => {
       app.get('authentication').oauth.origins = ['http://localhost']
 
@@ -319,7 +342,11 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
             }
           ),
         {
-          message: 'Referer "http://127.0.0.1:3000/login" is not allowed.'
+          message:
+            'Referer origin "http://127.0.0.1:3000" is not allowed. ' +
+            'Configured origins: http://localhost. ' +
+            'Use a full origin (scheme + host + port when non-default). ' +
+            'Loopback hosts (localhost, 127.0.0.1, ::1, 0.0.0.0) match any port.'
         }
       )
     })
@@ -338,7 +365,11 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
             }
           ),
         {
-          message: 'Referer "https://app.example.com:8443/login" is not allowed.'
+          message:
+            'Referer origin "https://app.example.com:8443" is not allowed. ' +
+            'Configured origins: https://app.example.com. ' +
+            'Use a full origin (scheme + host + port when non-default). ' +
+            'Loopback hosts (localhost, 127.0.0.1, ::1, 0.0.0.0) match any port.'
         }
       )
     })
@@ -357,7 +388,11 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
             }
           ),
         {
-          message: 'Referer "http://localhost:3000/login" is not allowed.'
+          message:
+            'Referer origin "http://localhost:3000" is not allowed. ' +
+            'Configured origins: https://localhost. ' +
+            'Use a full origin (scheme + host + port when non-default). ' +
+            'Loopback hosts (localhost, 127.0.0.1, ::1, 0.0.0.0) match any port.'
         }
       )
     })
@@ -483,7 +518,11 @@ describe('@feathersjs/authentication-oauth/strategy', () => {
           }
         ),
       {
-        message: 'Referer "https://example.com" is not allowed.'
+        message:
+          'Referer origin "https://example.com" is not allowed. ' +
+          'Configured origins: https://feathersjs.com, https://feathers.cloud. ' +
+          'Use a full origin (scheme + host + port when non-default). ' +
+          'Loopback hosts (localhost, 127.0.0.1, ::1, 0.0.0.0) match any port.'
       }
     )
   })

--- a/packages/authentication-oauth/test/strategy.test.ts
+++ b/packages/authentication-oauth/test/strategy.test.ts
@@ -238,6 +238,130 @@ describe('@feathersjs/authentication-oauth/strategy security', () => {
       assert.equal(redirect, 'https://target.com#access_token=testing')
     })
   })
+
+  describe('loopback origin port matching (#3684)', () => {
+    afterEach(() => {
+      delete app.get('authentication').oauth.origins
+    })
+
+    it('should allow any port on localhost when configured without a port', async () => {
+      app.get('authentication').oauth.origins = ['http://localhost']
+
+      const redirect = await strategy.getRedirect(
+        { accessToken: 'testing' },
+        {
+          headers: {
+            referer: 'http://localhost:5173/login'
+          }
+        }
+      )
+
+      // Redirect must use the referer port, not the config string
+      assert.equal(redirect, 'http://localhost:5173#access_token=testing')
+    })
+
+    it('should allow a different loopback port than the configured one', async () => {
+      app.get('authentication').oauth.origins = ['http://localhost:3030']
+
+      const redirect = await strategy.getRedirect(
+        { accessToken: 'testing' },
+        {
+          headers: {
+            referer: 'http://localhost:3000/app'
+          }
+        }
+      )
+
+      assert.equal(redirect, 'http://localhost:3000#access_token=testing')
+    })
+
+    it('should allow any port on 127.0.0.1', async () => {
+      app.get('authentication').oauth.origins = ['http://127.0.0.1:8080']
+
+      const redirect = await strategy.getRedirect(
+        { accessToken: 'testing' },
+        {
+          headers: {
+            referer: 'http://127.0.0.1:5173/'
+          }
+        }
+      )
+
+      assert.equal(redirect, 'http://127.0.0.1:5173#access_token=testing')
+    })
+
+    it('should allow any port on IPv6 loopback', async () => {
+      app.get('authentication').oauth.origins = ['http://[::1]']
+
+      const redirect = await strategy.getRedirect(
+        { accessToken: 'testing' },
+        {
+          headers: {
+            referer: 'http://[::1]:4173/path'
+          }
+        }
+      )
+
+      assert.equal(redirect, 'http://[::1]:4173#access_token=testing')
+    })
+
+    it('should not treat localhost and 127.0.0.1 as the same host', async () => {
+      app.get('authentication').oauth.origins = ['http://localhost']
+
+      await assert.rejects(
+        () =>
+          strategy.getRedirect(
+            { accessToken: 'testing' },
+            {
+              headers: {
+                referer: 'http://127.0.0.1:3000/login'
+              }
+            }
+          ),
+        {
+          message: 'Referer "http://127.0.0.1:3000/login" is not allowed.'
+        }
+      )
+    })
+
+    it('should still require exact port match for non-loopback hosts', async () => {
+      app.get('authentication').oauth.origins = ['https://app.example.com']
+
+      await assert.rejects(
+        () =>
+          strategy.getRedirect(
+            { accessToken: 'testing' },
+            {
+              headers: {
+                referer: 'https://app.example.com:8443/login'
+              }
+            }
+          ),
+        {
+          message: 'Referer "https://app.example.com:8443/login" is not allowed.'
+        }
+      )
+    })
+
+    it('should require matching scheme on loopback', async () => {
+      app.get('authentication').oauth.origins = ['https://localhost']
+
+      await assert.rejects(
+        () =>
+          strategy.getRedirect(
+            { accessToken: 'testing' },
+            {
+              headers: {
+                referer: 'http://localhost:3000/login'
+              }
+            }
+          ),
+        {
+          message: 'Referer "http://localhost:3000/login" is not allowed.'
+        }
+      )
+    })
+  })
 })
 
 describe('@feathersjs/authentication-oauth/strategy', () => {


### PR DESCRIPTION
## Summary

- Fixes local OAuth redirects after the 5.0.40 exact-origin security change (#3653 / #3676), which rejected common setups where the frontend runs on a different port than the configured origin (e.g. `http://localhost` vs `http://localhost:5173`).
- For local machine hosts only (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`), match on scheme + host and ignore port.
- On a successful match, redirect using the **referer** origin so the access token returns to the correct local port.
- Non-loopback hosts still require an exact WHATWG origin match (security fix preserved). Config entries are also normalized via `URL` (trailing slash / default port / path on the config string no longer break matching).
- Clearer `NotAuthenticated` errors: report the normalized referer origin, list configured origins, and hint about ports and loopback matching.

Closes #3684

## Test plan

- [x] `npm test --workspace @feathersjs/authentication-oauth` (34 passing)
- [x] Loopback any-port allow for `localhost`, `127.0.0.1`, `::1`, `0.0.0.0`
- [x] Redirect uses referer port, not config port
- [x] `localhost` ≠ `127.0.0.1`
- [x] Non-loopback still requires exact port
- [x] Scheme must still match on loopback
- [x] Rejection errors include configured origins and a port/loopback hint
- [x] Existing open-redirect / prefix-bypass security tests still pass