### PR TITLE
fix(transport-commons): map HEAD requests like GET for REST services

### DIFF
--- a/packages/transport-commons/src/http.ts
+++ b/packages/transport-commons/src/http.ts
@@ -38,7 +38,9 @@ export function getServiceMethod(_httpMethod: string, id: unknown, headerOverrid
     return mappedMethod
   }
 
-  if (httpMethod === 'get') {
+  // HEAD is semantically a GET without a body (RFC 9110). Map it the same
+  // way so Express/Koa REST endpoints do not 405/500 on HEAD probes.
+  if (httpMethod === 'get' || httpMethod === 'head') {
     return id === null ? 'find' : 'get'
   }
 

--- a/packages/transport-commons/test/http.test.ts
+++ b/packages/transport-commons/test/http.test.ts
@@ -68,6 +68,9 @@ describe('@feathersjs/transport-commons HTTP helpers', () => {
   it('getServiceMethod', () => {
     assert.strictEqual(http.getServiceMethod('GET', 2), 'get')
     assert.strictEqual(http.getServiceMethod('GET', null), 'find')
+    assert.strictEqual(http.getServiceMethod('HEAD', 2), 'get')
+    assert.strictEqual(http.getServiceMethod('HEAD', null), 'find')
+    assert.strictEqual(http.getServiceMethod('head', null), 'find')
     assert.strictEqual(http.getServiceMethod('PoST', null), 'create')
     assert.strictEqual(http.getServiceMethod('PoST', null, 'customMethod'), 'customMethod')
     assert.strictEqual(http.getServiceMethod('delete', null), 'remove')


### PR DESCRIPTION
Fixes #3464

Map HEAD like GET in getServiceMethod so REST HEAD probes do not throw MethodNotAllowed. Unit tests cover HEAD/head with and without an id.